### PR TITLE
Update the README response example to the current send_response signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ conn.next_event()   # EndOfMessage(trailers=[])
 conn.next_event()   # NEED_DATA
 
 # Build a response:
-conn.send_response(b"1.1", 200, b"OK", [(b"Content-Length", b"5")])
+conn.send_response(200, [(b"Content-Length", b"5")])
 conn.send_data(b"hello")
 conn.end_message()
 conn.data_to_send()  # b'HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello'


### PR DESCRIPTION
The README still showed `send_response(b"1.1", 200, b"OK", [...])`. Updated it to the current `send_response(status, headers)` signature (the version and reason are no longer arguments).

Docs only - no release needed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.