### PR TITLE
Move docs deploy to Cloudflare Workers Builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,53 +55,6 @@ jobs:
       - name: Enforce coverage
         run: scripts/coverage
 
-  # Preview: build the docs for each PR and upload a versioned Cloudflare build,
-  # commenting the URL on the PR. Skipped on forks and when the secret is absent.
-  docs-preview:
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-
-    env:
-      HAS_CLOUDFLARE_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN != '' }}
-
-    permissions:
-      contents: read
-      pull-requests: write
-
-    environment:
-      name: cloudflare
-      url: ${{ steps.deploy.outputs.deployment-url }}
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.12"
-          enable-cache: false
-
-      - name: Build docs
-        run: scripts/docs
-
-      - name: Upload preview to Cloudflare
-        id: deploy
-        if: ${{ env.HAS_CLOUDFLARE_TOKEN == 'true' }}
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --tag pr-${{ github.event.pull_request.number }}
-
-      - name: Comment preview URL on PR
-        if: ${{ steps.deploy.outcome == 'success' }}
-        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
-        with:
-          message: |
-            :book: Docs preview: ${{ steps.deploy.outputs.deployment-url }}
-          comment-tag: docs-preview
-
   # https://github.com/marketplace/actions/alls-green#why
   check:
     name: All green

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,38 +9,6 @@ on:
 permissions: {}
 
 jobs:
-  # Production: publish https://zttp.marcelotryle.com on every push to main.
-  docs:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    environment:
-      name: cloudflare
-      url: https://zttp.marcelotryle.com
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.12"
-          enable-cache: false
-
-      - name: Build docs
-        run: scripts/docs
-
-      - name: Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
-
   build-wheels:
     name: "Wheels on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,8 +6,12 @@ workers_dev = true
 directory = "./site"
 not_found_handling = "404-page"
 
+# Cloudflare Workers Builds (the GitHub App connected to this repo) builds and
+# deploys this worker: production on main, preview URLs per pull request. The
+# build runs scripts/docs to render ./site.
+#
 # Serve the production docs at the custom domain. The zone must live on the same
-# Cloudflare account as the worker (CLOUDFLARE_ACCOUNT_ID).
+# Cloudflare account as the worker.
 [[routes]]
 pattern = "zttp.marcelotryle.com"
 custom_domain = true


### PR DESCRIPTION
Drop the `cloudflare/wrangler-action` docs jobs from `main.yml` (PR preview) and `publish.yml` (production deploy). Cloudflare Workers Builds (the GitHub App connected to the repo) now builds and deploys the docs directly - production on main, preview URLs per PR - running `scripts/docs` to render `./site`, mirroring zloop.

The `cloudflare` GitHub environment and its `CLOUDFLARE_*` secrets are no longer used by CI.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.