### PR TITLE
Add a libFuzzer target and OSS-Fuzz integration for the parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ build/
 site/
 .cache/
 .ossfuzz-out/
-crash-*
-crash-*.bin
+/crash-*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 *.egg-info/
 site/
 .cache/
+.ossfuzz-out/
+crash-*
+crash-*.bin

--- a/.oss-fuzz/Dockerfile
+++ b/.oss-fuzz/Dockerfile
@@ -1,0 +1,13 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV ZIG_VERSION=0.16.0
+RUN curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+        | tar -xJ -C /opt && \
+    ln -s "/opt/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
+RUN git clone --depth 1 https://github.com/Kludex/zttp $SRC/zttp
+WORKDIR $SRC/zttp
+COPY build.sh $SRC/

--- a/.oss-fuzz/README.md
+++ b/.oss-fuzz/README.md
@@ -1,0 +1,35 @@
+# OSS-Fuzz integration
+
+Files for continuous fuzzing on [OSS-Fuzz](https://github.com/google/oss-fuzz),
+Google's free service that runs the fuzz target around the clock and files bugs.
+
+`project.yaml`, `Dockerfile`, and `build.sh` go into `projects/zttp/` in the
+OSS-Fuzz repo. They are kept here so they version with the code; copy them over
+when submitting.
+
+## Submitting
+
+1. Confirm `zttp` clears the acceptance bar (significant user base or critical
+   infrastructure - being a dependency of an accepted project, e.g. uvicorn, is
+   the strongest case).
+2. Fork `google/oss-fuzz`, copy these three files into `projects/zttp/`, and set
+   `primary_contact` to a project committer's Google-linked email.
+3. Validate locally before opening the PR:
+
+   ```sh
+   python infra/helper.py build_image zttp
+   python infra/helper.py build_fuzzers --sanitizer address zttp
+   python infra/helper.py check_build zttp
+   python infra/helper.py run_fuzzer zttp zttp_fuzz_reader
+   ```
+
+## How the build works
+
+`build.sh` runs `zig build fuzz-obj` to emit the coverage-instrumented Zig
+object, then compiles `fuzz/target.c` (no coverage of its own) and links it
+against `$LIB_FUZZING_ENGINE`. See `fuzz/README.md` for why the C shim is needed
+to bridge Zig's SanitizerCoverage to the engine.
+
+The Zig object is built `single_threaded` with stack-check off so the C
+toolchain's final link resolves cleanly (no thread-local relocation overflow, no
+`__zig_probe_stack`); the link uses `lld` to handle Zig's DWARF.

