### PR TITLE
Document HTTP/2 across the docs and mark it done

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ integrator is responsible for.
   use zttp unchanged.
 - **HTTP/2** - HPACK, the frame layer, and the multiplexed connection state
   machine in the Zig core, surfaced through the same event API
-  (`Connection(role, protocol=zttp.HTTP2)`); events carry a `stream_id`. The
-  server read path (prior-knowledge) is implemented; client responses and the
-  Python write side are next. *(in progress)*
+  (`Connection(role, protocol=zttp.HTTP2)`); events carry a `stream_id`. Both
+  read paths (server requests, client responses) and the full write side - a
+  `Stream` handle per stream, with outbound flow control - are implemented. *(done)*
 - **HTTP/3** - QPACK + the QUIC-side framing, same event API.
 
 ## Status

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,11 +18,12 @@ icon: lucide/zap
 
 ---
 
-zttp is a [sans-IO](https://sans-io.readthedocs.io/) HTTP/1.1 parser whose engine
-is written in [Zig](https://ziglang.org). It does **no I/O of its own**: you feed
-it bytes and pull out events, and you ask it for bytes to send. It never touches a
-socket - so it works with any I/O you like (asyncio, threads, a green-thread
-library, a test harness), and it's a joy to test.
+zttp is a [sans-IO](https://sans-io.readthedocs.io/) HTTP parser whose engine
+is written in [Zig](https://ziglang.org). It speaks **HTTP/1.1 and HTTP/2**, and
+it does **no I/O of its own**: you feed it bytes and pull out events, and you ask
+it for bytes to send. It never touches a socket - so it works with any I/O you
+like (asyncio, threads, a green-thread library, a test harness), and it's a joy
+to test.
 
 It's the same idea as [h11](https://github.com/python-hyper/h11), with a
 hand-written Zig engine underneath instead of pure Python.
@@ -32,6 +33,9 @@ The key features are:
 * **Sans-IO**: a clean, event-based API. Feed bytes with `receive_data`, pull
   `Request` / `Data` / `EndOfMessage` events with `next_event`. No callbacks, no
   sockets, no surprises.
+* **HTTP/1.1 and HTTP/2**: the *same* event API for both. Pass
+  `protocol=zttp.HTTP2` and you get multiplexed streams, HPACK, and flow control -
+  see [HTTP/2](usage/http2.md).
 * **Fast**: a hand-written Zig engine with branch-light scanning and minimal
   allocation - see [Performance](reference/performance.md) for the numbers.
 * **Safe**: strict by default. It defends against request smuggling, rejects bare
@@ -119,6 +123,12 @@ That's it. The buffering, the header parsing, the body framing - all Zig. 🎉
     ---
 
     The write side: build requests and responses, get bytes to send.
+
+-   :material-transit-connection-variant: **[HTTP/2](usage/http2.md)**
+
+    ---
+
+    The same API, multiplexed: streams, flow control, and the control events.
 
 -   :material-sitemap: **[Why sans-IO](architecture/sans-io.md)**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,18 +9,35 @@ importable straight from `zttp` (e.g. `from zttp import Connection`).
 
 ## Connection
 
+`zttp.Connection` is the base - the read side, shared by both protocols.
+Constructing one returns the subclass for the protocol you picked: an
+`H1Connection` (the default) or an `H2Connection`, so the send surface you get
+matches the protocol.
+
 ::: zttp.Connection
 
-## Roles
+::: zttp.H1Connection
 
-A `Connection`'s role is fixed at construction:
+::: zttp.H2Connection
+
+A `Stream` is the per-stream send handle on an HTTP/2 connection - see
+[HTTP/2](../usage/http2.md).
+
+::: zttp.Stream
+
+## Roles and protocols
+
+A `Connection`'s role and protocol are fixed at construction:
 
 - `zttp.SERVER` - you receive requests, send responses.
 - `zttp.CLIENT` - you send requests, receive responses.
+- `zttp.HTTP1` *(default)* - one message at a time; you send on the connection.
+- `zttp.HTTP2` - multiplexed streams; you send on a `Stream`.
 
 ## Events
 
-[`next_event`](#zttp.Connection.next_event) returns one of these.
+[`next_event`](#zttp.Connection.next_event) returns one of these. On HTTP/2 each
+also carries a `.stream_id`.
 
 ::: zttp.Request
 
@@ -29,6 +46,21 @@ A `Connection`'s role is fixed at construction:
 ::: zttp.Data
 
 ::: zttp.EndOfMessage
+
+### HTTP/2 control events
+
+An HTTP/2 connection also surfaces the protocol's control frames. zttp acts on
+the ones that matter on its own; they're here when you want visibility.
+
+::: zttp.Settings
+
+::: zttp.WindowUpdate
+
+::: zttp.Ping
+
+::: zttp.RstStream
+
+::: zttp.Goaway
 
 ### Sentinels
 

--- a/docs/usage/first-steps.md
+++ b/docs/usage/first-steps.md
@@ -103,6 +103,12 @@ A client connection is the mirror image: you get `Response` (with `.status_code`
 `.reason`, `.http_version`, `.headers`) instead of `Request`, then the same
 `Data` / `EndOfMessage`.
 
+!!! tip "Same events on HTTP/2"
+    Pass `protocol=zttp.HTTP2` and the read side is unchanged - the *same*
+    `Request` / `Response` / `Data` / `EndOfMessage`, plus a `.stream_id` on each
+    (it's `0` on HTTP/1.1) because one connection now multiplexes many requests.
+    The send side differs - HTTP/2 sends on a stream. See [HTTP/2](http2.md).
+
 ## Keep-alive
 
 HTTP/1.1 connections are reused. After you've pulled `EndOfMessage` for one

--- a/docs/usage/http2.md
+++ b/docs/usage/http2.md
@@ -1,0 +1,236 @@
+---
+icon: lucide/network
+---
+
+# HTTP/2
+
+You already know the zttp API: feed bytes with `receive_data`, pull events with
+`next_event`, ask for bytes with `data_to_send`. **HTTP/2 is the same API.** You
+opt in with one argument, and the events you already know - `Request`,
+`Response`, `Data`, `EndOfMessage` - come back, now tagged with the stream they
+belong to.
+
+```python
+import zttp
+
+conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # (1)!
+```
+
+1.  The only new thing: `protocol=zttp.HTTP2`. Leave it off and you get HTTP/1.1,
+    exactly as before.
+
+!!! note "Prior knowledge"
+    zttp speaks HTTP/2 over a plain connection (the *prior-knowledge* mode, and
+    what you get after ALPN or an upgrade negotiates `h2`). zttp does no I/O and
+    no TLS - it parses and serializes the HTTP/2 framing once you have the bytes.
+
+## Two connections, one base
+
+A connection's *send* surface depends on its protocol, so zttp gives you the
+right type for the protocol you asked for:
+
+```python
+import zttp
+
+h1 = zttp.Connection(zttp.SERVER)                       # (1)!
+h2 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # (2)!
+
+type(h1).__name__  #> 'H1Connection'
+type(h2).__name__  #> 'H2Connection'
+
+isinstance(h2, zttp.Connection)  #> True  (3)!
+```
+
+1.  An `H1Connection`: the message-scoped send API you saw in
+    [Sending](sending.md) - `send_response`, `send_data`, `end_message`.
+
+2.  An `H2Connection`: everything is **stream-scoped**, so it has no connection-level
+    `send_data`. You send on a [`Stream`](#streams) instead.
+
+3.  Both are real `Connection` subclasses, so code that only reads (`receive_data`
+    / `next_event` / `data_to_send`) can take either one.
+
+!!! tip "Your editor knows"
+    Because they're distinct types, calling `h2.send_data(...)` is a **type
+    error**, not a runtime surprise - your editor flags it before you run.
+    HTTP/2 has no single "current message" to send on, so the method simply
+    isn't there.
+
+## The read side
+
+Reading is what you already do. The only addition is `stream_id` on every event,
+because one HTTP/2 connection multiplexes many requests at once:
+
+```python title="server_read.py" hl_lines="10"
+import zttp
+
+server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+server.receive_data(incoming_bytes)  # (1)!
+
+while True:
+    event = server.next_event()
+    if event is zttp.NEED_DATA:
+        break
+    if isinstance(event, zttp.Request):
+        print(event.method, event.target, event.stream_id)  # (2)!
+```
+
+1.  The bytes off the wire - HTTP/2 frames, not text. Feed whole or in fragments,
+    same as always.
+
+2.  `event.stream_id` tells you which stream this `Request` arrived on. On
+    HTTP/1.1 it's `0`; on HTTP/2 it's the real id, and every `Data` /
+    `EndOfMessage` for that request carries the same id.
+
+A **client** reads the mirror image - `Response` events instead of `Request` -
+again tagged with the `stream_id` of the request they answer.
+
+## Streams
+
+In HTTP/2 you don't send "on the connection" - you send **on a stream**. A
+`Stream` is a small handle with the send API scoped to one stream:
+
+* `send_response(status, headers=None)` - a response head.
+* `send_data(data)` - body bytes (flow-controlled, see [below](#flow-control)).
+* `end_message(trailers=None)` - finish the message.
+
+The connection owns the real stream state; the `Stream` is just a typed handle to
+it. You get one in two ways, depending on who opens the stream.
+
+### Client: opening a stream
+
+The client **originates** a stream by sending a request, so `send_request`
+hands you the `Stream` back:
+
+```python title="client.py" hl_lines="4"
+import zttp
+
+client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])  # (1)!
+
+stream  #> Stream(stream_id=1)
+
+stream.end_message()  # (2)!
+print(client.data_to_send())  # the HTTP/2 frames to put on the wire
+```
+
+1.  `send_request` opens the stream and returns its `Stream`. The version arg is
+    ignored (it's always `2`), and `:authority` is derived from your `host`
+    header - so a request you'd build for HTTP/1.1 works unchanged.
+
+2.  From here you talk to the **stream**, not the connection: `stream.send_data`,
+    `stream.end_message`.
+
+### Server: answering a stream
+
+The server learns a stream's id by **reading** the request off it. Use
+`conn.stream(id)` to get the handle for the stream you want to answer:
+
+```python title="server.py" hl_lines="7 9"
+import zttp
+
+server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+server.receive_data(request_bytes)
+request = next(e for e in drain(server) if isinstance(e, zttp.Request))  # (1)!
+
+stream = server.stream(request.stream_id)  # (2)!
+stream.send_response(200, [(b"content-type", b"text/plain")])
+stream.send_data(b"Hello, HTTP/2!")
+stream.end_message()
+
+print(server.data_to_send())
+```
+
+1.  `drain` is just a loop over `next_event` until `NEED_DATA` - the events carry
+    the `stream_id` you need.
+
+2.  `conn.stream(id)` returns the handle for that stream. The connection already
+    owns the stream state; this is your typed view onto it.
+
+!!! tip "Many streams at once"
+    Because each `Stream` names its own id, you can answer requests in **any
+    order** - hold a handle per in-flight request and respond as each is ready.
+    Two requests arriving before you answer either is the normal HTTP/2 case, and
+    routing the responses is just `server.stream(s1)` and `server.stream(s2)`.
+
+## Flow control
+
+HTTP/2 has per-stream and per-connection **send windows**: the peer tells you how
+many body bytes it's willing to receive, and you mustn't send past that. zttp
+handles this for you - and keeps it sans-IO.
+
+When you call `stream.send_data`, zttp emits as many bytes as the window allows
+and **parks the rest**. As the peer grants more window (it sends you
+`WINDOW_UPDATE` frames, which arrive as bytes you `receive_data`), zttp drains the
+parked bytes automatically on the next `next_event`:
+
+```python title="flow.py" hl_lines="6 11"
+import zttp
+
+stream = server.stream(1)
+stream.send_response(200, [(b"content-type", b"text/plain")])
+stream.send_data(b"a very large body ...")  # (1)!
+out = server.data_to_send()                 # only what the window allowed
+
+# ... later, the peer grants more window ...
+server.receive_data(window_update_bytes)    # (2)!
+for event in drain(server):
+    ...                                      # a WindowUpdate flows past
+more = server.data_to_send()                 # (3)!  the parked bytes, now freed
+```
+
+1.  You hand zttp the whole body. It never blocks and never drops anything - it
+    sends what fits and remembers the rest.
+
+2.  The credit arrives as ordinary inbound bytes. No special call.
+
+3.  The bytes the window now permits are waiting for you, framed and ready.
+
+!!! note "Buffering is not I/O"
+    Parking bytes until the window opens is bookkeeping, not I/O - zttp still
+    never touches a socket, never blocks, and never waits. *When* to ask for more
+    window and what your event loop does meanwhile stays yours; zttp only decides
+    *how many bytes may leave now*. That's the sans-IO line. See
+    [Why sans-IO](../architecture/sans-io.md).
+
+## Control events
+
+Beyond the `Request` / `Response` / `Data` / `EndOfMessage` you already handle,
+an HTTP/2 connection surfaces the protocol's own control frames as events, so you
+can observe (and react to) what the peer is doing:
+
+| Event | Meaning |
+| --- | --- |
+| `Settings` | The peer announced its settings. |
+| `WindowUpdate` | The peer granted flow-control credit. |
+| `Ping` | A keepalive / round-trip probe. |
+| `RstStream` | The peer reset a single stream. |
+| `Goaway` | The peer is shutting the connection down. |
+
+They flow out of `next_event` like any other event. Most applications can ignore
+them - zttp acts on the ones that matter (crediting windows, releasing parked
+data) on its own - but they're there when you need visibility.
+
+## Where to go next
+
+<div class="grid cards" markdown>
+
+-   :material-upload-network: **[Sending](sending.md)**
+
+    ---
+
+    The HTTP/1.1 write side, in full - the foundation the `Stream` API mirrors.
+
+-   :material-alert-circle: **[Errors](errors.md)**
+
+    ---
+
+    `LocalProtocolError` vs `RemoteProtocolError`, on both protocols.
+
+-   :material-book-open: **[API reference](../reference/api.md)**
+
+    ---
+
+    `H2Connection`, `Stream`, and the control events in full.
+
+</div>

--- a/docs/usage/sending.md
+++ b/docs/usage/sending.md
@@ -17,6 +17,12 @@ There are four building blocks, plus one call to collect the output:
 * `end_message(trailers=None)` - finish the message.
 * `data_to_send()` - take and clear the bytes produced so far.
 
+!!! note "This page is the HTTP/1.1 write side"
+    These message-scoped calls live on an `H1Connection`. HTTP/2 sends on a
+    *stream* instead - the same four building blocks, scoped to a `Stream`
+    handle. See [HTTP/2](http2.md). The read side and `data_to_send` are
+    identical on both.
+
 ## A response
 
 As a **server**, you answer a request:

--- a/docs/usage/sending.md
+++ b/docs/usage/sending.md
@@ -17,11 +17,9 @@ There are four building blocks, plus one call to collect the output:
 * `end_message(trailers=None)` - finish the message.
 * `data_to_send()` - take and clear the bytes produced so far.
 
-!!! note "This page is the HTTP/1.1 write side"
-    These message-scoped calls live on an `H1Connection`. HTTP/2 sends on a
-    *stream* instead - the same four building blocks, scoped to a `Stream`
-    handle. See [HTTP/2](http2.md). The read side and `data_to_send` are
-    identical on both.
+These same four building blocks carry over to HTTP/2 - there, you call them on a
+[`Stream`](http2.md) instead of the connection, because one connection carries
+many at once.
 
 ## A response
 
@@ -143,3 +141,8 @@ conn.send_response(200, [(b"X-Evil", b"a\r\nInjected: yes")])
     Misusing the send API raises `LocalProtocolError` - *you* did something wrong.
     Malformed bytes from the peer raise `RemoteProtocolError`. See
     [Errors](errors.md).
+
+## Where to go next
+
+* [HTTP/2](http2.md) - the same four building blocks, multiplexed across streams.
+* [Errors](errors.md) - what zttp rejects on the send side, and why.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zttp"
-description = "A sans-IO HTTP parser for Python with a Zig core."
+description = "A sans-IO HTTP/1.1 and HTTP/2 parser for Python with a Zig core."
 readme = "README.md"
 license = "BSD-3-Clause"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [{ name = "Marcelo Trylesinski", email = "marcelotryle@gmail.com" }]
-keywords = ["http", "parser", "sans-io", "zig", "asgi"]
+keywords = ["http", "http2", "parser", "sans-io", "zig", "asgi"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "zttp"
-site_description = "A sans-IO HTTP parser for Python with a Zig core."
+site_description = "A sans-IO HTTP/1.1 and HTTP/2 parser for Python with a Zig core."
 site_author = "Marcelo Trylesinski"
 #site_url = "https://zttp.dev/"
 repo_url = "https://github.com/Kludex/zttp"
@@ -18,6 +18,7 @@ nav = [
   { "Using zttp" = [
     "usage/parsing.md",
     "usage/sending.md",
+    "usage/http2.md",
     "usage/errors.md",
   ] },
   { "Architecture" = [


### PR DESCRIPTION
The HTTP/2 write side (#32) - a `Stream` handle per stream, with outbound flow control - is implemented, but the docs still described HTTP/2 as read-only / "in progress." This updates every surface and adds a dedicated usage page.

## Changes

- **README roadmap**: HTTP/2 is now *done* - both read paths (server requests, client responses) plus the full `Stream`-based write side with flow control.
- **docs/index.md**: the intro and feature list mention HTTP/1.1 *and* HTTP/2; added a grid card linking to the new page.
- **docs/usage/http2.md** *(new)*: protocol selection, `H1Connection` vs `H2Connection`, the client `send_request` -> `Stream` flow, the server `conn.stream(id)` flow, the `Stream` send API, outbound flow control (and why parking bytes is still sans-IO), and the control events.
- **docs/usage/sending.md** / **first-steps.md**: note the HTTP/1.1-vs-HTTP/2 send split and the `stream_id` on events, cross-linking to the new page.
- **docs/reference/api.md**: surface `H1Connection`, `H2Connection`, `Stream`, and the HTTP/2 control events.
- **pyproject.toml** / **zensical.toml**: description and keywords now cover HTTP/2.

## Notes

- The docs site builds (`zensical build`). Every code snippet's behaviour was verified against the running extension before writing its output.
- One pre-existing `zensical build` warning remains (an autoref in `first-steps.md` that predates this PR); it is left untouched to keep the diff scoped to HTTP/2 docs.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.