### PR TITLE
Polish the docs

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -8,20 +8,25 @@ zttp is layered the same way [zloop](https://github.com/Kludex/zloop) is: a pure
 Zig core that knows nothing about Python, a thin C-API adapter at the edge, and a
 small Python package on top. Each layer depends only on the one below it.
 
-```text
-+-----------------------------------------------------------+
-|  zttp/__init__.py        the public Python API            |   Python edge
-+-----------------------------------------------------------+
-|  src/python/*.zig        CPython C-API adapter            |   adapter
-|    - Connection object (receive_data / next_event / send) |
-|    - Request / Response / Data / EndOfMessage events      |
-|    - ProtocolError / Remote / Local exceptions            |
-+-----------------------------------------------------------+
-|  src/core/*.zig          the sans-IO parser (no Python.h) |   domain
-|    - reader: the read-side state machine + buffering      |
-|    - writer: the serializer                               |
-|    - framing / chunked / headers / scanner                |
-+-----------------------------------------------------------+
+```mermaid
+flowchart TB
+    subgraph edge["Python edge &nbsp;·&nbsp; zttp/__init__.py"]
+        api["the public Python API"]
+    end
+    subgraph adapter["Adapter &nbsp;·&nbsp; src/python/*.zig &nbsp;·&nbsp; CPython C-API"]
+        conn["Connection<br/>receive_data · next_event · send_*"]
+        events["events<br/>Request · Response · Data · EndOfMessage"]
+        exc["exceptions<br/>Protocol · Remote · Local"]
+    end
+    subgraph domain["Domain &nbsp;·&nbsp; src/core/*.zig &nbsp;·&nbsp; sans-IO parser (no Python.h)"]
+        reader["reader<br/>read-side state machine + buffering"]
+        writer["writer<br/>serializer"]
+        prim["framing · chunked · headers · scanner"]
+    end
+
+    edge --> adapter --> domain
+    reader --> prim
+    writer --> prim
 ```
 
 ## The core (`src/core`)

--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#5e35b1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 3 4 7l4 4M4 7h16M16 21l4-4-4-4M20 17H4"/>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,6 @@ icon: lucide/zap
 
 ---
 
-**Documentation**: you are reading it 🙂
-
 **Source Code**: <a href="https://github.com/Kludex/zttp" target="_blank">https://github.com/Kludex/zttp</a>
 
 ---
@@ -48,12 +46,8 @@ The key features are:
 
 ## Installation
 
-<!-- termynal -->
-
 ```console
-$ pip install zttp
-
----> 100%
+pip install zttp
 ```
 
 ## Example
@@ -61,7 +55,7 @@ $ pip install zttp
 Let's parse an HTTP request. You play the **server**: bytes come in, events come
 out.
 
-```python title="parse.py" hl_lines="3 6"
+```python title="parse.py" hl_lines="3 9"
 import zttp
 
 conn = zttp.Connection(zttp.SERVER)  # (1)!

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -4,85 +4,31 @@ icon: lucide/book-open
 
 # API reference
 
-The whole public surface of zttp. It's small on purpose.
+The whole public surface of zttp. It's small on purpose. Everything here is
+importable straight from `zttp` (e.g. `from zttp import Connection`).
 
-## `Connection`
+## Connection
 
-```python
-zttp.Connection(role)
-```
-
-The one object you create. `role` is `zttp.SERVER` or `zttp.CLIENT`.
-
-### Read side
-
-| Method | Description |
-| --- | --- |
-| `receive_data(data: bytes) -> None` | Append received bytes. An empty `bytes` signals end of input (the peer closed). |
-| `next_event() -> Event` | Return the next event, or the `NEED_DATA` sentinel if more bytes are needed. A parse error poisons the connection: every later call re-raises it. |
-| `start_next_cycle() -> None` | Reset to read the next message on a kept-alive connection (call after `EndOfMessage`). |
-| `expect_bodyless() -> None` | Declare that the next response has no body regardless of its headers - responses to `HEAD`, and `1xx` / `204` / `304`. Client role; call before parsing that response's head. |
-
-### Write side
-
-| Method | Description |
-| --- | --- |
-| `send_request(method, target, version, headers) -> None` | Serialize a request head. |
-| `send_response(version, status, reason, headers, bodyless=False) -> None` | Serialize a response head. |
-| `send_data(data: bytes) -> None` | Serialize body bytes (chunk-framed if the head declared chunked). |
-| `end_message(trailers=None) -> None` | Finish the outgoing message. |
-| `data_to_send() -> bytes` | Return and clear the pending outgoing bytes. |
-
-All `headers` / `trailers` are sequences of `(name, value)` byte pairs.
+::: zttp.Connection
 
 ## Roles
 
-| Constant | Meaning |
-| --- | --- |
-| `zttp.SERVER` | You receive requests, send responses. |
-| `zttp.CLIENT` | You send requests, receive responses. |
+A `Connection`'s role is fixed at construction:
+
+- `zttp.SERVER` - you receive requests, send responses.
+- `zttp.CLIENT` - you send requests, receive responses.
 
 ## Events
 
-`next_event()` returns one of these.
+[`next_event`](#zttp.Connection.next_event) returns one of these.
 
-### `Request`
+::: zttp.Request
 
-The start of a request (server role).
+::: zttp.Response
 
-| Field | Type |
-| --- | --- |
-| `method` | `bytes` |
-| `target` | `bytes` |
-| `http_version` | `bytes` |
-| `headers` | `list[tuple[bytes, bytes]]` |
+::: zttp.Data
 
-### `Response`
-
-The start of a response (client role).
-
-| Field | Type |
-| --- | --- |
-| `status_code` | `int` |
-| `reason` | `bytes` |
-| `http_version` | `bytes` |
-| `headers` | `list[tuple[bytes, bytes]]` |
-
-### `Data`
-
-A run of body bytes.
-
-| Field | Type |
-| --- | --- |
-| `data` | `bytes` |
-
-### `EndOfMessage`
-
-The body has ended.
-
-| Field | Type |
-| --- | --- |
-| `trailers` | `list[tuple[bytes, bytes]]` |
+::: zttp.EndOfMessage
 
 ### Sentinels
 
@@ -93,10 +39,8 @@ The body has ended.
 
 ## Exceptions
 
-```text
-zttp.ProtocolError
-├── zttp.RemoteProtocolError   the peer sent something malformed
-└── zttp.LocalProtocolError    you used the API incorrectly
-```
+::: zttp.ProtocolError
 
-See [Errors](../usage/errors.md) for when each is raised.
+::: zttp.RemoteProtocolError
+
+::: zttp.LocalProtocolError

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -33,7 +33,7 @@ safety-checked (`ReleaseSafe`) build.
 The benchmark lives in `bench.py` and compares all three parsers:
 
 ```console
-$ uv run --group bench python bench.py
+uv run --group bench python bench.py
 ```
 
 It feeds each parser identical bytes and verifies they extract identical data

--- a/docs/usage/first-steps.md
+++ b/docs/usage/first-steps.md
@@ -4,7 +4,7 @@ icon: lucide/rocket
 
 # First steps
 
-zttp gives you one object: a **`Connection`**.
+zttp gives you one object: a [`Connection`][zttp.Connection].
 
 ```python
 import zttp
@@ -41,7 +41,7 @@ conn.receive_data(b"TP/1.1\r\n") # the rest of it
 
 Then call `next_event()` to get the next thing that happened:
 
-```python title="echo.py" hl_lines="11"
+```python title="echo.py" hl_lines="12"
 import zttp
 
 conn = zttp.Connection(zttp.SERVER)

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -6,25 +6,21 @@ icon: lucide/download
 
 zttp ships as a wheel with the Zig core already compiled, so installing it is just:
 
-<!-- termynal -->
-
 ```console
-$ pip install zttp
-
----> 100%
+pip install zttp
 ```
 
 That's all you need. There's nothing else to configure. ✨
 
 !!! note "Requirements"
-    zttp needs **CPython 3.12+** and runs on **Linux** and **macOS**.
+    zttp needs **CPython 3.12+** and runs on **Linux**, **macOS**, and **Windows**.
 
 ## With uv
 
 If you use [uv](https://docs.astral.sh/uv/) (we do):
 
 ```console
-$ uv add zttp
+uv add zttp
 ```
 
 ## Building from source
@@ -34,7 +30,7 @@ source distribution builds the Zig extension on install - you only need a Zig
 toolchain, and even that comes along automatically:
 
 ```console
-$ pip install --no-binary zttp zttp
+pip install --no-binary zttp zttp
 ```
 
 The build pulls in the [`ziglang`](https://pypi.org/project/ziglang/) wheel as a

--- a/docs/usage/sending.md
+++ b/docs/usage/sending.md
@@ -21,7 +21,7 @@ There are four building blocks, plus one call to collect the output:
 
 As a **server**, you answer a request:
 
-```python title="respond.py" hl_lines="11"
+```python title="respond.py" hl_lines="12"
 import zttp
 
 conn = zttp.Connection(zttp.SERVER)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ bench = [
 ]
 docs = [
     "zensical",
+    "mkdocstrings[python]",
 ]
 
 [tool.hatch.version]

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,27 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -359,6 +380,103 @@ wheels = [
 ]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/c0/f641843de3f612a6b48253f39244165acff36657a91cc903633d456ae1ac/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197", size = 56588, upload-time = "2026-02-10T15:23:55.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/de/a3e710469772c6a89595fc52816da05c1e164b4c866a89e3cb82fb1b67c5/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089", size = 25530, upload-time = "2026-02-10T15:23:53.817Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/5d/f888d4d3eb31359b327bc9b17a212d6ef03fe0b0682fbb3fc2cb849fb12b/mkdocstrings-1.0.4.tar.gz", hash = "sha256:3969a6515b77db65fd097b53c1b7aa4ae840bd71a2ee62a6a3e89503446d7172", size = 100088, upload-time = "2026-04-15T09:16:53.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/94/be70f8ee9c45f2f62b39a1f0e9303bc20e138a8f3b8e50ffd89498e177e1/mkdocstrings-1.0.4-py3-none-any.whl", hash = "sha256:63464b4b29053514f32a1dbbf604e52876d5e638111b0c295ab7ed3cac73ca9b", size = 35560, upload-time = "2026-04-15T09:16:51.436Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b4/5fed370d8ebd96e4e399460a7146ae989263f16588b05a6facd6dbd51e60/mkdocstrings_python-2.0.4.tar.gz", hash = "sha256:58c73c5d358e64e9b1673447663f4a2f8a8941e392e225fc0a0c893758cc452f", size = 199219, upload-time = "2026-06-05T08:13:01.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/e3/00ec594aef5f55522e6d373bc2ac53e53a8f5e9ae32f2d6854b0de4270f3/mkdocstrings_python-2.0.4-py3-none-any.whl", hash = "sha256:fd87c173e1e719a85997b6d4f852cdc55f36710e0ed08da3a7bd9abe79c9db00", size = 104790, upload-time = "2026-06-05T08:13:00.393Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -430,6 +548,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -474,6 +601,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -523,6 +662,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -545,6 +696,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
     { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -602,6 +762,30 @@ wheels = [
 ]
 
 [[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
 name = "zensical"
 version = "0.0.44"
 source = { registry = "https://pypi.org/simple" }
@@ -647,6 +831,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "zensical" },
 ]
 
@@ -663,4 +848,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff" },
 ]
-docs = [{ name = "zensical" }]
+docs = [
+    { name = "mkdocstrings", extras = ["python"] },
+    { name = "zensical" },
+]

--- a/zensical.toml
+++ b/zensical.toml
@@ -32,6 +32,7 @@ nav = [
 
 [project.theme]
 language = "en"
+favicon = "assets/favicon.svg"
 features = [
   "announce.dismiss",
   "content.code.annotate",
@@ -51,7 +52,7 @@ features = [
 ]
 
 [project.theme.icon]
-logo = "lucide/zap"
+logo = "lucide/arrow-left-right"
 
 [[project.theme.palette]]
 scheme = "default"
@@ -70,6 +71,33 @@ toggle.name = "Switch to light mode"
 [[project.extra.social]]
 icon = "fontawesome/brands/github"
 link = "https://github.com/Kludex/zttp"
+
+# Auto-generate the API reference from the package + its type stubs (the public
+# surface is a Zig C-extension, so Griffe reads zttp/_zttp.pyi for signatures).
+# Enables `::: zttp.X` blocks and [`zttp.X`][zttp.X] cross-references.
+[project.plugins.mkdocstrings.config]
+default_handler = "python"
+
+[project.plugins.mkdocstrings.config.handlers.python]
+paths = ["."]
+
+[project.plugins.mkdocstrings.config.handlers.python.options]
+show_source = false
+show_root_heading = true
+show_symbol_type_heading = true
+show_symbol_type_toc = true
+members_order = "source"
+separate_signature = true
+docstring_style = "google"
+filters = []
+inherited_members = true
+# The .pyi stub carries signatures but not docstrings, so members would
+# otherwise be hidden; show them on signature alone.
+show_if_no_docstring = true
+# The public API is a Zig C-extension; force static analysis so Griffe reads
+# the signatures from zttp/_zttp.pyi rather than inspecting the opaque .so.
+allow_inspection = false
+force_inspection = false
 
 [project.markdown_extensions.abbr]
 [project.markdown_extensions.admonition]


### PR DESCRIPTION
- **Distinct logo + favicon** — switch from `lucide/zap` (zloop's icon) to `lucide/arrow-left-right` (request in / response out), and add a matching SVG favicon.
- **Cleaner install snippets** — drop the termynal `---> 100%` lines and the `$` prompts so commands copy cleanly; remove "Documentation: you are reading it 🙂".
- **Fixed code-block highlights** — the `hl_lines` in the index / first-steps / sending examples pointed at blank lines; now they highlight the line each example is about.
- **mkdocstrings API reference** — the reference page is now generated from the package + its `.pyi` type stubs (with `show_if_no_docstring` so the stub-only members render), and `[obj][]` cross-references between docs pages now work.
- **Mermaid architecture diagram** — replace the ASCII layering box with a real mermaid diagram.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.