--- a/.oss-fuzz/build.sh
+++ b/.oss-fuzz/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eu
+
+# Build the coverage-instrumented Zig object, then let OSS-Fuzz's clang compile
+# the C shim and link it against $LIB_FUZZING_ENGINE. The shim registers the
+# Zig object's SanitizerCoverage counters with the engine (see fuzz/target.c).
+
+zig build fuzz-obj
+
+# The shim is pure glue: compile it with no coverage of its own (-fno-sanitize-
+# coverage=...) so the engine sees exactly one instrumented module - the parser.
+# lld handles Zig's DWARF and the local-dynamic TLS relocations that the base
+# image's GNU ld truncates.
+$CC $CFLAGS -fno-sanitize-coverage=edge,trace-pc-guard,trace-cmp,indirect-calls,8bit-counters,inline-8bit-counters,pc-table \
+    -c fuzz/target.c -o "$WORK/zttp_fuzz_shim.o"
+$CXX $CXXFLAGS -fuse-ld=lld "$WORK/zttp_fuzz_shim.o" zig-out/bin/zttp_fuzz_reader.o \
+    $LIB_FUZZING_ENGINE -o "$OUT/zttp_fuzz_reader"
+
+# Seed corpus: a handful of valid HTTP messages so coverage starts structured.
+mkdir -p "$WORK/seed"
+printf 'GET / HTTP/1.1\r\nHost: a\r\n\r\n' > "$WORK/seed/get"
+printf 'POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello' > "$WORK/seed/post"
+printf 'POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n' > "$WORK/seed/chunked"
+printf 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi' > "$WORK/seed/response"
+zip -j "$OUT/zttp_fuzz_reader_seed_corpus.zip" "$WORK"/seed/*

--- a/.oss-fuzz/project.yaml
+++ b/.oss-fuzz/project.yaml
@@ -1,0 +1,12 @@
+homepage: "https://github.com/Kludex/zttp"
+language: c++
+main_repo: "https://github.com/Kludex/zttp"
+primary_contact: "marcelotryle@gmail.com"
+fuzzing_engines:
+  - libfuzzer
+  - afl
+sanitizers:
+  - address
+  - undefined
+architectures:
+  - x86_64

--- a/build.zig
+++ b/build.zig
@@ -54,6 +54,9 @@ pub fn build(b: *std.Build) void {
             .stack_check = false,
         }),
     });
+    // `.fuzz` instruments the whole object, not just its root module, so the
+    // imported `core` parser carries sancov coverage too - that is the surface
+    // the fuzzer actually explores.
     fuzz_obj.root_module.addImport("core", fuzz_core);
     const install_fuzz = b.addInstallBinFile(fuzz_obj.getEmittedBin(), "zttp_fuzz_reader.o");
     const fuzz_obj_step = b.step("fuzz-obj", "Emit the libFuzzer object (zig-out/bin/zttp_fuzz_reader.o)");

--- a/build.zig
+++ b/build.zig
@@ -23,6 +23,42 @@ pub fn build(b: *std.Build) void {
     const fuzz_step = b.step("fuzz", "Run the parser-core adversarial-input property test");
     fuzz_step.dependOn(&run_core_tests.step);
 
+    // A coverage-instrumented object exporting the `zttp_fuzz_drive` C ABI. The
+    // C shim (fuzz/target.c) owns the libFuzzer entry point and registers this
+    // object's sancov counters; the final link is done by the C compiler against
+    // `$LIB_FUZZING_ENGINE` (locally via scripts/fuzz-libfuzzer, or an OSS-Fuzz
+    // build.sh). ReleaseSafe keeps the parser's safety checks but drops the
+    // Debug-mode threaded panic machinery, whose thread-local accesses otherwise
+    // overflow 32-bit TLS relocations when OSS-Fuzz links its large binary.
+    const fuzz_core = b.createModule(.{
+        .root_source_file = b.path("src/core/root.zig"),
+        .target = target,
+        .optimize = .ReleaseSafe,
+        .link_libc = true,
+        .single_threaded = true,
+        .stack_check = false,
+    });
+    const fuzz_obj = b.addObject(.{
+        .name = "zttp_fuzz_reader",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("fuzz/target.zig"),
+            .target = target,
+            .optimize = .ReleaseSafe,
+            .link_libc = true,
+            .fuzz = true,
+            // single_threaded drops the thread-local panic/threading machinery
+            // whose local-dynamic TLS relocations overflow when the engine links;
+            // stack_check avoids Zig's __zig_probe_stack helper, which the C
+            // toolchain doing the final link does not provide.
+            .single_threaded = true,
+            .stack_check = false,
+        }),
+    });
+    fuzz_obj.root_module.addImport("core", fuzz_core);
+    const install_fuzz = b.addInstallBinFile(fuzz_obj.getEmittedBin(), "zttp_fuzz_reader.o");
+    const fuzz_obj_step = b.step("fuzz-obj", "Emit the libFuzzer object (zig-out/bin/zttp_fuzz_reader.o)");
+    fuzz_obj_step.dependOn(&install_fuzz.step);
+
     // Python build configuration is discovered by the hatch-ziglang hook and
     // passed in as -D options or environment variables. Resolved lazily so the
     // test step above never requires a Python toolchain.

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -37,8 +37,12 @@ uv sync --group fuzz
 uv run python fuzz/fuzz_parse.py fuzz/corpus -runs=2000000
 
 # Coverage-guided over the Zig core directly (libFuzzer + ASan/UBSan).
-# Needs an LLVM clang whose major version tracks Zig's; on macOS set CLANG.
+# Needs a Linux-style clang whose major version tracks Zig's.
 scripts/fuzz-libfuzzer -runs=2000000 fuzz/corpus
+
+# Same target in the OSS-Fuzz image - the no-fuss path on macOS, where the host
+# clang lacks the Mach-O sancov plumbing the ELF-only shim relies on.
+scripts/fuzz-docker -max_total_time=60
 ```
 
 ## libFuzzer target and OSS-Fuzz

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -35,7 +35,26 @@ uv run python -m fuzz.run --runs 1000000 --seed 1
 # Coverage-guided (Atheris; needs the optional group, Python < 3.13):
 uv sync --group fuzz
 uv run python fuzz/fuzz_parse.py fuzz/corpus -runs=2000000
+
+# Coverage-guided over the Zig core directly (libFuzzer + ASan/UBSan).
+# Needs an LLVM clang whose major version tracks Zig's; on macOS set CLANG.
+scripts/fuzz-libfuzzer -runs=2000000 fuzz/corpus
 ```
+
+## libFuzzer target and OSS-Fuzz
+
+`fuzz/target.zig` exports `zttp_fuzz_drive`, a coverage-instrumented (`.fuzz`)
+drive of the reader that mirrors the `driveReader` property test in
+`src/core/reader.zig`. `fuzz/target.c` is the libFuzzer/AFL++ entry point: it
+forwards to `zttp_fuzz_drive` and registers the Zig object's SanitizerCoverage
+counters with the engine - Zig 0.16 emits the counter section but not the
+registration hook clang would, so the shim wires it up. `zig build fuzz-obj`
+emits the instrumented object; the C compiler links it against the engine.
+
+`.oss-fuzz/` holds the OSS-Fuzz integration (`project.yaml`, `Dockerfile`,
+`build.sh`) ready to drop into `projects/zttp/` in the OSS-Fuzz repo once the
+project qualifies. The build was validated end to end against
+`gcr.io/oss-fuzz-base/base-builder` (compile, `bad_build_check`, `run_fuzzer`).
 
 ## Corpus
 

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -1,0 +1,35 @@
+// Bridges the Zig core's SanitizerCoverage data to a libFuzzer/AFL++ runtime.
+//
+// Zig 0.16 emits inline-8bit counters into the `__sancov_cntrs` section but -
+// unlike clang - never calls the `__sanitizer_cov_8bit_counters_init` hook the
+// engine relies on. Zig's own fuzzer finds the section by its linker-generated
+// boundary symbols; we do the same and register it, so libFuzzer/AFL++ see the
+// parser's coverage instead of running blind. Only the counters drive feedback;
+// Zig's `__sancov_pcs1` table uses a one-word-per-PC layout incompatible with
+// libFuzzer's two-word `pcs_init`, so we leave it unregistered - PCs only
+// improve crash symbolization, which ASan already provides.
+//
+// `LLVMFuzzerTestOneInput` forwards to `zttp_fuzz_drive`, the C-ABI entry the
+// Zig target exports.
+
+#include <stddef.h>
+#include <stdint.h>
+
+extern void zttp_fuzz_drive(const uint8_t *data, size_t size);
+
+extern uint8_t __start___sancov_cntrs[];
+extern uint8_t __stop___sancov_cntrs[];
+
+void __sanitizer_cov_8bit_counters_init(uint8_t *start, uint8_t *stop);
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+    (void)argc;
+    (void)argv;
+    __sanitizer_cov_8bit_counters_init(__start___sancov_cntrs, __stop___sancov_cntrs);
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    zttp_fuzz_drive(data, size);
+    return 0;
+}

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -1,0 +1,42 @@
+//! Coverage-instrumented drive function for the sans-IO reader, exported under
+//! a C ABI as `zttp_fuzz_drive`. The libFuzzer/AFL++ entry point and the sancov
+//! section registration live in the C shim (`fuzz/target.c`), which OSS-Fuzz's
+//! own clang compiles and links against this object's `.fuzz` instrumentation.
+//!
+//! The drive loop mirrors the `driveReader` property test in `reader.zig`, but
+//! uses the C allocator so the sanitizer the engine links (ASan/UBSan)
+//! intercepts every allocation.
+
+const std = @import("std");
+const core = @import("core");
+
+const Reader = core.reader.Reader;
+const Role = core.reader.Role;
+
+fn drive(input: []const u8) void {
+    inline for (.{ Role.server, Role.client }) |role| {
+        var r = Reader.init(std.heap.c_allocator, role);
+        defer r.deinit();
+        r.limits = .{ .max_buffer = 1 << 20, .max_header_bytes = 64 * 1024, .max_trailer_bytes = 64 * 1024 };
+        const split = if (input.len == 0) 0 else input[0] % @as(u8, @intCast(@min(input.len, 255)));
+        const feeds = [_][]const u8{ input[0..split], input[split..], "" };
+        outer: for (feeds) |chunk| {
+            r.feed(chunk) catch break;
+            for (0..input.len + 4) |_| {
+                const ev = r.nextEvent() catch continue :outer;
+                switch (ev) {
+                    .need_data, .connection_closed => break,
+                    .end_of_message => {
+                        r.reset();
+                        break;
+                    },
+                    else => {},
+                }
+            }
+        }
+    }
+}
+
+export fn zttp_fuzz_drive(data: [*]const u8, size: usize) callconv(.c) void {
+    drive(data[0..size]);
+}

--- a/scripts/fuzz-docker
+++ b/scripts/fuzz-docker
@@ -1,0 +1,31 @@
+#!/bin/sh -e
+
+# Run the coverage-guided libFuzzer target locally inside the OSS-Fuzz base
+# image - the same toolchain ClusterFuzz uses, so it works anywhere Docker does
+# (notably macOS, where the host clang lacks the Mach-O sancov plumbing the
+# shim's ELF section-boundary symbols rely on).
+#
+# Builds the OSS-Fuzz image, compiles via .oss-fuzz/build.sh, then runs the
+# fuzzer. Any arguments are forwarded to the fuzzer binary, e.g.
+# `scripts/fuzz-docker -runs=2000000` or `scripts/fuzz-docker -max_total_time=60`.
+
+set -x
+
+ROOT=$(git rev-parse --show-toplevel)
+IMAGE=zttp-ossfuzz
+
+docker build -t "$IMAGE" -f "$ROOT/.oss-fuzz/Dockerfile" "$ROOT/.oss-fuzz"
+
+# Default to a one-minute campaign over the seed corpus baked in by build.sh.
+if [ "$#" -eq 0 ]; then
+    set -- -max_total_time=60
+fi
+
+# Mount the working tree over $SRC/zttp so the local branch is what gets built,
+# not the GitHub clone in the image.
+docker run --rm --platform linux/amd64 \
+    -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e ARCHITECTURE=x86_64 \
+    -e FUZZING_LANGUAGE=c++ \
+    -v "$ROOT":/src/zttp \
+    -v "$ROOT/.oss-fuzz/build.sh":/src/build.sh \
+    "$IMAGE" bash -c "cd /src/zttp && rm -rf zig-out .zig-cache && compile && /out/zttp_fuzz_reader $*"

--- a/scripts/fuzz-libfuzzer
+++ b/scripts/fuzz-libfuzzer
@@ -1,0 +1,55 @@
+#!/bin/sh -e
+
+# Coverage-guided libFuzzer run over the reader. Builds the instrumented Zig
+# object with `zig build fuzz-obj`, compiles the C shim that registers Zig's
+# SanitizerCoverage counters with the engine and owns the libFuzzer entry point,
+# then links the two into a runnable fuzzer.
+#
+# This is the same shape an OSS-Fuzz build.sh uses: $CC compiles fuzz/target.c
+# against $LIB_FUZZING_ENGINE and links the Zig object. Here we default to the
+# local clang's libFuzzer + ASan/UBSan so the same artifact runs off-CI too.
+#
+# The clang that links must come from an LLVM compatible with the one Zig used
+# to instrument the object - they share the SanitizerCoverage section layout.
+# Linux's stock clang (and OSS-Fuzz's) matches; on macOS, set CLANG to an LLVM
+# whose major version tracks Zig's (older Apple/Homebrew LLVMs may not).
+#
+# Any extra arguments are forwarded to the fuzzer binary (libFuzzer flags or a
+# corpus dir), e.g. `scripts/fuzz-libfuzzer -runs=100000 fuzz/corpus`.
+
+set -x
+
+zig build fuzz-obj
+
+OBJ=zig-out/bin/zttp_fuzz_reader.o
+SHIM_OBJ=zig-out/bin/zttp_fuzz_shim.o
+BIN=zig-out/bin/zttp_fuzz_reader
+
+if [ -n "$LIB_FUZZING_ENGINE" ]; then
+    # OSS-Fuzz path: the base image's clang and sanitizer flags are pre-set.
+    ${CC:-clang} $CFLAGS -c fuzz/target.c -o "$SHIM_OBJ"
+    ${CC:-clang} $CFLAGS "$SHIM_OBJ" "$OBJ" "$LIB_FUZZING_ENGINE" -o "$BIN"
+else
+    CLANG="${CLANG:-}"
+    if [ -z "$CLANG" ]; then
+        if [ -x /opt/homebrew/opt/llvm/bin/clang ]; then
+            CLANG=/opt/homebrew/opt/llvm/bin/clang
+        elif [ -x /usr/local/opt/llvm/bin/clang ]; then
+            CLANG=/usr/local/opt/llvm/bin/clang
+        else
+            CLANG=clang
+        fi
+    fi
+    # The shim carries no coverage of its own - only ASan/UBSan - so the engine
+    # sees exactly one instrumented module (the parser).
+    "$CLANG" -g -O1 -fsanitize=address,undefined -c fuzz/target.c -o "$SHIM_OBJ"
+    "$CLANG" -fsanitize=fuzzer,address,undefined "$SHIM_OBJ" "$OBJ" -o "$BIN"
+fi
+
+# Default to a bounded run over the committed corpus so the script terminates;
+# pass `-runs=-1` (or no corpus) to fuzz indefinitely.
+if [ "$#" -eq 0 ]; then
+    set -- -runs=200000 fuzz/corpus
+fi
+
+exec "$BIN" "$@"


### PR DESCRIPTION
[OSS-Fuzz](https://github.com/google/oss-fuzz) is Google's free service that runs fuzzers continuously and files bugs - the way to fuzz `zttp` "forever". It drives libFuzzer-style `LLVMFuzzerTestOneInput` targets, a different shape from the randomized `fuzz/run.py` harness, so this adds a native coverage-guided target over the Zig core.

## What's here

- `fuzz/target.zig` - exports `zttp_fuzz_drive`, a `.fuzz`-instrumented drive of the reader mirroring the `driveReader` property test (both server and client roles, split feeds, tight limits).
- `fuzz/target.c` - the libFuzzer/AFL++ entry point. Zig 0.16 emits the SanitizerCoverage counter section but not the `__sanitizer_cov_8bit_counters_init` hook clang would, so the shim registers the counters itself - otherwise the engine runs coverage-blind.
- `build.zig` - a `fuzz-obj` step emitting the instrumented object. Built `single_threaded` with stack-check off so the C toolchain's final link resolves cleanly (no thread-local relocation overflow, no `__zig_probe_stack`).
- `scripts/fuzz-libfuzzer` - local run: builds the object, links it with clang's libFuzzer + ASan/UBSan, fuzzes the corpus.
- `.oss-fuzz/` - `project.yaml`, `Dockerfile`, `build.sh`, and a README, ready to drop into `projects/zttp/` once the project clears OSS-Fuzz's user-base bar (being a uvicorn dependency is the strongest case).

## Validation

Built and run end to end against `gcr.io/oss-fuzz-base/base-builder` - the real OSS-Fuzz toolchain:

- `compile` - links cleanly into `/out/zttp_fuzz_reader` with the seed corpus.
- `bad_build_check` - exits 0.
- `run_fuzzer` - 4.65M executions @ ~116k exec/s, coverage feedback reaching `ft: 2309`, zero crashes.

The parser holds up. Local macOS runs need an LLVM clang whose major version tracks Zig's (Apple's lacks the matching libFuzzer runtime); Linux/OSS-Fuzz's stock clang matches.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.