### PR TITLE
Raise the wheel-build job timeout to 30 minutes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,9 @@ jobs:
   build-wheels:
     name: "Wheels on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    timeout-minutes: 15
+    # Windows builds each cp3x wheel serially at ~2-4 min apiece; six of them
+    # with a cold Zig cache overran the previous 15 min limit.
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
The Windows wheel build on `main` ([run](https://github.com/Kludex/zttp/actions/runs/27221405476/job/80376889839)) hit the 15 min job timeout after #31 added cp310/cp311. Windows builds each cp3x wheel serially at ~2-4 min apiece, and six of them with a cold Zig cache overran the limit. No wheel failed - every one that built passed its test command; the job was just cut off mid-build.

Bumps `timeout-minutes` to 30, which leaves headroom for six Windows wheels while still catching a genuine hang.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.