### PR TITLE
Stop the fuzz job from saving the uv cache

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
+          save-cache: false
 
       - name: Install dependencies
         run: scripts/install


### PR DESCRIPTION
The run on [#27188469597](https://github.com/Kludex/zttp/actions/runs/27188469597) flagged `Failed to save: Unable to reserve cache with key setup-uv-...`. The job itself passed and no fuzz reproducer was lost - that annotation comes from `astral-sh/setup-uv` racing to write the uv cache.

The fuzz workflow reuses an identical cache key on every run, so concurrent invocations race on the write. Dependency install is one shot per job, so saving the cache buys nothing; setting `save-cache: false` keeps restore on and removes the noisy red annotation.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.