### PR TITLE
Always send HTTP/1.1 in the response status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # zttp
 
 <p align="center">
-  <img src="docs/assets/logo.png" alt="zttp" width="400">
+  <img src="https://github.com/Kludex/zttp/blob/main/docs/assets/logo.png?raw=true" alt="zttp" width="400">
 </p>
 
 > [!WARNING]

--- a/docs/usage/sending.md
+++ b/docs/usage/sending.md
@@ -38,8 +38,8 @@ print(conn.data_to_send())  # (4)!
 ```
 
 1.  The head: just the status code, plus the headers as a list of
-    `(name, value)` byte pairs. The reason phrase defaults from the status and
-    the version comes from the parsed request, so you pass neither.
+    `(name, value)` byte pairs. The reason phrase is derived from the status and
+    the version is `1.1`, so you pass neither.
 
 2.  Body bytes. With a `Content-Length` they pass straight through.
 
@@ -82,8 +82,7 @@ print(conn.data_to_send())
 ```
 
 1.  `send_response(status, headers=None)`. The reason phrase is derived from the
-    status (`200` -> `OK`), and the version is the one zttp parsed from the
-    request (or `1.1`), so you pass neither.
+    status (`200` -> `OK`) and the version is `1.1`, so you pass neither.
 2.  Trailers go on `end_message`. They're only emitted for a chunked body.
 
 ## Bodyless responses

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -28,11 +28,6 @@ const ConnectionObject = extern struct {
     /// bodyless framing. Cleared per cycle by start_next_cycle.
     req_method: [16]u8,
     req_method_len: usize,
-    /// The HTTP version of the message the next response answers, captured at
-    /// event time so send_response can default it. Empty until a request is
-    /// parsed; send_response then falls back to "1.1".
-    req_version: [8]u8,
-    req_version_len: usize,
     /// Connection signals for the last parsed request, captured at event time so
     /// they outlive the head buffer. `upgrade_obj` is held Python bytes (or null).
     should_close: bool,
@@ -70,7 +65,6 @@ fn new(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c
     wctx.* = Writer.init(gpa);
     self.writer = wctx;
     self.req_method_len = 0;
-    self.req_version_len = 0;
     self.should_close = false;
     self.upgrade_obj = null;
     return obj;
@@ -107,22 +101,12 @@ fn rememberMethod(self: *ConnectionObject, method: []const u8) void {
     self.req_method_len = method.len;
 }
 
-fn rememberVersion(self: *ConnectionObject, version: []const u8) void {
-    if (version.len > self.req_version.len) {
-        self.req_version_len = 0;
-        return;
-    }
-    @memcpy(self.req_version[0..version.len], version);
-    self.req_version_len = version.len;
-}
-
 fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const r = self.reader orelse return py.raiseRuntime("connection is closed");
     const ev = r.nextEvent() catch |e| return exceptions.raiseParse(e);
     if (ev == .request) {
         rememberMethod(self, ev.request.method);
-        rememberVersion(self, ev.request.http_version);
         self.should_close = r.shouldClose();
         py.xdecref(self.upgrade_obj);
         self.upgrade_obj = if (r.upgrade()) |u| py.fromBytes(u) else null;
@@ -225,7 +209,7 @@ fn send_response(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obj
     if (c.PyArg_ParseTuple(args, "l|O", &status, &hdrs_seq) == 0) return null;
     if (status < 0 or status > 999) return py.raiseValue("status code out of range");
     const rb = core.writer.reasonPhrase(@intCast(status));
-    const vb = if (self.req_version_len != 0) self.req_version[0..self.req_version_len] else "1.1";
+    const vb = "1.1";
     const method = self.req_method[0..self.req_method_len];
     if (hdrs_seq == null or py.isNone(hdrs_seq)) {
         wc.sendResponse(vb, @intCast(status), rb, &.{}, method) catch |e| return raiseWrite(e);
@@ -306,10 +290,7 @@ fn next_message(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const r = self.reader orelse return py.raiseRuntime("connection is closed");
     r.reset();
-    // req_method / req_version are intentionally NOT cleared here: a caller may
-    // call start_next_cycle() before writing the previous response, and they're
-    // only read by send_response (for framing/version). They're overwritten when
-    // the next request is parsed, so stale values are never observed.
+    self.req_method_len = 0;
     self.should_close = false;
     py.xdecref(self.upgrade_obj);
     self.upgrade_obj = null;
@@ -333,7 +314,7 @@ var methods = [_]py.MethodDef{
     .{ .ml_name = "next_event", .ml_meth = next_event, .ml_flags = c.METH_NOARGS, .ml_doc = "Return the next parse event, or NEED_DATA." },
     .{ .ml_name = "start_next_cycle", .ml_meth = next_message, .ml_flags = c.METH_NOARGS, .ml_doc = "Reset to read the next message on a keep-alive connection." },
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a request head: send_request(method, target, version, headers)." },
-    .{ .ml_name = "send_response", .ml_meth = send_response, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a response head: send_response(status, headers=None). The reason phrase is derived from the status and the version from the request (or 1.1). Bodyless framing (HEAD / 204 / 304) is derived automatically." },
+    .{ .ml_name = "send_response", .ml_meth = send_response, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a response head: send_response(status, headers=None). The reason phrase is derived from the status; the version is 1.1. Bodyless framing (HEAD / 204 / 304) is derived automatically." },
     .{ .ml_name = "send_informational", .ml_meth = send_informational, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize an interim 1xx response: send_informational(status, headers=None). The real response still follows on the same cycle." },
     .{ .ml_name = "send_data", .ml_meth = send_data, .ml_flags = c.METH_O, .ml_doc = "Serialize a run of body bytes (chunk-framed if the head was chunked)." },
     .{ .ml_name = "end_message", .ml_meth = end_message, .ml_flags = c.METH_VARARGS, .ml_doc = "End the outgoing message: end_message(trailers=None)." },

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -290,7 +290,10 @@ fn next_message(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const r = self.reader orelse return py.raiseRuntime("connection is closed");
     r.reset();
-    self.req_method_len = 0;
+    // req_method is intentionally NOT cleared: a caller may call start_next_cycle()
+    // before serializing the previous response (e.g. pipelined keep-alive reads),
+    // and send_response reads it to frame HEAD / CONNECT responses as bodyless. It
+    // is overwritten when the next request is parsed, so a stale value is never seen.
     self.should_close = false;
     py.xdecref(self.upgrade_obj);
     self.upgrade_obj = null;

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -125,6 +125,16 @@ def test_head_response_is_bodyless_despite_content_length() -> None:
     assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n"
 
 
+def test_head_response_bodyless_after_early_start_next_cycle() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"HEAD / HTTP/1.1\r\nHost: x\r\n\r\n")
+    list(drain(conn))
+    conn.start_next_cycle()
+    conn.send_response(200, [(b"Content-Length", b"1234")])
+    conn.end_message()
+    assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n"
+
+
 def test_status_code_formatting() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(404, [])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -273,25 +273,15 @@ def test_send_response_headers_default_empty() -> None:
     assert conn.data_to_send() == b"HTTP/1.1 204 No Content\r\n\r\n"
 
 
-def test_send_response_version_from_request() -> None:
-    conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"GET / HTTP/1.0\r\nHost: h\r\n\r\n")
-    assert isinstance(conn.next_event(), zttp.Request)
-    conn.send_response(200, [(b"Content-Length", b"0")])
-    assert conn.data_to_send() == b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
-
-
-def test_send_response_version_defaults_without_request() -> None:
+def test_send_response_version_is_always_1_1() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(500)
     assert conn.data_to_send() == b"HTTP/1.1 500 Internal Server Error\r\n\r\n"
 
 
-def test_send_response_version_survives_start_next_cycle() -> None:
+def test_send_response_version_1_1_even_for_http_1_0_request() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET / HTTP/1.0\r\nHost: h\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
-    assert isinstance(conn.next_event(), zttp.EndOfMessage)
-    conn.start_next_cycle()
     conn.send_response(200, [(b"Content-Length", b"0")])
-    assert conn.data_to_send() == b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n"
+    assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"


### PR DESCRIPTION
`send_response` (added in #24) defaulted the response version to the one parsed from the request, so an `HTTP/1.0` request got an `HTTP/1.0` response. That diverges from h11, httptools, and most servers, which always respond `HTTP/1.1` - the response version states the version the message conforms to, not an echo of the client's. Responding `HTTP/1.1` to a `1.0` request is standard (RFC 9110/9112).

This pins the response status line to `HTTP/1.1` and removes the per-request version tracking that backed the old default (the `req_version` field, its capture in `next_event`, and the reset bookkeeping). The status line is HTTP/1.1-specific anyway; the forthcoming h2/h3 write paths have no textual version line and are unaffected.

Also points the README logo at the GitHub blob URL so it renders on PyPI (relative paths don't).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.