### PR TITLE
Drop THREAT_MODEL.md from the sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ optimize = "ReleaseSafe"
 
 [tool.hatch.build.targets.sdist]
 # Ship the sources needed to compile the extension from an sdist.
-include = ["zttp", "src", "tools", "build.zig", "THREAT_MODEL.md"]
+include = ["zttp", "src", "tools", "build.zig"]
 
 [tool.cibuildwheel]
 # Zig comes from the `ziglang` build requirement (build isolation), so no system


### PR DESCRIPTION
Keep the threat model in the repo / on GitHub only, not in any distribution
artifact. It was never in the wheel (the wheel only packs the `zttp/` package);
this removes it from the sdist include too, so neither published artifact
carries it.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.