### PR TITLE
Harden the HTTP/2 read path, C-API error handling, and fuzzing

### DIFF
--- a/fuzz/harness.py
+++ b/fuzz/harness.py
@@ -58,3 +58,31 @@ def consume(data: bytes) -> None:
         _drive(role, chunks)
     except ALLOWED:
         return
+
+
+# A valid client preface + empty SETTINGS frame: enough to push the mutated tail
+# past the handshake and into the connection/HPACK/frame/stream state machine.
+H2_PREAMBLE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+H2_PREFIX = H2_PREAMBLE + b"\x00\x00\x00\x04\x00\x00\x00\x00\x00"
+
+
+def _drive_h2(role: int, chunks: list[bytes]) -> None:
+    conn = zttp.Connection(role, protocol=zttp.HTTP2)
+    # A client has no inbound preface; only a server consumes it.
+    conn.receive_data(H2_PREFIX if role == zttp.SERVER else H2_PREFIX[len(H2_PREAMBLE) :])
+    for chunk in chunks:
+        conn.receive_data(chunk)
+        while True:
+            event = conn.next_event()
+            if event is zttp.NEED_DATA or event is zttp.CONNECTION_CLOSED:
+                break
+
+
+def consume_h2(data: bytes) -> None:
+    """H2 fuzz iteration: drive the HTTP/2 engine. Raises only on a real bug."""
+    role = ROLES[data[0] & 1] if data else zttp.SERVER
+    chunks = _split(data[1:] if data else data)
+    try:
+        _drive_h2(role, chunks)
+    except ALLOWED:
+        return

--- a/fuzz/run.py
+++ b/fuzz/run.py
@@ -21,7 +21,7 @@ import traceback
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
-from fuzz.harness import consume
+from fuzz.harness import consume, consume_h2
 from fuzz.roundtrip import roundtrip
 
 CORPUS = Path(__file__).parent / "corpus"
@@ -37,7 +37,16 @@ SEEDS = (
     b"\r\n\n: \r\n\x00\xff",
 )
 
-ORACLES: tuple[Callable[[bytes], None], ...] = (consume, roundtrip)
+# H2 wire fragments: preface + empty SETTINGS, then a HEADERS frame whose HPACK
+# block is fully indexed (:method GET, :scheme http, :path /) with END_HEADERS.
+H2_SEEDS = (
+    b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+    b"\x00\x00\x00\x04\x00\x00\x00\x00\x00",
+    b"\x00\x00\x03\x01\x05\x00\x00\x00\x01\x82\x86\x84",
+    b"\x00\x00\x04\x03\x00\x00\x00\x00\x01\x00\x00\x00\x08",
+)
+
+ORACLES: tuple[Callable[[bytes], None], ...] = (consume, consume_h2, roundtrip)
 
 
 def _mutate(rng: random.Random, sample: bytes) -> bytes:
@@ -64,9 +73,11 @@ def _mutate(rng: random.Random, sample: bytes) -> bytes:
 def _inputs(rng: random.Random, runs: int) -> Iterator[bytes]:
     for _ in range(runs):
         roll = rng.random()
-        if roll < 0.5:
+        if roll < 0.4:
             yield _mutate(rng, rng.choice(SEEDS))
-        elif roll < 0.75:
+        elif roll < 0.65:
+            yield _mutate(rng, b"".join(H2_SEEDS) + rng.randbytes(rng.randint(0, 32)))
+        elif roll < 0.8:
             yield rng.randbytes(rng.randint(0, 256))
         else:
             yield _mutate(rng, b"".join(rng.sample(SEEDS, rng.randint(1, 3))))

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -10,8 +10,11 @@
 const std = @import("std");
 const core = @import("core");
 
