### PR TITLE
Give each send-side misuse its own error message

### DIFF
--- a/src/core/writer.zig
+++ b/src/core/writer.zig
@@ -13,9 +13,20 @@ const Header = events.Header;
 const responseIsBodyless = framing.responseIsBodyless;
 
 pub const WriteError = error{
-    /// A send was attempted in a state that does not allow it (e.g. data before
-    /// the head, or a second head before the first message ended).
-    LocalProtocol,
+    /// A head was sent while a message was still in progress.
+    MessageNotEnded,
+    /// Body bytes were sent when none can be: before a head, or on a message
+    /// whose framing carries no body.
+    NoBodyAllowed,
+    /// More body bytes were sent than the declared Content-Length allows.
+    BodyTooLong,
+    /// The message was ended before the declared Content-Length was reached.
+    BodyTooShort,
+    /// Trailers were passed to a message that cannot carry them - only a chunked
+    /// body has a place for trailers on the wire.
+    TrailersNotAllowed,
+    /// The message was ended when none was in progress.
+    NoMessageInProgress,
     /// A field (method/target/version/reason/header) contained bytes that would
     /// break the wire grammar - CR, LF, NUL or other controls. Serializing them
     /// verbatim would allow header/response-splitting injection.
@@ -150,7 +161,7 @@ pub const Writer = struct {
 
     /// Serialize a request-line + headers. `framing` decides body handling.
     pub fn sendRequest(self: *Writer, method: []const u8, target: []const u8, version: []const u8, hdrs: []const Header) WriteError!void {
-        if (self.state != .idle) return error.LocalProtocol;
+        if (self.state != .idle) return error.MessageNotEnded;
         try validLineToken(method, false);
         try validLineToken(target, false);
         const ver = try normalizeVersion(version);
@@ -171,7 +182,7 @@ pub const Writer = struct {
     /// response answers; together with the status it decides whether the response
     /// is bodyless (RFC 9112 6.3), so the caller never tracks framing by hand.
     pub fn sendResponse(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, request_method: []const u8) WriteError!void {
-        if (self.state != .idle) return error.LocalProtocol;
+        if (self.state != .idle) return error.MessageNotEnded;
         const ver = try normalizeVersion(version);
         try validLineToken(reason, true); // reason-phrase may contain SP/HTAB
         try validateHeaders(hdrs);
@@ -212,7 +223,7 @@ pub const Writer = struct {
     pub fn sendData(self: *Writer, data: []const u8) WriteError!void {
         switch (self.state) {
             .body_length => {
-                if (data.len > self.body_remaining) return error.LocalProtocol; // over Content-Length
+                if (data.len > self.body_remaining) return error.BodyTooLong;
                 try self.w(data);
                 self.body_remaining -= data.len;
             },
@@ -224,7 +235,7 @@ pub const Writer = struct {
                 try self.w(data);
                 try self.w("\r\n");
             },
-            else => return error.LocalProtocol,
+            else => return error.NoBodyAllowed,
         }
     }
 
@@ -246,13 +257,13 @@ pub const Writer = struct {
                 try self.w("\r\n");
             },
             .body_length => {
-                if (self.body_remaining != 0) return error.LocalProtocol; // under Content-Length
-                if (trailers.len != 0) return error.LocalProtocol; // Content-Length and trailers don't mix
+                if (self.body_remaining != 0) return error.BodyTooShort;
+                if (trailers.len != 0) return error.TrailersNotAllowed;
             },
             .body_none => {
-                if (trailers.len != 0) return error.LocalProtocol; // no body, nowhere for trailers
+                if (trailers.len != 0) return error.TrailersNotAllowed;
             },
-            .idle => return error.LocalProtocol,
+            .idle => return error.NoMessageInProgress,
         }
         self.state = .idle;
     }
@@ -377,7 +388,7 @@ test "HEAD response is bodyless despite Content-Length" {
     defer wr.deinit();
     const hdrs = [_]Header{.{ .name = "Content-Length", .value = "1234" }};
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "HEAD");
-    try t.expectError(error.LocalProtocol, wr.sendData("x")); // no body allowed
+    try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
     try wr.endMessage(&.{});
     try t.expectEqualStrings("HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n", wr.pending());
 }
@@ -385,7 +396,7 @@ test "HEAD response is bodyless despite Content-Length" {
 test "data before head is rejected" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
-    try t.expectError(error.LocalProtocol, wr.sendData("x"));
+    try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
 }
 
 test "oversized body rejected against Content-Length" {
@@ -393,7 +404,7 @@ test "oversized body rejected against Content-Length" {
     defer wr.deinit();
     const hdrs = [_]Header{.{ .name = "Content-Length", .value = "5" }};
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
-    try t.expectError(error.LocalProtocol, wr.sendData("abcdef")); // 6 > 5
+    try t.expectError(error.BodyTooLong, wr.sendData("abcdef")); // 6 > 5
 }
 
 test "oversized body rejected across multiple writes" {
@@ -402,7 +413,7 @@ test "oversized body rejected across multiple writes" {
     const hdrs = [_]Header{.{ .name = "Content-Length", .value = "5" }};
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
     try wr.sendData("abc");
-    try t.expectError(error.LocalProtocol, wr.sendData("def")); // 3 + 3 > 5
+    try t.expectError(error.BodyTooLong, wr.sendData("def")); // 3 + 3 > 5
 }
 
 test "undersized body rejected at end_message" {
@@ -411,7 +422,7 @@ test "undersized body rejected at end_message" {
     const hdrs = [_]Header{.{ .name = "Content-Length", .value = "5" }};
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
     try wr.sendData("abc");
-    try t.expectError(error.LocalProtocol, wr.endMessage(&.{})); // 2 bytes still owed
+    try t.expectError(error.BodyTooShort, wr.endMessage(&.{})); // 2 bytes still owed
 }
 
 test "exact-length body is accepted" {
@@ -432,7 +443,7 @@ test "trailers rejected on a Content-Length body" {
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
     try wr.sendData("abc");
     const trailers = [_]Header{.{ .name = "X-Checksum", .value = "abc" }};
-    try t.expectError(error.LocalProtocol, wr.endMessage(&trailers));
+    try t.expectError(error.TrailersNotAllowed, wr.endMessage(&trailers));
 }
 
 test "trailers rejected on a bodyless message" {
@@ -440,14 +451,20 @@ test "trailers rejected on a bodyless message" {
     defer wr.deinit();
     try wr.sendResponse("1.1", 204, "No Content", &.{}, "GET");
     const trailers = [_]Header{.{ .name = "X-Checksum", .value = "abc" }};
-    try t.expectError(error.LocalProtocol, wr.endMessage(&trailers));
+    try t.expectError(error.TrailersNotAllowed, wr.endMessage(&trailers));
 }
 
 test "two heads without ending is rejected" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     try wr.sendResponse("1.1", 200, "OK", &.{}, "GET");
-    try t.expectError(error.LocalProtocol, wr.sendResponse("1.1", 200, "OK", &.{}, "GET"));
+    try t.expectError(error.MessageNotEnded, wr.sendResponse("1.1", 200, "OK", &.{}, "GET"));
+}
+
+test "end_message with no message in progress is rejected" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    try t.expectError(error.NoMessageInProgress, wr.endMessage(&.{}));
 }
 
 test "take transfers ownership and empties" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -252,10 +252,16 @@ fn data_to_send(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
 }
 
 fn raiseWrite(e: core.writer.WriteError) py.Object {
+    const local = exceptions.LocalProtocolError;
     return switch (e) {
         error.OutOfMemory => c.PyErr_NoMemory(),
-        error.LocalProtocol => py.raise(exceptions.LocalProtocolError, "invalid send for current connection state"),
-        error.InvalidField => py.raise(exceptions.LocalProtocolError, "invalid field: a header/method/target/version/reason was malformed or contained CR/LF/control bytes"),
+        error.MessageNotEnded => py.raise(local, "a message is already in progress: end it before sending another head"),
+        error.NoBodyAllowed => py.raise(local, "cannot send body data now: send a head first, or this message takes no body"),
+        error.BodyTooLong => py.raise(local, "sent more body than the declared Content-Length"),
+        error.BodyTooShort => py.raise(local, "the message ended before the declared Content-Length was reached"),
+        error.TrailersNotAllowed => py.raise(local, "trailers can only follow a chunked body"),
+        error.NoMessageInProgress => py.raise(local, "no message is in progress to end"),
+        error.InvalidField => py.raise(local, "invalid field: a header/method/target/version/reason was malformed or contained CR/LF/control bytes"),
     };
 }
 

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -17,7 +17,7 @@ def test_send_response_content_length() -> None:
 def test_oversized_body_rejected() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(b"1.1", 200, b"OK", [(b"Content-Length", b"5")])
-    with pytest.raises(zttp.LocalProtocolError):
+    with pytest.raises(zttp.LocalProtocolError, match="more body than the declared Content-Length"):
         conn.send_data(b"too long")
 
 
@@ -33,7 +33,7 @@ def test_undersized_body_rejected_at_end() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(b"1.1", 200, b"OK", [(b"Content-Length", b"5")])
     conn.send_data(b"abc")
-    with pytest.raises(zttp.LocalProtocolError):
+    with pytest.raises(zttp.LocalProtocolError, match="ended before the declared Content-Length"):
         conn.end_message()
 
 
@@ -50,15 +50,31 @@ def test_trailers_rejected_on_content_length_body() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(b"1.1", 200, b"OK", [(b"Content-Length", b"3")])
     conn.send_data(b"abc")
-    with pytest.raises(zttp.LocalProtocolError):
+    with pytest.raises(zttp.LocalProtocolError, match="trailers can only follow a chunked body"):
         conn.end_message([(b"X-Checksum", b"abc")])
 
 
 def test_trailers_rejected_on_bodyless_message() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(b"1.1", 204, b"No Content", [])
-    with pytest.raises(zttp.LocalProtocolError):
+    with pytest.raises(zttp.LocalProtocolError, match="trailers can only follow a chunked body"):
         conn.end_message([(b"X-Checksum", b"abc")])
+
+
+def test_all_send_misuses_share_one_exception_class() -> None:
+    # Distinct messages, but every send-side misuse is a single catchable type.
+    cases = [
+        lambda c: c.send_data(b"x"),  # no head yet
+        lambda c: (c.send_response(b"1.1", 200, b"OK", []), c.send_response(b"1.1", 200, b"OK", [])),
+        lambda c: c.end_message(),  # nothing in progress
+    ]
+    messages = set()
+    for case in cases:
+        conn = zttp.Connection(zttp.SERVER)
+        with pytest.raises(zttp.ProtocolError) as exc_info:  # base class catches all
+            case(conn)
+        messages.add(str(exc_info.value))
+    assert len(messages) == len(cases)  # each misuse has its own message
 
 
 def test_send_request() -> None:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -61,20 +61,22 @@ def test_trailers_rejected_on_bodyless_message() -> None:
         conn.end_message([(b"X-Checksum", b"abc")])
 
 
-def test_all_send_misuses_share_one_exception_class() -> None:
-    # Distinct messages, but every send-side misuse is a single catchable type.
-    cases = [
-        lambda c: c.send_data(b"x"),  # no head yet
-        lambda c: (c.send_response(b"1.1", 200, b"OK", []), c.send_response(b"1.1", 200, b"OK", [])),
-        lambda c: c.end_message(),  # nothing in progress
-    ]
-    messages = set()
-    for case in cases:
-        conn = zttp.Connection(zttp.SERVER)
-        with pytest.raises(zttp.ProtocolError) as exc_info:  # base class catches all
-            case(conn)
-        messages.add(str(exc_info.value))
-    assert len(messages) == len(cases)  # each misuse has its own message
+@pytest.mark.parametrize(
+    ("misuse", "message"),
+    [
+        (lambda c: c.send_data(b"x"), "send a head first"),
+        (
+            lambda c: (c.send_response(b"1.1", 200, b"OK", []), c.send_response(b"1.1", 200, b"OK", [])),
+            "a message is already in progress",
+        ),
+        (lambda c: c.end_message(), "no message is in progress to end"),
+    ],
+)
+def test_send_misuse_raises_specific_message(misuse, message: str) -> None:  # type: ignore[no-untyped-def]
+    # Distinct, actionable messages - all catchable by the one base class.
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.ProtocolError, match=message):
+        misuse(conn)
 
 
 def test_send_request() -> None:


### PR DESCRIPTION
Every write-side error mapped to one generic `LocalProtocolError("invalid send for current connection state")`, so a user who over-sent a body got the same message as one who sent two heads. The message existed but told you nothing.

The core's single `error.LocalProtocol` is split into specific Zig error variants - `BodyTooLong`, `BodyTooShort`, `TrailersNotAllowed`, `MessageNotEnded`, `NoBodyAllowed`, `NoMessageInProgress` - set at each failure site where the cause is known (the way h11 raises a specific message at the point of failure). The binding maps each to a precise message:

| Misuse | Message |
| --- | --- |
| over-send | `sent more body than the declared Content-Length` |
| under-send | `the message ended before the declared Content-Length was reached` |
| trailers on non-chunked | `trailers can only follow a chunked body` |
| body with no head / bodyless | `cannot send body data now: send a head first, or this message takes no body` |
| head while busy | `a message is already in progress: end it before sending another head` |
| end with nothing in progress | `no message is in progress to end` |

The variants are an internal detail. **Every case still raises the one `LocalProtocolError` class** (and its base `ProtocolError`), so a single `except zttp.LocalProtocolError` catches them all - there's a test asserting exactly that.

Verified: `zig build test`, full Python suite (92 passed, 100% coverage), `scripts/check`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.