### PR TITLE
Expose Event as a public type

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,15 @@ import zttp
 from tests.conftest import drain, drain_all
 
 
+def test_event_is_public() -> None:
+    # next_event()'s return type is importable from the package, not zttp._zttp.
+    assert "Event" in zttp.__all__
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    ev: zttp.Event = conn.next_event()
+    assert isinstance(ev, zttp.Request)
+
+
 def test_request_repr() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET /p HTTP/1.1\r\nHost: x\r\n\r\n")

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from zttp._zttp import (
     CLIENT,
     NEED_DATA,
@@ -15,6 +17,14 @@ from zttp._zttp import (
     Response,
 )
 
+if TYPE_CHECKING:
+    # The type checker reads the alias from the extension's stub, where it's a
+    # proper union; at runtime it's the value below (a `types.UnionType`), which
+    # mypy would otherwise reject in annotation position.
+    from zttp._zttp import Event as Event
+else:
+    Event = Request | Response | Data | EndOfMessage | type(NEED_DATA) | type(ConnectionClosed)
+
 __all__ = [
     "CLIENT",
     "SERVER",
@@ -23,6 +33,7 @@ __all__ = [
     "ConnectionClosed",
     "Data",
     "EndOfMessage",
+    "Event",
     "LocalProtocolError",
     "ProtocolError",
     "RemoteProtocolError",


### PR DESCRIPTION
`Event` - the return type of `Connection.next_event()` - was only defined in the extension stub (`zttp/_zttp.pyi`), never re-exported from the package. So a consumer wanting to annotate the result (e.g. uvicorn's zttp backend) had to reach into the private module: `from zttp._zttp import Event`.

Export it from `zttp` instead:
- Type checkers read the alias from the stub, where it's already a proper union (`Request | Response | Data | EndOfMessage | NeedDataType | ConnectionClosedType`).
- At runtime it's the matching `|` union over the public classes, so `import zttp; zttp.Event` also works for any runtime use.

The `TYPE_CHECKING` split is needed because the runtime form is built with `type(NEED_DATA)`, which mypy treats as a variable (not valid in annotation position) - so the checker takes the stub alias and the runtime takes the value.

Now consumers do `from zttp import Event` and `def handle(ev: Event): ...`.

Verified: full Python suite (97 passed, 100% coverage), `scripts/check` (ruff/mypy/zig fmt), and `ev: zttp.Event = conn.next_event()` type-checks cleanly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.