-const Reader = core.reader.Reader;
-const Role = core.reader.Role;
+const Reader = core.h1.reader.Reader;
+const Role = core.h1.reader.Role;
+const H2Connection = core.h2.connection.Connection;
+const h2_constants = core.h2.constants;
+const H2Role = core.h2.connection.Role;
 
 fn drive(input: []const u8) void {
     inline for (.{ Role.server, Role.client }) |role| {
@@ -37,6 +40,40 @@ fn drive(input: []const u8) void {
     }
 }
 
+// The connection orchestrator (and the HPACK/frame/stream parsers it drives) is
+// the H2 surface with the least automated assurance; prepending a valid
+// preface+SETTINGS gets the mutated tail past the handshake into that machine.
+fn driveH2(input: []const u8) void {
+    inline for (.{ H2Role.server, H2Role.client }) |role| {
+        var conn = H2Connection.init(std.heap.c_allocator, role);
+        defer conn.deinit();
+        conn.limits.max_buffer = 1 << 20;
+        if (role == .server) conn.feed(h2_constants.CLIENT_PREFACE) catch return;
+        // An empty SETTINGS frame: 9-byte header, type=0x04, no payload.
+        conn.feed(&[_]u8{ 0, 0, 0, 0x04, 0, 0, 0, 0, 0 }) catch return;
+        const split = if (input.len == 0) 0 else input[0] % @as(u8, @intCast(@min(input.len, 255)));
+        const feeds = [_][]const u8{ input[0..split], input[split..], "" };
+        outer: for (feeds) |chunk| {
+            conn.feed(chunk) catch break;
+            for (0..input.len + 4) |_| {
+                const ev = conn.nextEvent() catch continue :outer;
+                switch (ev) {
+                    .need_data => break,
+                    else => {},
+                }
+            }
+        }
+    }
+}
+
 export fn zttp_fuzz_drive(data: [*]const u8, size: usize) callconv(.c) void {
-    drive(data[0..size]);
+    const input = data[0..size];
+    // First byte selects the parser so one corpus exercises both H1 and H2; the
+    // rest is the mutated body. No build wiring changes: `.fuzz` already
+    // instruments the whole `core` import, H2 included.
+    if (input.len != 0 and input[0] & 1 == 1) {
+        driveH2(input[1..]);
+    } else {
+        drive(if (input.len == 0) input else input[1..]);
+    }
 }

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -46,6 +46,12 @@ pub const Limits = struct {
     /// against the CONTINUATION flood (CVE-2024-27316).
     max_field_block_bytes: usize = 64 * 1024,
     max_continuation_frames: u32 = 16,
+    /// Total streams ever opened on one connection and total resets the peer may
+    /// drive, defending against rapid-reset churn (CVE-2023-44487). Defaults are
+    /// generous multiples of max_concurrent_streams; exceeding either trips
+    /// EnhanceYourCalm (-> GOAWAY).
+    max_streams: u64 = 4096,
+    max_stream_resets: u64 = 256,
 };
 
 /// The error set the H2 engine raises. Mapped to RFC 9113 error codes for the
@@ -87,6 +93,13 @@ pub const Connection = struct {
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     highest_peer_id: u32 = 0,
+    /// O(1) live-stream count (streams in a concurrency-counting state). Kept in
+    /// step with the map: ++ on idle->open insertion, -- on eviction of a closed
+    /// stream. Replaces the old O(map-size) liveStreamCount scan.
+    live_streams: u32 = 0,
+    /// Rapid-reset churn budgets: total streams ever opened and total resets.
+    streams_opened: u64 = 0,
+    stream_resets: u64 = 0,
 
     pending: [PENDING_CAP]Event = undefined,
     pending_len: usize = 0,
@@ -343,7 +356,14 @@ pub const Connection = struct {
         if (@as(i64, self.conn_recv_window) - @as(i64, f.header.length) < 0) return error.FlowControlError;
         self.conn_recv_window -= @intCast(f.header.length);
 
-        const s = self.streams.getPtr(f.header.stream_id) orelse return error.ProtocolError;
+        const s = self.streams.getPtr(f.header.stream_id) orelse {
+            // No live stream: an idle id (never opened) is a connection error;
+            // a closed/evicted id is a stream error STREAM_CLOSED (RFC 9113 5.1,
+            // mirroring stream.classifyRecv's .closed branch).
+            if (self.isIdle(f.header.stream_id)) return error.ProtocolError;
+            self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(ErrorCode.stream_closed) } });
+            return;
+        };
         const classify = s.classifyRecv(.data, end_stream);
         switch (classify.action) {
             .ok => {},
@@ -367,6 +387,7 @@ pub const Connection = struct {
                 return;
             }
             self.push(.{ .end_of_message = .{ .stream_id = f.header.stream_id } });
+            self.maybeEvictDone(f.header.stream_id);
         }
     }
 
@@ -380,6 +401,8 @@ pub const Connection = struct {
             return;
         };
         s.recvApply(.rst_stream, false);
+        self.evictStream(f.header.stream_id);
+        try self.chargeReset();
         self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = code } });
     }
 
