### PR TITLE
Deploy the docs to Cloudflare

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,53 @@ jobs:
       - name: Enforce coverage
         run: scripts/coverage
 
+  # Preview: build the docs for each PR and upload a versioned Cloudflare build,
+  # commenting the URL on the PR. Skipped on forks and when the secret is absent.
+  docs-preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    env:
+      HAS_CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    environment:
+      name: cloudflare
+      url: ${{ steps.deploy.outputs.deployment-url }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Build docs
+        run: scripts/docs
+
+      - name: Upload preview to Cloudflare
+        id: deploy
+        if: ${{ env.HAS_CLOUDFLARE_TOKEN == 'true' }}
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: versions upload --tag pr-${{ github.event.pull_request.number }}
+
+      - name: Comment preview URL on PR
+        if: ${{ steps.deploy.outcome == 'success' }}
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
+        with:
+          message: |
+            :book: Docs preview: ${{ steps.deploy.outputs.deployment-url }}
+          comment-tag: docs-preview
+
   # https://github.com/marketplace/actions/alls-green#why
   check:
     name: All green

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,38 @@ on:
 permissions: {}
 
 jobs:
+  # Production: publish https://zttp.marcelotryle.com on every push to main.
+  docs:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    environment:
+      name: cloudflare
+      url: https://zttp.marcelotryle.com
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.12"
+          enable-cache: false
+
+      - name: Build docs
+        run: scripts/docs
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy
+
   build-wheels:
     name: "Wheels on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,13 @@
+name = "zttp"
+compatibility_date = "2026-05-22"
+workers_dev = true
+
+[assets]
+directory = "./site"
+not_found_handling = "404-page"
+
+# Serve the production docs at the custom domain. The zone must live on the same
+# Cloudflare account as the worker (CLOUDFLARE_ACCOUNT_ID).
+[[routes]]
+pattern = "zttp.marcelotryle.com"
+custom_domain = true


### PR DESCRIPTION
Mirrors zloop's documentation deployment for zttp.

- **`wrangler.toml`** — a Cloudflare Worker serving the built `./site` at `zttp.marcelotryle.com` (custom domain on the same account as `CLOUDFLARE_ACCOUNT_ID`).
- **`docs-preview` job** (`main.yml`) — on each PR, builds the docs and uploads a versioned Cloudflare build, commenting the preview URL on the PR. Skipped on forks / when the secret is absent.
- **`docs` job** (`publish.yml`) — deploys the production docs on every push to `main`.

Both use the `cloudflare` environment's `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.