### PR TITLE
Group the HTTP/1.1 core modules under an h1/ package

### DIFF
--- a/src/core/h1/chunked.zig
+++ b/src/core/h1/chunked.zig
@@ -5,9 +5,9 @@
 //! Trailer field-lines after the last chunk are returned to the caller to parse.
 
 const std = @import("std");
-const tables = @import("tables.zig");
-const Scanner = @import("scanner.zig").Scanner;
-const ParseError = @import("errors.zig").ParseError;
+const tables = @import("../tables.zig");
+const Scanner = @import("../scanner.zig").Scanner;
+const ParseError = @import("../errors.zig").ParseError;
 
 const State = enum {
     /// Reading the chunk-size hex digits (and any chunk extensions) up to CRLF.

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -6,8 +6,8 @@
 //! caller.
 
 const std = @import("std");
-const tables = @import("tables.zig");
-const events = @import("events.zig");
+const tables = @import("../tables.zig");
+const events = @import("../events.zig");
 
 const Header = events.Header;
 

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -4,9 +4,9 @@
 //! conflicting values, we reject rather than guess.
 
 const std = @import("std");
-const tables = @import("tables.zig");
-const events = @import("events.zig");
-const ParseError = @import("errors.zig").ParseError;
+const tables = @import("../tables.zig");
+const events = @import("../events.zig");
+const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
 

--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -4,11 +4,11 @@
 //! of (name, value) pairs, which the caller owns.
 
 const std = @import("std");
-const tables = @import("tables.zig");
-const events = @import("events.zig");
-const Scanner = @import("scanner.zig").Scanner;
-const trimTrailingOws = @import("scanner.zig").trimTrailingOws;
-const ParseError = @import("errors.zig").ParseError;
+const tables = @import("../tables.zig");
+const events = @import("../events.zig");
+const Scanner = @import("../scanner.zig").Scanner;
+const trimTrailingOws = @import("../scanner.zig").trimTrailingOws;
+const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
 

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -9,13 +9,13 @@
 //! so steady-state parsing is append-and-advance with no per-call memmove.
 
 const std = @import("std");
-const events = @import("events.zig");
+const events = @import("../events.zig");
 const headers_mod = @import("headers.zig");
 const framing_mod = @import("framing.zig");
 const connection_mod = @import("connection.zig");
 const chunked_mod = @import("chunked.zig");
-const Scanner = @import("scanner.zig").Scanner;
-const ParseError = @import("errors.zig").ParseError;
+const Scanner = @import("../scanner.zig").Scanner;
+const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
 const Event = events.Event;

--- a/src/core/h1/root.zig
+++ b/src/core/h1/root.zig
@@ -1,0 +1,20 @@
+//! The HTTP/1.1 layer: connection state, the pull-API reader, the writer, and
+//! the framing/chunked/header codecs. Aggregates the submodules and pulls their
+//! tests, mirroring src/core/h2/root.zig so `zig build test`/`zig build fuzz`
+//! cover H1 with no new build step.
+
+pub const headers = @import("headers.zig");
+pub const framing = @import("framing.zig");
+pub const chunked = @import("chunked.zig");
+pub const connection = @import("connection.zig");
+pub const reader = @import("reader.zig");
+pub const writer = @import("writer.zig");
+
+test {
+    _ = headers;
+    _ = framing;
+    _ = chunked;
+    _ = connection;
+    _ = reader;
+    _ = writer;
+}

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -5,8 +5,8 @@
 //! reject misuse (a body before a head, two heads in a row).
 
 const std = @import("std");
-const tables = @import("tables.zig");
-const events = @import("events.zig");
+const tables = @import("../tables.zig");
+const events = @import("../events.zig");
 const framing = @import("framing.zig");
 
 const Header = events.Header;

--- a/src/core/root.zig
+++ b/src/core/root.zig
@@ -4,22 +4,12 @@ pub const tables = @import("tables.zig");
 pub const errors = @import("errors.zig");
 pub const events = @import("events.zig");
 pub const scanner = @import("scanner.zig");
-pub const headers = @import("headers.zig");
-pub const framing = @import("framing.zig");
-pub const chunked = @import("chunked.zig");
-pub const connection = @import("connection.zig");
-pub const reader = @import("reader.zig");
-pub const writer = @import("writer.zig");
+pub const h1 = @import("h1/root.zig");
 
 test {
     _ = tables;
     _ = errors;
     _ = events;
     _ = scanner;
-    _ = headers;
-    _ = framing;
-    _ = chunked;
-    _ = connection;
-    _ = reader;
-    _ = writer;
+    _ = h1;
 }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -7,9 +7,9 @@ const std = @import("std");
 const py = @import("py.zig");
 const c = py.c;
 const core = @import("core");
-const Reader = core.reader.Reader;
-const Role = core.reader.Role;
-const Writer = core.writer.Writer;
+const Reader = core.h1.reader.Reader;
+const Role = core.h1.reader.Role;
+const Writer = core.h1.writer.Writer;
 const events = core.events;
 const events_obj = @import("events_obj.zig");
 const exceptions = @import("exceptions.zig");
@@ -208,7 +208,7 @@ fn send_response(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obj
     var hdrs_seq: ?*c.PyObject = null;
     if (c.PyArg_ParseTuple(args, "l|O", &status, &hdrs_seq) == 0) return null;
     if (status < 0 or status > 999) return py.raiseValue("status code out of range");
-    const rb = core.writer.reasonPhrase(@intCast(status));
+    const rb = core.h1.writer.reasonPhrase(@intCast(status));
     const vb = "1.1";
     const method = self.req_method[0..self.req_method_len];
     if (hdrs_seq == null or py.isNone(hdrs_seq)) {
@@ -271,7 +271,7 @@ fn data_to_send(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     return out;
 }
 
-fn raiseWrite(e: core.writer.WriteError) py.Object {
+fn raiseWrite(e: core.h1.writer.WriteError) py.Object {
     const local = exceptions.LocalProtocolError;
     return switch (e) {
         error.OutOfMemory => c.PyErr_NoMemory(),


### PR DESCRIPTION
The transport-specific H1 modules (`connection`, `reader`, `writer`, `framing`, `chunked`, `headers`) lived flat in `src/core/`, while HTTP/2 already had its own `src/core/h2/` package. That made `core.connection` mean H1 but `core.h2.connection` mean H2 - peers the tree presented asymmetrically.

This moves the H1 modules into `src/core/h1/` with their own `root.zig` mirroring `h2/root.zig`, leaving only the transport-agnostic vocabulary (`events`, `errors`, `tables`, `scanner`) at the top level. The Python binding now reaches them via `core.h1.reader` / `core.h1.writer`.

Pure rename plus import-path updates - no behaviour change. It sets up the HTTP/2 (and later HTTP/3) work to slot in as sibling packages rather than special cases.

- `zig build test`: passes
- `pytest`: 115 passed
- `bench.py`: unchanged within noise (GET ~1.06x httptools, POST ~2.9x), as expected for a move with identical codegen

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.