@@ -416,8 +439,7 @@ pub const Connection = struct {
             // out of scope). The stream is created here for the response if the
             // send side has not already (the H2 write path opens it on request).
             if (id % 2 == 0) return error.ProtocolError;
-            self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
-            self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+            try self.openStream(id);
         } else {
             // A new request stream. Its id must be odd and exceed the highest peer
             // id (5.1.1: parity + monotonicity).
@@ -426,10 +448,9 @@ pub const Connection = struct {
             // connection-global dynamic table in sync, but refuse the request
             // (RST_STREAM REFUSED_STREAM) and never surface it. No stream record
             // is inserted, so the map cannot grow under a refused-stream flood.
-            refused = self.liveStreamCount() >= self.limits.max_concurrent_streams;
+            refused = self.live_streams >= self.limits.max_concurrent_streams;
             if (!refused) {
-                self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
-                self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+                try self.openStream(id);
             }
             self.highest_peer_id = id;
         }
@@ -485,11 +506,12 @@ pub const Connection = struct {
             // Trailers: a second HEADERS block; must carry END_STREAM (8.1) and
             // must not contain pseudo-headers or otherwise-invalid fields.
             if (!end_stream or !validTrailers(headers)) {
-                self.resetStream(s, id, .protocol_error);
+                try self.resetStream(s, id, .protocol_error);
                 return;
             }
             s.recvApply(.headers, true);
             self.push(.{ .end_of_message = .{ .trailers = headers, .stream_id = id } });
+            self.maybeEvictDone(id);
             return;
         }
 
@@ -497,7 +519,7 @@ pub const Connection = struct {
             // Collapse the response pseudo-header (:status) + regular fields.
             const resp = self.collapseResponse(headers, id) catch |e| switch (e) {
                 error.Malformed => {
-                    self.resetStream(s, id, .protocol_error);
+                    try self.resetStream(s, id, .protocol_error);
                     return;
                 },
                 error.OutOfMemory => return error.MessageTooLong,
@@ -509,7 +531,7 @@ pub const Connection = struct {
             // arrive, so it is malformed and resets the stream.
             if (resp.event.status_code >= 100 and resp.event.status_code < 200) {
                 if (end_stream) {
-                    self.resetStream(s, id, .protocol_error);
+                    try self.resetStream(s, id, .protocol_error);
                     return;
                 }
                 self.push(.{ .response = resp.event });
@@ -521,6 +543,7 @@ pub const Connection = struct {
             if (end_stream) {
                 s.recvApply(.headers, true); // open -> half_closed_remote
                 self.push(.{ .end_of_message = .{ .stream_id = id } });
+                self.maybeEvictDone(id);
             }
             return;
         }
@@ -528,7 +551,7 @@ pub const Connection = struct {
         // Collapse pseudo-headers into the request line + regular headers.
         const req = self.collapseRequest(headers, id) catch |e| switch (e) {
             error.Malformed => {
-                self.resetStream(s, id, .protocol_error);
+                try self.resetStream(s, id, .protocol_error);
                 return;
             },
             error.OutOfMemory => return error.MessageTooLong,
@@ -539,13 +562,16 @@ pub const Connection = struct {
         if (end_stream) {
             s.recvApply(.headers, true); // open -> half_closed_remote
             self.push(.{ .end_of_message = .{ .stream_id = id } });
+            self.maybeEvictDone(id);
         }
     }
 
-    /// Reset a stream for a stream error: emit RST_STREAM and move its state to
-    /// closed so later frames on it are no longer treated as open.
-    fn resetStream(self: *Connection, s: *Stream, id: u32, code: ErrorCode) void {
+    /// Reset a stream for a stream error: emit RST_STREAM, move its state to
+    /// closed, and evict it. A locally-driven reset still counts as churn.
+    fn resetStream(self: *Connection, s: *Stream, id: u32, code: ErrorCode) H2Error!void {
         s.recvApply(.rst_stream, false); // -> closed
+        self.evictStream(id);
+        try self.chargeReset();
         self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = @intFromEnum(code) } });
     }
 
@@ -709,8 +735,12 @@ pub const Connection = struct {
     /// is seeded from the peer's INITIAL_WINDOW_SIZE (what the peer will accept).
     pub fn registerSendStream(self: *Connection, id: u32) error{OutOfMemory}!void {
         if (self.streams.getPtr(id) != null) return;
-        self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.OutOfMemory;
-        self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+        self.openStream(id) catch return error.OutOfMemory;
+        // A server only registers a send to RESPOND to a request whose recv side
+        // already ended (it was evicted on read-completion). Restore that state so
+        // the response drains to eviction (no live_streams leak) and any late peer
+        // DATA is a STREAM_CLOSED stream error, not silently reopened.
+        if (self.role == .server) self.streams.getPtr(id).?.state = .half_closed_remote;
     }
 
     /// Queue outbound body bytes on `id`, emitting as much as the connection and
@@ -768,6 +798,7 @@ pub const Connection = struct {
             try writer.writeDataFrame(id, &.{}, true);
             s.send_end_pending = false;
         }
+        self.maybeEvictDone(id);
     }
 
     /// Whether any stream still has parked outbound bytes (or an owed END_STREAM)
@@ -781,20 +812,56 @@ pub const Connection = struct {
         return false;
     }
 
-    fn liveStreamCount(self: *Connection) u32 {
-        var n: u32 = 0;
-        var it = self.streams.valueIterator();
-        while (it.next()) |s| {
-            if (s.countsTowardConcurrency()) n += 1;
+    /// Insert a stream and move it idle->open. Maintains the live counter and the
+    /// total-streams churn cap (CVE-2023-44487). Every counted insertion goes
+    /// through here so live_streams and streams_opened stay exact.
+    fn openStream(self: *Connection, id: u32) H2Error!void {
+        if (self.limits.max_streams != 0 and self.streams_opened >= self.limits.max_streams) return error.EnhanceYourCalm;
+        self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
+        self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+        self.streams_opened += 1;
+        self.live_streams += 1;
+    }
+
+    /// Remove a stream from the map, keeping live_streams exact. Safe to call on a
+    /// closed entry: the null path in handleData/handleWindowUpdate/handleRstStream
+    /// classifies an evicted (id <= highest_peer_id) stream as closed, not idle.
+    fn evictStream(self: *Connection, id: u32) void {
+        if (self.streams.fetchRemove(id)) |kv| {
+            var s = kv.value;
+            // Every map entry was counted once in openStream and this is its sole
+            // removal, so the decrement is unconditional - the stream's state is
+            // already .closed here, so countsTowardConcurrency() would wrongly
+            // skip it.
+            self.live_streams -= 1;
+            s.deinit(self.gpa);
         }
-        return n;
+    }
+
+    /// Evict a stream whose receive side has fully ended and which owes no outbound
+    /// send. This is the read-only server's normal completion (the stream sits in
+    /// half_closed_remote, never reaching .closed because the app sent no response)
+    /// as well as the post-response close (.closed). Without it, completed requests
+    /// pin live_streams forever and a long-lived connection refuses every request
+    /// past max_concurrent_streams. A stream still owing a send (the app is
+    /// responding) is retained; if the app responds after the stream was evicted,
+    /// registerSendStream re-opens it for the response.
+    fn maybeEvictDone(self: *Connection, id: u32) void {
+        const s = self.streams.getPtr(id) orelse return;
+        const recv_done = s.state == .half_closed_remote or s.state == .closed;
+        if (recv_done and s.send_pending.items.len == 0 and !s.send_end_pending) self.evictStream(id);
+    }
+
+    /// Charge one stream reset against the churn budget (CVE-2023-44487).
+    fn chargeReset(self: *Connection) H2Error!void {
+        self.stream_resets += 1;
+        if (self.limits.max_stream_resets != 0 and self.stream_resets > self.limits.max_stream_resets) return error.EnhanceYourCalm;
     }
 
     /// Open a stream as if a HEADERS had arrived - used by tests that exercise the
     /// DATA path without driving a full HEADERS block.
     pub fn openStreamForTest(self: *Connection, id: u32) !void {
-        try self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size));
-        self.streams.getPtr(id).?.recvApply(.headers, false);
+        try self.openStream(id);
         if (id > self.highest_peer_id) self.highest_peer_id = id;
     }
 
@@ -1147,7 +1214,7 @@ test "over the concurrency cap, a request is refused not surfaced" {
     try testing.expectEqual(@as(u32, 3), refused.rst_stream.stream_id);
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.refused_stream)), refused.rst_stream.error_code);
     // The refused stream left no record, so only stream 1 is tracked.
-    try testing.expectEqual(@as(u32, 1), c.liveStreamCount());
+    try testing.expectEqual(@as(u32, 1), c.live_streams);
 }
 
 // A client's inbound handshake is just the server's SETTINGS - no preface to
@@ -1409,6 +1476,254 @@ test "an obs-text value (0x80-0xFF) is accepted" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
     try testing.expectEqualStrings("x-obs", req.request.headers[0].name);
     try testing.expectEqualStrings(&[_]u8{ 0x80, 0xFF }, req.request.headers[0].value);
+}
+
+test "rapid open+RST churn keeps the stream map and live counter bounded" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Open-then-RST 100 streams on increasing odd ids. Each pair must leave zero
+    // residue: no map entry, no live count.
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 100) : (k += 1) {
+        try frameBytes(&frames, .headers, Flags.end_headers, id, &GET_BLOCK); // open, no END_STREAM
+        try frameBytes(&frames, .rst_stream, 0, id, &[_]u8{ 0x00, 0x00, 0x00, 0x08 }); // CANCEL
+        id += 2;
+    }
+    try handshook(&c, frames.items);
+    var seen: usize = 0;
+    while (true) {
+        const ev = try c.nextEvent();
+        if (ev == .need_data) break;
+        seen += 1;
+    }
+    try testing.expect(seen >= 100); // at least the 100 rst_stream echoes surfaced
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+}
+
+test "a late WINDOW_UPDATE or RST on an evicted closed stream is tolerated" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Open stream 1, RST it (evicts), then send a stray WINDOW_UPDATE and a stray
+    // RST on the now-evicted id 1 (<= highest_peer_id, so closed not idle).
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK);
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try frameBytes(&frames, .window_update, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x10 });
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try handshook(&c, frames.items);
+    // The opening HEADERS surfaces the request; then the RST echo; then the strays
+    // after eviction are dropped.
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+}
+
+test "DATA on an evicted closed stream is a stream error STREAM_CLOSED" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK); // open
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 }); // evicts
+    try frameBytes(&frames, .data, Flags.end_stream, 1, "x"); // DATA on the evicted id
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // the opening request
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent())); // the RST echo
+    const stale = try c.nextEvent();
+    try testing.expectEqual(@as(u32, 1), stale.rst_stream.stream_id);
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), stale.rst_stream.error_code);
+}
+
+test "live_streams matches reality across read-completion and reset" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Stream 1: a complete read-only request (END_STREAM, no response owed) is
+    // evicted on completion, so it does NOT pin the concurrency counter.
+    try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    // Stream 3: open, no END_STREAM -> still receiving -> counts.
+    try frameBytes(&frames, .headers, Flags.end_headers, 3, &GET_BLOCK);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 1 request
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent())); // 1 eom
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 3 request
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    // Stream 1 completed and was evicted; only the still-open stream 3 counts.
+    try testing.expectEqual(@as(u32, 1), c.live_streams);
+    try testing.expectEqual(@as(usize, 1), c.streams.count());
+    // Now RST stream 3: it leaves counting and is evicted, draining the map.
+    var more: std.ArrayList(u8) = .empty;
+    defer more.deinit(testing.allocator);
+    try frameBytes(&more, .rst_stream, 0, 3, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try c.feed(more.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "a reset-churn flood trips EnhanceYourCalm" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_stream_resets = 3;
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Four open+RST cycles; the 4th reset exceeds the budget of 3.
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 4) : (k += 1) {
+        try frameBytes(&frames, .headers, Flags.end_headers, id, &GET_BLOCK);
+        try frameBytes(&frames, .rst_stream, 0, id, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+        id += 2;
+    }
+    try handshook(&c, frames.items);
+    var tripped = false;
+    for (0..64) |_| {
+        const ev = c.nextEvent() catch |e| {
+            try testing.expectEqual(error.EnhanceYourCalm, e);
+            tripped = true;
+            break;
+        };
+        if (ev == .need_data) break;
+    }
+    try testing.expect(tripped);
+}
+
+test "opening more than max_streams trips EnhanceYourCalm" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_streams = 2;
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Three opens (no END_STREAM); the 3rd open exceeds the cap of 2.
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK);
+    try frameBytes(&frames, .headers, Flags.end_headers, 3, &GET_BLOCK);
+    try frameBytes(&frames, .headers, Flags.end_headers, 5, &GET_BLOCK);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // stream 1
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // stream 3
+    try testing.expectError(error.EnhanceYourCalm, c.nextEvent()); // stream 5 over the cap
+}
+
+test "a read-only server serves more than max_concurrent_streams sequential requests" {
+    // Regression for the half-closed leak: a completed request that owes no
+    // response is evicted, so a long-lived connection does not refuse every
+    // request past max_concurrent_streams (default 128).
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 500) : (k += 1) {
+        try frameBytes(&input, .headers, Flags.end_headers | Flags.end_stream, id, &GET_BLOCK);
+        id += 2;
+    }
+    try c.feed(input.items);
+    try testing.expectEqual(std.meta.Tag(Event).settings, std.meta.activeTag(try c.nextEvent()));
+    var requests: usize = 0;
+    var refusals: usize = 0;
+    while (true) {
+        const ev = try c.nextEvent();
+        switch (ev) {
+            .need_data => break,
+            .request => requests += 1,
+            .rst_stream => refusals += 1,
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 500), requests);
+    try testing.expectEqual(@as(usize, 0), refusals);
+    try testing.expectEqual(@as(u32, 0), c.live_streams); // all completed and evicted
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "a request+response cycle returns live_streams to zero" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    // A complete request (END_STREAM): the recv side ends and the stream is
+    // evicted on read-completion, so live_streams is 0 between request and response.
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    // The app responds: register the send, then a body with END_STREAM. Once the
+    // response drains the stream closes and is evicted - back to zero, no leak.
+    try w.sendResponse(1, 200, &.{}, false);
+    try c.sendStreamData(&w, 1, "hi", true);
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "many request+response cycles do not leak the concurrency budget" {
+    // Regression: a re-created response stream must drain to eviction, or every
+    // cycle leaks one live_streams and the connection refuses requests past 128.
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    try c.feed(input.items);
+    try testing.expectEqual(std.meta.Tag(Event).settings, std.meta.activeTag(try c.nextEvent()));
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 300) : (k += 1) {
+        var hdr: std.ArrayList(u8) = .empty;
+        defer hdr.deinit(testing.allocator);
+        try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, id, &GET_BLOCK);
+        try c.feed(hdr.items);
+        try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+        try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+        try testing.expectEqual(Event.need_data, try c.nextEvent());
+        try w.sendResponse(id, 200, &.{}, false);
+        try c.sendStreamData(&w, id, "ok", true);
+        try testing.expectEqual(@as(u32, 0), c.live_streams); // never accumulates
+        id += 2;
+    }
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "late DATA after a response is registered is a stream error STREAM_CLOSED" {
+    // The re-created response stream is half_closed_remote, so a peer sending DATA
+    // after its own END_STREAM is rejected, not silently reopened (smuggling guard).
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try w.sendResponse(1, 200, &.{}, false); // register the response (re-creates stream 1 half_closed_remote)
+    try c.registerSendStream(1);
+    // The peer sends DATA on stream 1 after it already ended: STREAM_CLOSED.
+    var data: std.ArrayList(u8) = .empty;
+    defer data.deinit(testing.allocator);
+    try frameBytes(&data, .data, 0, 1, "evil");
+    try c.feed(data.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), ev.rst_stream.error_code);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -570,6 +570,7 @@ pub const Connection = struct {
 
         for (headers) |h| {
             if (h.name.len == 0) return error.Malformed;
+            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (eql(h.name, ":method")) {
@@ -605,6 +606,9 @@ pub const Connection = struct {
 
         if (method == null or path == null or scheme == null) return error.Malformed;
         const target = path.?;
+        // RFC 9113 8.3.1: :path must be non-empty for http/https (the empty/CONNECT
+        // and asterisk-form carve-outs are *, which is non-empty, so this is enough).
+        if (target.len == 0) return error.Malformed;
         const q = std.mem.indexOfScalar(u8, target, '?');
         const req_path = if (q) |i| target[0..i] else target;
         const req_query = if (q) |i| target[i + 1 ..] else target[target.len..];
@@ -649,6 +653,7 @@ pub const Connection = struct {
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (!eql(h.name, ":status")) return error.Malformed; // request pseudo or unknown
+                // :status is digit-checked below, so it cannot carry a control byte.
                 if (status != null) return error.Malformed;
                 if (h.value.len != 3) return error.Malformed;
                 var code: u16 = 0;
@@ -664,6 +669,7 @@ pub const Connection = struct {
             }
             seen_regular = true;
             if (!isValidFieldName(h.name)) return error.Malformed;
+            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
             if (isConnectionSpecific(h.name)) return error.Malformed;
             if (eql(h.name, "content-length")) {
                 const cl = parseU64(h.value) orelse return error.Malformed;
@@ -835,12 +841,23 @@ fn isValidFieldName(name: []const u8) bool {
     return true;
 }
 
+/// A legal field-value byte (RFC 9113 8.2.1): no CR/LF/NUL or other control, no
+/// DEL; obs-text (0x80-0xFF) and inner SP/HTAB are allowed. The same rule the H1
+/// path and the H2 write path enforce, so a re-serialized request cannot split.
+fn validValue(value: []const u8) bool {
+    for (value) |ch| {
+        if (!tables.is_field_vchar[ch]) return false;
+    }
+    return true;
+}
+
 /// Trailers (RFC 9113 8.1): no pseudo-header may appear, and every name must be
 /// a valid lowercase field name. Connection-specific fields are likewise barred.
 fn validTrailers(headers: []const events.Header) bool {
     for (headers) |h| {
         if (h.name.len == 0 or h.name[0] == ':') return false;
         if (!isValidFieldName(h.name)) return false;
+        if (!validValue(h.value)) return false;
         if (isConnectionSpecific(h.name)) return false;
     }
     return true;
@@ -1284,6 +1301,114 @@ test "a pseudo-header in trailers is rejected" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).data, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a CR in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, then literal "x-evil: a\rb".
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x0D, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(@as(u32, 1), ev.rst_stream.stream_id);
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an LF in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x0A, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a NUL in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x00, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a CRLF in :path resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, then a literal :path value "/\r\n".
+    const block = [_]u8{ 0x82, 0x86, 0x00, 0x05 } ++ ":path".* ++ [_]u8{ 0x03, '/', 0x0D, 0x0A };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+}
+
+test "a CRLF in :authority resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, then a literal :authority "evil\r\n".
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x0a } ++ ":authority".* ++ [_]u8{ 0x06, 'e', 'v', 'i', 'l', 0x0D, 0x0A };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a control byte in a trailer value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK); // open, no END_STREAM
+    try frameBytes(&frames, .data, 0, 1, "body");
+    // Trailer "x-checksum: a\x00b" - a NUL in the value.
+    const trailer = [_]u8{ 0x00, 0x0a } ++ "x-checksum".* ++ [_]u8{ 0x03, 'a', 0x00, 'b' };
+    try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &trailer);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).data, std.meta.activeTag(try c.nextEvent()));
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an empty :path is malformed and resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, then a literal :path with an empty value.
+    const block = [_]u8{ 0x82, 0x86, 0x00, 0x05 } ++ ":path".* ++ [_]u8{0x00};
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an obs-text value (0x80-0xFF) is accepted" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // A full GET request plus a literal "x-obs: \x80\xFF" (obs-text, legal).
+    const block = GET_BLOCK ++ [_]u8{ 0x00, 0x05 } ++ "x-obs".* ++ [_]u8{ 0x02, 0x80, 0xFF };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const req = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
+    try testing.expectEqualStrings("x-obs", req.request.headers[0].name);
+    try testing.expectEqualStrings(&[_]u8{ 0x80, 0xFF }, req.request.headers[0].value);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -1726,6 +1726,43 @@ test "late DATA after a response is registered is a stream error STREAM_CLOSED" 
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), ev.rst_stream.error_code);
 }
 
+test "fuzz: H2 connection never panics on adversarial frame streams" {
+    const seeds = [_][]const u8{
+        &[_]u8{ 0x00, 0x00, 0x03, 0x01, 0x05, 0x00, 0x00, 0x00, 0x01, 0x82, 0x86, 0x84 }, // HEADERS GET
+        &[_]u8{ 0x00, 0x00, 0x04, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08 }, // RST_STREAM
+        &([_]u8{ 0x00, 0x00, 0x08, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00 } ++ [_]u8{0} ** 8), // PING
+        &[_]u8{ 0x00, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 'h', 'e', 'l', 'l', 'o' }, // DATA END_STREAM
+        &[_]u8{ 0xff, 0xff, 0xff, 0x01, 0x04, 0x00, 0x00, 0x00, 0x01 }, // over-long HEADERS length
+        &[_]u8{ 0x00, 0x00, 0x04, 0x08, 0x00, 0x00, 0x00, 0x00, 0x01, 0x7f, 0xff, 0xff, 0xff }, // WINDOW_UPDATE
+    };
+    var rng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const r = rng.random();
+    var k: usize = 0;
+    while (k < 2000) : (k += 1) {
+        var input: std.ArrayList(u8) = .empty;
+        defer input.deinit(testing.allocator);
+        try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+        try frameBytes(&input, .settings, 0, 0, &.{});
+        const n = r.intRangeAtMost(usize, 1, 6);
+        var j: usize = 0;
+        while (j < n) : (j += 1) {
+            const seed = try testing.allocator.dupe(u8, seeds[r.intRangeLessThan(usize, 0, seeds.len)]);
+            defer testing.allocator.free(seed);
+            if (seed.len != 0 and r.boolean()) seed[r.intRangeLessThan(usize, 0, seed.len)] = r.int(u8);
+            try input.appendSlice(testing.allocator, seed);
+        }
+        var c = Connection.init(testing.allocator, .server);
+        defer c.deinit();
+        c.limits.max_buffer = 1 << 20;
+        c.feed(input.items) catch continue;
+        var iter: usize = 0;
+        while (iter < input.items.len + 16) : (iter += 1) {
+            const ev = c.nextEvent() catch break;
+            if (ev == .need_data) break;
+        }
+    }
+}
+
 fn driveConnection(input: []const u8) void {
     var c = Connection.init(testing.allocator, .server);
     defer c.deinit();

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -121,8 +121,8 @@ const H2Engine = struct {
 
     /// Drain parked DATA that a freshly-parsed WINDOW_UPDATE / SETTINGS credit now
     /// permits. Called from next_event after such an event is produced.
-    fn flushSendable(self: *H2Engine) void {
-        self.conn.flushSendable(self.writer) catch {};
+    fn flushSendable(self: *H2Engine) core.h2.writer.WriteError!void {
+        try self.conn.flushSendable(self.writer);
     }
 
     fn deinit(self: *H2Engine) void {
@@ -461,7 +461,8 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             // A parsed WINDOW_UPDATE / SETTINGS may have credited a send window;
             // drain any DATA that was parked waiting for it. The bytes land in the
             // writer's buffer for the next data_to_send.
-            if (ev == .window_update or ev == .settings) e.flushSendable();
+            if (ev == .window_update or ev == .settings)
+                e.flushSendable() catch |err| return h2RaiseWrite(err);
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {
@@ -470,7 +471,10 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
                 e.rememberMethod(ev.request.method);
                 e.should_close = e.reader.shouldClose();
                 py.xdecref(e.upgrade_obj);
-                e.upgrade_obj = if (e.reader.upgrade()) |u| py.fromBytes(u) else null;
+                if (e.reader.upgrade()) |u| {
+                    e.upgrade_obj = py.fromBytes(u);
+                    if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
+                } else e.upgrade_obj = null;
             }
             return events_obj.fromH1Event(ev);
         },


### PR DESCRIPTION
Hardens the HTTP/2 read path, the Python C-API error paths, and the fuzz tooling. Each finding is a separate commit; every commit builds with `zig build test` + `pytest` green.

## Changes

**Evict completed HTTP/2 streams and bound stream churn** - the connection never removed a stream from its map: RST'd streams and completed requests lingered forever. A peer could open-then-reset streams (Rapid Reset, CVE-2023-44487) to grow memory unbounded, and a long-lived connection refused every request past `max_concurrent_streams` once enough streams completed. Now streams are evicted at every terminal point, an O(1) counter replaces the O(n) concurrency scan, and `max_streams` / `max_stream_resets` caps trip `EnhanceYourCalm`. A server registering a response re-creates the stream in `half_closed_remote`, so late peer DATA is `STREAM_CLOSED` rather than silently reopening the receive side.

**Validate HTTP/2 header values and reject an empty `:path`** - the read path checked header names but never values, so CR/LF/NUL in an HPACK value reached the surfaced request unchecked (an H2->H1 splitting vector). Values now go through the same `is_field_vchar` rule the H1 path and the H2 write path enforce; an empty `:path` is rejected per RFC 9113 8.3.1.

**Surface allocation failures from the HTTP/2 and upgrade paths** - `next_event` left a `MemoryError` pending while returning a valid `Request` when the Upgrade bytes failed, and the H2 flush swallowed `OutOfMemory`. Both now propagate.

**Restore the fuzz build and extend it to HTTP/2** - the libFuzzer target imported the moved `core.reader`, so `zig build fuzz-obj` failed and the only ASan/UBSan oracle was dead. Import fixed, plus an H2 drive in the libFuzzer target, a `consume_h2` oracle for the random runner, and an in-source H2 connection property test.

## Notes

The stream-lifecycle change was the deepest; an adversarial review pass caught a half-closed accounting leak and a response-cycle leak that are now fixed and regression-tested (a request+response cycle returns the concurrency counter to zero; 500 sequential read-only requests all surface). The half-closed refusal it surfaced predated the rapid-reset work but is resolved here too.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.