### PR TITLE
Evict completed HTTP/2 streams and bound stream churn

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -570,6 +570,7 @@ pub const Connection = struct {
 
         for (headers) |h| {
             if (h.name.len == 0) return error.Malformed;
+            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (eql(h.name, ":method")) {
@@ -605,6 +606,9 @@ pub const Connection = struct {
 
         if (method == null or path == null or scheme == null) return error.Malformed;
         const target = path.?;
+        // RFC 9113 8.3.1: :path must be non-empty for http/https (the empty/CONNECT
+        // and asterisk-form carve-outs are *, which is non-empty, so this is enough).
+        if (target.len == 0) return error.Malformed;
         const q = std.mem.indexOfScalar(u8, target, '?');
         const req_path = if (q) |i| target[0..i] else target;
         const req_query = if (q) |i| target[i + 1 ..] else target[target.len..];
@@ -649,6 +653,7 @@ pub const Connection = struct {
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (!eql(h.name, ":status")) return error.Malformed; // request pseudo or unknown
+                // :status is digit-checked below, so it cannot carry a control byte.
                 if (status != null) return error.Malformed;
                 if (h.value.len != 3) return error.Malformed;
                 var code: u16 = 0;
@@ -664,6 +669,7 @@ pub const Connection = struct {
             }
             seen_regular = true;
             if (!isValidFieldName(h.name)) return error.Malformed;
+            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
             if (isConnectionSpecific(h.name)) return error.Malformed;
             if (eql(h.name, "content-length")) {
                 const cl = parseU64(h.value) orelse return error.Malformed;
@@ -835,12 +841,23 @@ fn isValidFieldName(name: []const u8) bool {
     return true;
 }
 
+/// A legal field-value byte (RFC 9113 8.2.1): no CR/LF/NUL or other control, no
+/// DEL; obs-text (0x80-0xFF) and inner SP/HTAB are allowed. The same rule the H1
+/// path and the H2 write path enforce, so a re-serialized request cannot split.
+fn validValue(value: []const u8) bool {
+    for (value) |ch| {
+        if (!tables.is_field_vchar[ch]) return false;
+    }
+    return true;
+}
+
 /// Trailers (RFC 9113 8.1): no pseudo-header may appear, and every name must be
 /// a valid lowercase field name. Connection-specific fields are likewise barred.
 fn validTrailers(headers: []const events.Header) bool {
     for (headers) |h| {
         if (h.name.len == 0 or h.name[0] == ':') return false;
         if (!isValidFieldName(h.name)) return false;
+        if (!validValue(h.value)) return false;
         if (isConnectionSpecific(h.name)) return false;
     }
     return true;
@@ -1284,6 +1301,114 @@ test "a pseudo-header in trailers is rejected" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).data, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a CR in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, then literal "x-evil: a\rb".
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x0D, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(@as(u32, 1), ev.rst_stream.stream_id);
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an LF in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x0A, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a NUL in a regular header value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-evil".* ++ [_]u8{ 0x03, 'a', 0x00, 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a CRLF in :path resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, then a literal :path value "/\r\n".
+    const block = [_]u8{ 0x82, 0x86, 0x00, 0x05 } ++ ":path".* ++ [_]u8{ 0x03, '/', 0x0D, 0x0A };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+}
+
+test "a CRLF in :authority resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, then a literal :authority "evil\r\n".
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x0a } ++ ":authority".* ++ [_]u8{ 0x06, 'e', 'v', 'i', 'l', 0x0D, 0x0A };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a control byte in a trailer value resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK); // open, no END_STREAM
+    try frameBytes(&frames, .data, 0, 1, "body");
+    // Trailer "x-checksum: a\x00b" - a NUL in the value.
+    const trailer = [_]u8{ 0x00, 0x0a } ++ "x-checksum".* ++ [_]u8{ 0x03, 'a', 0x00, 'b' };
+    try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &trailer);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).data, std.meta.activeTag(try c.nextEvent()));
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an empty :path is malformed and resets the stream" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, then a literal :path with an empty value.
+    const block = [_]u8{ 0x82, 0x86, 0x00, 0x05 } ++ ":path".* ++ [_]u8{0x00};
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "an obs-text value (0x80-0xFF) is accepted" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // A full GET request plus a literal "x-obs: \x80\xFF" (obs-text, legal).
+    const block = GET_BLOCK ++ [_]u8{ 0x00, 0x05 } ++ "x-obs".* ++ [_]u8{ 0x02, 0x80, 0xFF };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const req = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
+    try testing.expectEqualStrings("x-obs", req.request.headers[0].name);
+    try testing.expectEqualStrings(&[_]u8{ 0x80, 0xFF }, req.request.headers[0].value);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -107,6 +107,9 @@ pub const Connection = struct {
     /// Owned scratch for a Settings event's params; valid until the next event is
     /// produced (the integrator copies what it needs synchronously, as for Data).
     settings_scratch: std.ArrayList(events.SettingPair) = .empty,
+    /// Scratch list of stream ids to evict after a flushSendable pass, so the map
+    /// is never mutated while its iterator is live.
+    evict_scratch: std.ArrayList(u32) = .empty,
 
     /// The single open field block (RFC 9113 4.3): once HEADERS without
     /// END_HEADERS opens it, the very next frame must be CONTINUATION on this
@@ -146,6 +149,7 @@ pub const Connection = struct {
         self.streams.deinit(self.gpa);
         self.hpack.deinit();
         self.settings_scratch.deinit(self.gpa);
+        self.evict_scratch.deinit(self.gpa);
         self.fb_buf.deinit(self.gpa);
         self.req_headers.deinit(self.gpa);
         self.req_scratch.deinit(self.gpa);
@@ -387,7 +391,6 @@ pub const Connection = struct {
                 return;
             }
             self.push(.{ .end_of_message = .{ .stream_id = f.header.stream_id } });
-            self.maybeEvictDone(f.header.stream_id);
         }
     }
 
@@ -424,12 +427,13 @@ pub const Connection = struct {
             // A second HEADERS block is a trailer ONLY while the stream is still
             // open (body not yet ended). A HEADERS after the peer's END_STREAM
             // (half-closed-remote) or on a closed stream is a protocol error.
+            const client_reading = self.role == .client and (s.state == .open or s.state == .half_closed_local);
             if (s.headers_done and s.state == .open) {
                 is_trailer = true;
-            } else if (self.role == .client and !s.headers_done and s.state == .open) {
-                // A client stream that is open but whose head is not done yet: an
-                // interim (1xx) response already arrived and this is the next
-                // response head (another interim, or the final). Accept it.
+            } else if (client_reading and !s.headers_done) {
+                // A client reading a response head: the stream is open, or
+                // half_closed_local once the client finished sending its request.
+                // An interim (1xx) head may already have arrived; accept the next.
             } else {
                 return error.ProtocolError;
             }
@@ -439,7 +443,7 @@ pub const Connection = struct {
             // out of scope). The stream is created here for the response if the
             // send side has not already (the H2 write path opens it on request).
             if (id % 2 == 0) return error.ProtocolError;
-            try self.openStream(id);
+            try self.openPeerStream(id);
         } else {
             // A new request stream. Its id must be odd and exceed the highest peer
             // id (5.1.1: parity + monotonicity).
@@ -450,7 +454,7 @@ pub const Connection = struct {
             // is inserted, so the map cannot grow under a refused-stream flood.
             refused = self.live_streams >= self.limits.max_concurrent_streams;
             if (!refused) {
-                try self.openStream(id);
+                try self.openPeerStream(id);
             }
             self.highest_peer_id = id;
         }
@@ -511,7 +515,6 @@ pub const Connection = struct {
             }
             s.recvApply(.headers, true);
             self.push(.{ .end_of_message = .{ .trailers = headers, .stream_id = id } });
-            self.maybeEvictDone(id);
             return;
         }
 
@@ -543,7 +546,6 @@ pub const Connection = struct {
             if (end_stream) {
                 s.recvApply(.headers, true); // open -> half_closed_remote
                 self.push(.{ .end_of_message = .{ .stream_id = id } });
-                self.maybeEvictDone(id);
             }
             return;
         }
@@ -562,7 +564,6 @@ pub const Connection = struct {
         if (end_stream) {
             s.recvApply(.headers, true); // open -> half_closed_remote
             self.push(.{ .end_of_message = .{ .stream_id = id } });
-            self.maybeEvictDone(id);
         }
     }
 
@@ -736,11 +737,6 @@ pub const Connection = struct {
     pub fn registerSendStream(self: *Connection, id: u32) error{OutOfMemory}!void {
         if (self.streams.getPtr(id) != null) return;
         self.openStream(id) catch return error.OutOfMemory;
-        // A server only registers a send to RESPOND to a request whose recv side
-        // already ended (it was evicted on read-completion). Restore that state so
-        // the response drains to eviction (no live_streams leak) and any late peer
-        // DATA is a STREAM_CLOSED stream error, not silently reopened.
-        if (self.role == .server) self.streams.getPtr(id).?.state = .half_closed_remote;
     }
 
     /// Queue outbound body bytes on `id`, emitting as much as the connection and
@@ -758,13 +754,26 @@ pub const Connection = struct {
     /// Flushing mutates only each stream's own fields and the writer (never the
     /// map's shape), so iterating value pointers in place is safe.
     pub fn flushSendable(self: *Connection, writer: *writer_mod.Writer) writer_mod.WriteError!void {
-        var it = self.streams.valueIterator();
-        while (it.next()) |s| try self.flushStreamPtr(writer, s);
+        // Flush every stream, then evict the ones that fully closed in a SEPARATE
+        // pass. Removing entries while the value iterator is live would be fragile
+        // (it happens to work only because the hash map tombstones rather than
+        // back-shifts on remove), so the eviction ids are collected first.
+        self.evict_scratch.clearRetainingCapacity();
+        var it = self.streams.iterator();
+        while (it.next()) |e| {
+            try self.flushStreamPtr(writer, e.value_ptr);
+            const st = e.value_ptr;
+            if (st.state == .closed and st.send_pending.items.len == 0 and !st.send_end_pending) {
+                self.evict_scratch.append(self.gpa, e.key_ptr.*) catch return error.OutOfMemory;
+            }
+        }
+        for (self.evict_scratch.items) |id| self.evictStream(id);
     }
 
     fn flushStream(self: *Connection, writer: *writer_mod.Writer, id: u32) writer_mod.WriteError!void {
         const s = self.streams.getPtr(id) orelse return;
         try self.flushStreamPtr(writer, s);
+        self.maybeEvictDone(id);
     }
 
     fn flushStreamPtr(self: *Connection, writer: *writer_mod.Writer, s: *Stream) writer_mod.WriteError!void {
@@ -784,7 +793,10 @@ pub const Connection = struct {
             s.send_window -= @intCast(chunk);
             self.conn_send_window -= @intCast(chunk);
             off += chunk;
-            if (end) s.send_end_pending = false;
+            if (end) {
+                s.send_end_pending = false;
+                s.sendEndStream();
+            }
         }
         // Drop the bytes we emitted; keep what the window could not admit.
         if (off > 0) {
@@ -797,8 +809,8 @@ pub const Connection = struct {
         if (s.send_pending.items.len == 0 and s.send_end_pending) {
             try writer.writeDataFrame(id, &.{}, true);
             s.send_end_pending = false;
+            s.sendEndStream();
         }
-        self.maybeEvictDone(id);
     }
 
     /// Whether any stream still has parked outbound bytes (or an owed END_STREAM)
@@ -815,12 +827,23 @@ pub const Connection = struct {
     /// Insert a stream and move it idle->open. Maintains the live counter and the
     /// total-streams churn cap (CVE-2023-44487). Every counted insertion goes
     /// through here so live_streams and streams_opened stay exact.
+    /// Insert a stream and move it idle->open, keeping the live counter exact.
+    /// The single insertion point; the trusted send path and the peer-driven read
+    /// path both route through it. The total-streams churn cap is enforced only on
+    /// the peer path (openPeerStream), never here - the local app is not the
+    /// adversary, so a client/server opening many streams to send is not abuse.
     fn openStream(self: *Connection, id: u32) H2Error!void {
-        if (self.limits.max_streams != 0 and self.streams_opened >= self.limits.max_streams) return error.EnhanceYourCalm;
         self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
         self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
-        self.streams_opened += 1;
         self.live_streams += 1;
+    }
+
+    /// Open a PEER-initiated stream, enforcing the total-streams churn cap
+    /// (CVE-2023-44487) that bounds how many streams one peer may ever open.
+    fn openPeerStream(self: *Connection, id: u32) H2Error!void {
+        if (self.limits.max_streams != 0 and self.streams_opened >= self.limits.max_streams) return error.EnhanceYourCalm;
+        try self.openStream(id);
+        self.streams_opened += 1;
     }
 
     /// Remove a stream from the map, keeping live_streams exact. Safe to call on a
@@ -838,18 +861,15 @@ pub const Connection = struct {
         }
     }
 
-    /// Evict a stream whose receive side has fully ended and which owes no outbound
-    /// send. This is the read-only server's normal completion (the stream sits in
-    /// half_closed_remote, never reaching .closed because the app sent no response)
-    /// as well as the post-response close (.closed). Without it, completed requests
-    /// pin live_streams forever and a long-lived connection refuses every request
-    /// past max_concurrent_streams. A stream still owing a send (the app is
-    /// responding) is retained; if the app responds after the stream was evicted,
-    /// registerSendStream re-opens it for the response.
+    /// Evict a stream that has reached the fully-closed terminal state with no
+    /// outbound send still owed. A half_closed_remote stream is NOT evicted here:
+    /// it still counts toward MAX_CONCURRENT_STREAMS and must stay addressable for
+    /// a late RST_STREAM/WINDOW_UPDATE until the local side finishes the response
+    /// (RFC 9113 5.1). The connection-error/memory bound for streams that never
+    /// finish comes from max_concurrent_streams and the churn caps, not eviction.
     fn maybeEvictDone(self: *Connection, id: u32) void {
         const s = self.streams.getPtr(id) orelse return;
-        const recv_done = s.state == .half_closed_remote or s.state == .closed;
-        if (recv_done and s.send_pending.items.len == 0 and !s.send_end_pending) self.evictStream(id);
+        if (s.state == .closed and s.send_pending.items.len == 0 and !s.send_end_pending) self.evictStream(id);
     }
 
     /// Charge one stream reset against the churn budget (CVE-2023-44487).
@@ -1592,8 +1612,8 @@ test "live_streams matches reality across read-completion and reset" {
     defer c.deinit();
     var frames: std.ArrayList(u8) = .empty;
     defer frames.deinit(testing.allocator);
-    // Stream 1: a complete read-only request (END_STREAM, no response owed) is
-    // evicted on completion, so it does NOT pin the concurrency counter.
+    // Stream 1: a complete request (END_STREAM) lingers in half_closed_remote and
+    // still counts until the app responds.
     try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
     // Stream 3: open, no END_STREAM -> still receiving -> counts.
     try frameBytes(&frames, .headers, Flags.end_headers, 3, &GET_BLOCK);
@@ -1602,17 +1622,17 @@ test "live_streams matches reality across read-completion and reset" {
     try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent())); // 1 eom
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 3 request
     try testing.expectEqual(Event.need_data, try c.nextEvent());
-    // Stream 1 completed and was evicted; only the still-open stream 3 counts.
-    try testing.expectEqual(@as(u32, 1), c.live_streams);
-    try testing.expectEqual(@as(usize, 1), c.streams.count());
-    // Now RST stream 3: it leaves counting and is evicted, draining the map.
+    // Both count: stream 1 (half_closed_remote, awaiting response) and stream 3 (open).
+    try testing.expectEqual(@as(u32, 2), c.live_streams);
+    try testing.expectEqual(@as(usize, 2), c.streams.count());
+    // Now RST stream 3: it is evicted; stream 1 still lingers awaiting its response.
     var more: std.ArrayList(u8) = .empty;
     defer more.deinit(testing.allocator);
     try frameBytes(&more, .rst_stream, 0, 3, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
     try c.feed(more.items);
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
-    try testing.expectEqual(@as(u32, 0), c.live_streams);
-    try testing.expectEqual(@as(usize, 0), c.streams.count());
+    try testing.expectEqual(@as(u32, 1), c.live_streams);
+    try testing.expectEqual(@as(usize, 1), c.streams.count());
 }
 
 test "a reset-churn flood trips EnhanceYourCalm" {
@@ -1658,19 +1678,21 @@ test "opening more than max_streams trips EnhanceYourCalm" {
     try testing.expectError(error.EnhanceYourCalm, c.nextEvent()); // stream 5 over the cap
 }
 
-test "a read-only server serves more than max_concurrent_streams sequential requests" {
-    // Regression for the half-closed leak: a completed request that owes no
-    // response is evicted, so a long-lived connection does not refuse every
-    // request past max_concurrent_streams (default 128).
+test "half-closed-remote requests count toward concurrency until the response finishes" {
+    // A completed request the app has not yet responded to lingers in
+    // half_closed_remote and counts toward MAX_CONCURRENT_STREAMS (RFC 9113 5.1.2),
+    // so a flood of bodyless requests is refused past the cap rather than all
+    // surfaced. (This is the inverse of the earlier eager-eviction bug.)
     var c = Connection.init(testing.allocator, .server);
     defer c.deinit();
+    c.limits.max_concurrent_streams = 4;
     var input: std.ArrayList(u8) = .empty;
     defer input.deinit(testing.allocator);
     try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
     try frameBytes(&input, .settings, 0, 0, &.{});
     var id: u32 = 1;
     var k: usize = 0;
-    while (k < 500) : (k += 1) {
+    while (k < 10) : (k += 1) {
         try frameBytes(&input, .headers, Flags.end_headers | Flags.end_stream, id, &GET_BLOCK);
         id += 2;
     }
@@ -1687,10 +1709,11 @@ test "a read-only server serves more than max_concurrent_streams sequential requ
             else => {},
         }
     }
-    try testing.expectEqual(@as(usize, 500), requests);
-    try testing.expectEqual(@as(usize, 0), refusals);
-    try testing.expectEqual(@as(u32, 0), c.live_streams); // all completed and evicted
-    try testing.expectEqual(@as(usize, 0), c.streams.count());
+    // The first 4 are surfaced; the rest are refused (REFUSED_STREAM) because the
+    // half-closed-remote streams still occupy concurrency slots.
+    try testing.expectEqual(@as(usize, 4), requests);
+    try testing.expectEqual(@as(usize, 6), refusals);
+    try testing.expectEqual(@as(u32, 4), c.live_streams);
 }
 
 test "a request+response cycle returns live_streams to zero" {
@@ -1700,16 +1723,17 @@ test "a request+response cycle returns live_streams to zero" {
     defer w.deinit();
     var hdr: std.ArrayList(u8) = .empty;
     defer hdr.deinit(testing.allocator);
-    // A complete request (END_STREAM): the recv side ends and the stream is
-    // evicted on read-completion, so live_streams is 0 between request and response.
+    // A complete request (END_STREAM): the recv side ends, but the stream lingers
+    // in half_closed_remote and still counts toward concurrency until the local
+    // side finishes the response (RFC 9113 5.1).
     try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
     try handshook(&c, hdr.items);
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(Event.need_data, try c.nextEvent());
-    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(u32, 1), c.live_streams); // still awaiting the response
     // The app responds: register the send, then a body with END_STREAM. Once the
-    // response drains the stream closes and is evicted - back to zero, no leak.
+    // response drains the stream reaches .closed and is evicted - back to zero.
     try w.sendResponse(1, 200, &.{}, false);
     try c.sendStreamData(&w, 1, "hi", true);
     try testing.expectEqual(@as(u32, 0), c.live_streams);
@@ -1771,6 +1795,24 @@ test "late DATA after a response is registered is a stream error STREAM_CLOSED" 
     const ev = try c.nextEvent();
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), ev.rst_stream.error_code);
+}
+
+test "a WINDOW_UPDATE on a half-closed-remote stream awaiting its response is honored" {
+    // The P1 case: a completed request awaiting a response stays addressable - a
+    // WINDOW_UPDATE for it must be applied, not dropped as a forgotten stream.
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    try frameBytes(&frames, .window_update, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x10 });
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+    // The stream is still present, so the WINDOW_UPDATE is surfaced (not dropped).
+    const wu = try c.nextEvent();
+    try testing.expectEqual(@as(u32, 1), wu.window_update.stream_id);
+    try testing.expectEqual(@as(u32, 0x10), wu.window_update.increment);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -46,6 +46,12 @@ pub const Limits = struct {
     /// against the CONTINUATION flood (CVE-2024-27316).
     max_field_block_bytes: usize = 64 * 1024,
     max_continuation_frames: u32 = 16,
+    /// Total streams ever opened on one connection and total resets the peer may
+    /// drive, defending against rapid-reset churn (CVE-2023-44487). Defaults are
+    /// generous multiples of max_concurrent_streams; exceeding either trips
+    /// EnhanceYourCalm (-> GOAWAY).
+    max_streams: u64 = 4096,
+    max_stream_resets: u64 = 256,
 };
 
 /// The error set the H2 engine raises. Mapped to RFC 9113 error codes for the
@@ -87,6 +93,13 @@ pub const Connection = struct {
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     highest_peer_id: u32 = 0,
+    /// O(1) live-stream count (streams in a concurrency-counting state). Kept in
+    /// step with the map: ++ on idle->open insertion, -- on eviction of a closed
+    /// stream. Replaces the old O(map-size) liveStreamCount scan.
+    live_streams: u32 = 0,
+    /// Rapid-reset churn budgets: total streams ever opened and total resets.
+    streams_opened: u64 = 0,
+    stream_resets: u64 = 0,
 
     pending: [PENDING_CAP]Event = undefined,
     pending_len: usize = 0,
@@ -343,7 +356,14 @@ pub const Connection = struct {
         if (@as(i64, self.conn_recv_window) - @as(i64, f.header.length) < 0) return error.FlowControlError;
         self.conn_recv_window -= @intCast(f.header.length);
 
-        const s = self.streams.getPtr(f.header.stream_id) orelse return error.ProtocolError;
+        const s = self.streams.getPtr(f.header.stream_id) orelse {
+            // No live stream: an idle id (never opened) is a connection error;
+            // a closed/evicted id is a stream error STREAM_CLOSED (RFC 9113 5.1,
+            // mirroring stream.classifyRecv's .closed branch).
+            if (self.isIdle(f.header.stream_id)) return error.ProtocolError;
+            self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(ErrorCode.stream_closed) } });
+            return;
+        };
         const classify = s.classifyRecv(.data, end_stream);
         switch (classify.action) {
             .ok => {},
@@ -367,6 +387,7 @@ pub const Connection = struct {
                 return;
             }
             self.push(.{ .end_of_message = .{ .stream_id = f.header.stream_id } });
+            self.maybeEvictDone(f.header.stream_id);
         }
     }
 
@@ -380,6 +401,8 @@ pub const Connection = struct {
             return;
         };
         s.recvApply(.rst_stream, false);
+        self.evictStream(f.header.stream_id);
+        try self.chargeReset();
         self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = code } });
     }
 
@@ -416,8 +439,7 @@ pub const Connection = struct {
             // out of scope). The stream is created here for the response if the
             // send side has not already (the H2 write path opens it on request).
             if (id % 2 == 0) return error.ProtocolError;
-            self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
-            self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+            try self.openStream(id);
         } else {
             // A new request stream. Its id must be odd and exceed the highest peer
             // id (5.1.1: parity + monotonicity).
@@ -426,10 +448,9 @@ pub const Connection = struct {
             // connection-global dynamic table in sync, but refuse the request
             // (RST_STREAM REFUSED_STREAM) and never surface it. No stream record
             // is inserted, so the map cannot grow under a refused-stream flood.
-            refused = self.liveStreamCount() >= self.limits.max_concurrent_streams;
+            refused = self.live_streams >= self.limits.max_concurrent_streams;
             if (!refused) {
-                self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
-                self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+                try self.openStream(id);
             }
             self.highest_peer_id = id;
         }
@@ -485,11 +506,12 @@ pub const Connection = struct {
             // Trailers: a second HEADERS block; must carry END_STREAM (8.1) and
             // must not contain pseudo-headers or otherwise-invalid fields.
             if (!end_stream or !validTrailers(headers)) {
-                self.resetStream(s, id, .protocol_error);
+                try self.resetStream(s, id, .protocol_error);
                 return;
             }
             s.recvApply(.headers, true);
             self.push(.{ .end_of_message = .{ .trailers = headers, .stream_id = id } });
+            self.maybeEvictDone(id);
             return;
         }
 
@@ -497,7 +519,7 @@ pub const Connection = struct {
             // Collapse the response pseudo-header (:status) + regular fields.
             const resp = self.collapseResponse(headers, id) catch |e| switch (e) {
                 error.Malformed => {
-                    self.resetStream(s, id, .protocol_error);
+                    try self.resetStream(s, id, .protocol_error);
                     return;
                 },
                 error.OutOfMemory => return error.MessageTooLong,
@@ -509,7 +531,7 @@ pub const Connection = struct {
             // arrive, so it is malformed and resets the stream.
             if (resp.event.status_code >= 100 and resp.event.status_code < 200) {
                 if (end_stream) {
-                    self.resetStream(s, id, .protocol_error);
+                    try self.resetStream(s, id, .protocol_error);
                     return;
                 }
                 self.push(.{ .response = resp.event });
@@ -521,6 +543,7 @@ pub const Connection = struct {
             if (end_stream) {
                 s.recvApply(.headers, true); // open -> half_closed_remote
                 self.push(.{ .end_of_message = .{ .stream_id = id } });
+                self.maybeEvictDone(id);
             }
             return;
         }
@@ -528,7 +551,7 @@ pub const Connection = struct {
         // Collapse pseudo-headers into the request line + regular headers.
         const req = self.collapseRequest(headers, id) catch |e| switch (e) {
             error.Malformed => {
-                self.resetStream(s, id, .protocol_error);
+                try self.resetStream(s, id, .protocol_error);
                 return;
             },
             error.OutOfMemory => return error.MessageTooLong,
@@ -539,13 +562,16 @@ pub const Connection = struct {
         if (end_stream) {
             s.recvApply(.headers, true); // open -> half_closed_remote
             self.push(.{ .end_of_message = .{ .stream_id = id } });
+            self.maybeEvictDone(id);
         }
     }
 
-    /// Reset a stream for a stream error: emit RST_STREAM and move its state to
-    /// closed so later frames on it are no longer treated as open.
-    fn resetStream(self: *Connection, s: *Stream, id: u32, code: ErrorCode) void {
+    /// Reset a stream for a stream error: emit RST_STREAM, move its state to
+    /// closed, and evict it. A locally-driven reset still counts as churn.
+    fn resetStream(self: *Connection, s: *Stream, id: u32, code: ErrorCode) H2Error!void {
         s.recvApply(.rst_stream, false); // -> closed
+        self.evictStream(id);
+        try self.chargeReset();
         self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = @intFromEnum(code) } });
     }
 
@@ -709,8 +735,12 @@ pub const Connection = struct {
     /// is seeded from the peer's INITIAL_WINDOW_SIZE (what the peer will accept).
     pub fn registerSendStream(self: *Connection, id: u32) error{OutOfMemory}!void {
         if (self.streams.getPtr(id) != null) return;
-        self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.OutOfMemory;
-        self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+        self.openStream(id) catch return error.OutOfMemory;
+        // A server only registers a send to RESPOND to a request whose recv side
+        // already ended (it was evicted on read-completion). Restore that state so
+        // the response drains to eviction (no live_streams leak) and any late peer
+        // DATA is a STREAM_CLOSED stream error, not silently reopened.
+        if (self.role == .server) self.streams.getPtr(id).?.state = .half_closed_remote;
     }
 
     /// Queue outbound body bytes on `id`, emitting as much as the connection and
@@ -768,6 +798,7 @@ pub const Connection = struct {
             try writer.writeDataFrame(id, &.{}, true);
             s.send_end_pending = false;
         }
+        self.maybeEvictDone(id);
     }
 
     /// Whether any stream still has parked outbound bytes (or an owed END_STREAM)
@@ -781,20 +812,56 @@ pub const Connection = struct {
         return false;
     }
 
-    fn liveStreamCount(self: *Connection) u32 {
-        var n: u32 = 0;
-        var it = self.streams.valueIterator();
-        while (it.next()) |s| {
-            if (s.countsTowardConcurrency()) n += 1;
+    /// Insert a stream and move it idle->open. Maintains the live counter and the
+    /// total-streams churn cap (CVE-2023-44487). Every counted insertion goes
+    /// through here so live_streams and streams_opened stay exact.
+    fn openStream(self: *Connection, id: u32) H2Error!void {
+        if (self.limits.max_streams != 0 and self.streams_opened >= self.limits.max_streams) return error.EnhanceYourCalm;
+        self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
+        self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
+        self.streams_opened += 1;
+        self.live_streams += 1;
+    }
+
+    /// Remove a stream from the map, keeping live_streams exact. Safe to call on a
+    /// closed entry: the null path in handleData/handleWindowUpdate/handleRstStream
+    /// classifies an evicted (id <= highest_peer_id) stream as closed, not idle.
+    fn evictStream(self: *Connection, id: u32) void {
+        if (self.streams.fetchRemove(id)) |kv| {
+            var s = kv.value;
+            // Every map entry was counted once in openStream and this is its sole
+            // removal, so the decrement is unconditional - the stream's state is
+            // already .closed here, so countsTowardConcurrency() would wrongly
+            // skip it.
+            self.live_streams -= 1;
+            s.deinit(self.gpa);
         }
-        return n;
+    }
+
+    /// Evict a stream whose receive side has fully ended and which owes no outbound
+    /// send. This is the read-only server's normal completion (the stream sits in
+    /// half_closed_remote, never reaching .closed because the app sent no response)
+    /// as well as the post-response close (.closed). Without it, completed requests
+    /// pin live_streams forever and a long-lived connection refuses every request
+    /// past max_concurrent_streams. A stream still owing a send (the app is
+    /// responding) is retained; if the app responds after the stream was evicted,
+    /// registerSendStream re-opens it for the response.
+    fn maybeEvictDone(self: *Connection, id: u32) void {
+        const s = self.streams.getPtr(id) orelse return;
+        const recv_done = s.state == .half_closed_remote or s.state == .closed;
+        if (recv_done and s.send_pending.items.len == 0 and !s.send_end_pending) self.evictStream(id);
+    }
+
+    /// Charge one stream reset against the churn budget (CVE-2023-44487).
+    fn chargeReset(self: *Connection) H2Error!void {
+        self.stream_resets += 1;
+        if (self.limits.max_stream_resets != 0 and self.stream_resets > self.limits.max_stream_resets) return error.EnhanceYourCalm;
     }
 
     /// Open a stream as if a HEADERS had arrived - used by tests that exercise the
     /// DATA path without driving a full HEADERS block.
     pub fn openStreamForTest(self: *Connection, id: u32) !void {
-        try self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size));
-        self.streams.getPtr(id).?.recvApply(.headers, false);
+        try self.openStream(id);
         if (id > self.highest_peer_id) self.highest_peer_id = id;
     }
 
@@ -1154,7 +1221,7 @@ test "over the concurrency cap, a request is refused not surfaced" {
     try testing.expectEqual(@as(u32, 3), refused.rst_stream.stream_id);
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.refused_stream)), refused.rst_stream.error_code);
     // The refused stream left no record, so only stream 1 is tracked.
-    try testing.expectEqual(@as(u32, 1), c.liveStreamCount());
+    try testing.expectEqual(@as(u32, 1), c.live_streams);
 }
 
 // A client's inbound handshake is just the server's SETTINGS - no preface to
@@ -1456,6 +1523,254 @@ test "an inner-whitespace value is accepted (only edge OWS is rejected)" {
     const req = try c.nextEvent();
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
     try testing.expectEqualStrings("a b", req.request.headers[0].value);
+}
+
+test "rapid open+RST churn keeps the stream map and live counter bounded" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Open-then-RST 100 streams on increasing odd ids. Each pair must leave zero
+    // residue: no map entry, no live count.
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 100) : (k += 1) {
+        try frameBytes(&frames, .headers, Flags.end_headers, id, &GET_BLOCK); // open, no END_STREAM
+        try frameBytes(&frames, .rst_stream, 0, id, &[_]u8{ 0x00, 0x00, 0x00, 0x08 }); // CANCEL
+        id += 2;
+    }
+    try handshook(&c, frames.items);
+    var seen: usize = 0;
+    while (true) {
+        const ev = try c.nextEvent();
+        if (ev == .need_data) break;
+        seen += 1;
+    }
+    try testing.expect(seen >= 100); // at least the 100 rst_stream echoes surfaced
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+}
+
+test "a late WINDOW_UPDATE or RST on an evicted closed stream is tolerated" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Open stream 1, RST it (evicts), then send a stray WINDOW_UPDATE and a stray
+    // RST on the now-evicted id 1 (<= highest_peer_id, so closed not idle).
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK);
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try frameBytes(&frames, .window_update, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x10 });
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try handshook(&c, frames.items);
+    // The opening HEADERS surfaces the request; then the RST echo; then the strays
+    // after eviction are dropped.
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+}
+
+test "DATA on an evicted closed stream is a stream error STREAM_CLOSED" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK); // open
+    try frameBytes(&frames, .rst_stream, 0, 1, &[_]u8{ 0x00, 0x00, 0x00, 0x08 }); // evicts
+    try frameBytes(&frames, .data, Flags.end_stream, 1, "x"); // DATA on the evicted id
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // the opening request
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent())); // the RST echo
+    const stale = try c.nextEvent();
+    try testing.expectEqual(@as(u32, 1), stale.rst_stream.stream_id);
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), stale.rst_stream.error_code);
+}
+
+test "live_streams matches reality across read-completion and reset" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Stream 1: a complete read-only request (END_STREAM, no response owed) is
+    // evicted on completion, so it does NOT pin the concurrency counter.
+    try frameBytes(&frames, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    // Stream 3: open, no END_STREAM -> still receiving -> counts.
+    try frameBytes(&frames, .headers, Flags.end_headers, 3, &GET_BLOCK);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 1 request
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent())); // 1 eom
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 3 request
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    // Stream 1 completed and was evicted; only the still-open stream 3 counts.
+    try testing.expectEqual(@as(u32, 1), c.live_streams);
+    try testing.expectEqual(@as(usize, 1), c.streams.count());
+    // Now RST stream 3: it leaves counting and is evicted, draining the map.
+    var more: std.ArrayList(u8) = .empty;
+    defer more.deinit(testing.allocator);
+    try frameBytes(&more, .rst_stream, 0, 3, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+    try c.feed(more.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "a reset-churn flood trips EnhanceYourCalm" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_stream_resets = 3;
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Four open+RST cycles; the 4th reset exceeds the budget of 3.
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 4) : (k += 1) {
+        try frameBytes(&frames, .headers, Flags.end_headers, id, &GET_BLOCK);
+        try frameBytes(&frames, .rst_stream, 0, id, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
+        id += 2;
+    }
+    try handshook(&c, frames.items);
+    var tripped = false;
+    for (0..64) |_| {
+        const ev = c.nextEvent() catch |e| {
+            try testing.expectEqual(error.EnhanceYourCalm, e);
+            tripped = true;
+            break;
+        };
+        if (ev == .need_data) break;
+    }
+    try testing.expect(tripped);
+}
+
+test "opening more than max_streams trips EnhanceYourCalm" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_streams = 2;
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    // Three opens (no END_STREAM); the 3rd open exceeds the cap of 2.
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &GET_BLOCK);
+    try frameBytes(&frames, .headers, Flags.end_headers, 3, &GET_BLOCK);
+    try frameBytes(&frames, .headers, Flags.end_headers, 5, &GET_BLOCK);
+    try handshook(&c, frames.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // stream 1
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // stream 3
+    try testing.expectError(error.EnhanceYourCalm, c.nextEvent()); // stream 5 over the cap
+}
+
+test "a read-only server serves more than max_concurrent_streams sequential requests" {
+    // Regression for the half-closed leak: a completed request that owes no
+    // response is evicted, so a long-lived connection does not refuse every
+    // request past max_concurrent_streams (default 128).
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 500) : (k += 1) {
+        try frameBytes(&input, .headers, Flags.end_headers | Flags.end_stream, id, &GET_BLOCK);
+        id += 2;
+    }
+    try c.feed(input.items);
+    try testing.expectEqual(std.meta.Tag(Event).settings, std.meta.activeTag(try c.nextEvent()));
+    var requests: usize = 0;
+    var refusals: usize = 0;
+    while (true) {
+        const ev = try c.nextEvent();
+        switch (ev) {
+            .need_data => break,
+            .request => requests += 1,
+            .rst_stream => refusals += 1,
+            else => {},
+        }
+    }
+    try testing.expectEqual(@as(usize, 500), requests);
+    try testing.expectEqual(@as(usize, 0), refusals);
+    try testing.expectEqual(@as(u32, 0), c.live_streams); // all completed and evicted
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "a request+response cycle returns live_streams to zero" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    // A complete request (END_STREAM): the recv side ends and the stream is
+    // evicted on read-completion, so live_streams is 0 between request and response.
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    // The app responds: register the send, then a body with END_STREAM. Once the
+    // response drains the stream closes and is evicted - back to zero, no leak.
+    try w.sendResponse(1, 200, &.{}, false);
+    try c.sendStreamData(&w, 1, "hi", true);
+    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "many request+response cycles do not leak the concurrency budget" {
+    // Regression: a re-created response stream must drain to eviction, or every
+    // cycle leaks one live_streams and the connection refuses requests past 128.
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    try c.feed(input.items);
+    try testing.expectEqual(std.meta.Tag(Event).settings, std.meta.activeTag(try c.nextEvent()));
+    var id: u32 = 1;
+    var k: usize = 0;
+    while (k < 300) : (k += 1) {
+        var hdr: std.ArrayList(u8) = .empty;
+        defer hdr.deinit(testing.allocator);
+        try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, id, &GET_BLOCK);
+        try c.feed(hdr.items);
+        try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+        try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+        try testing.expectEqual(Event.need_data, try c.nextEvent());
+        try w.sendResponse(id, 200, &.{}, false);
+        try c.sendStreamData(&w, id, "ok", true);
+        try testing.expectEqual(@as(u32, 0), c.live_streams); // never accumulates
+        id += 2;
+    }
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+}
+
+test "late DATA after a response is registered is a stream error STREAM_CLOSED" {
+    // The re-created response stream is half_closed_remote, so a peer sending DATA
+    // after its own END_STREAM is rejected, not silently reopened (smuggling guard).
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &GET_BLOCK);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
+    try testing.expectEqual(Event.need_data, try c.nextEvent());
+    try w.sendResponse(1, 200, &.{}, false); // register the response (re-creates stream 1 half_closed_remote)
+    try c.registerSendStream(1);
+    // The peer sends DATA on stream 1 after it already ended: STREAM_CLOSED.
+    var data: std.ArrayList(u8) = .empty;
+    defer data.deinit(testing.allocator);
+    try frameBytes(&data, .data, 0, 1, "evil");
+    try c.feed(data.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), ev.rst_stream.error_code);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -93,11 +93,9 @@ pub const Connection = struct {
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     highest_peer_id: u32 = 0,
-    /// O(1) live-stream count (streams in a concurrency-counting state). Kept in
-    /// step with the map: ++ on idle->open insertion, -- on eviction of a closed
-    /// stream. Replaces the old O(map-size) liveStreamCount scan.
-    live_streams: u32 = 0,
     /// Rapid-reset churn budgets: total streams ever opened and total resets.
+    /// These count streams that no longer exist (evicted), so unlike the live
+    /// concurrency count they are real state, not derivable from the map.
     streams_opened: u64 = 0,
     stream_resets: u64 = 0,
 
@@ -452,7 +450,7 @@ pub const Connection = struct {
             // connection-global dynamic table in sync, but refuse the request
             // (RST_STREAM REFUSED_STREAM) and never surface it. No stream record
             // is inserted, so the map cannot grow under a refused-stream flood.
-            refused = self.live_streams >= self.limits.max_concurrent_streams;
+            refused = self.liveStreamCount() >= self.limits.max_concurrent_streams;
             if (!refused) {
                 try self.openPeerStream(id);
             }
@@ -763,7 +761,7 @@ pub const Connection = struct {
         while (it.next()) |e| {
             try self.flushStreamPtr(writer, e.value_ptr);
             const st = e.value_ptr;
-            if (st.state == .closed and st.send_pending.items.len == 0 and !st.send_end_pending) {
+            if (st.isFullyClosed()) {
                 self.evict_scratch.append(self.gpa, e.key_ptr.*) catch return error.OutOfMemory;
             }
         }
@@ -795,7 +793,7 @@ pub const Connection = struct {
             off += chunk;
             if (end) {
                 s.send_end_pending = false;
-                s.sendEndStream();
+                s.sendApply(true);
             }
         }
         // Drop the bytes we emitted; keep what the window could not admit.
@@ -809,7 +807,7 @@ pub const Connection = struct {
         if (s.send_pending.items.len == 0 and s.send_end_pending) {
             try writer.writeDataFrame(id, &.{}, true);
             s.send_end_pending = false;
-            s.sendEndStream();
+            s.sendApply(true);
         }
     }
 
@@ -827,15 +825,14 @@ pub const Connection = struct {
     /// Insert a stream and move it idle->open. Maintains the live counter and the
     /// total-streams churn cap (CVE-2023-44487). Every counted insertion goes
     /// through here so live_streams and streams_opened stay exact.
-    /// Insert a stream and move it idle->open, keeping the live counter exact.
-    /// The single insertion point; the trusted send path and the peer-driven read
-    /// path both route through it. The total-streams churn cap is enforced only on
-    /// the peer path (openPeerStream), never here - the local app is not the
-    /// adversary, so a client/server opening many streams to send is not abuse.
+    /// Insert a stream and move it idle->open. The single insertion point; the
+    /// trusted send path and the peer-driven read path both route through it. The
+    /// total-streams churn cap is enforced only on the peer path (openPeerStream),
+    /// never here - the local app is not the adversary, so a client/server opening
+    /// many streams to send is not abuse.
     fn openStream(self: *Connection, id: u32) H2Error!void {
         self.streams.put(self.gpa, id, Stream.init(id, self.local_settings.initial_window_size, self.peer_settings.initial_window_size)) catch return error.MessageTooLong;
         self.streams.getPtr(id).?.recvApply(.headers, false); // idle -> open
-        self.live_streams += 1;
     }
 
     /// Open a PEER-initiated stream, enforcing the total-streams churn cap
@@ -846,19 +843,27 @@ pub const Connection = struct {
         self.streams_opened += 1;
     }
 
-    /// Remove a stream from the map, keeping live_streams exact. Safe to call on a
-    /// closed entry: the null path in handleData/handleWindowUpdate/handleRstStream
-    /// classifies an evicted (id <= highest_peer_id) stream as closed, not idle.
+    /// Remove a stream from the map. Safe to call on a closed entry: the null path
+    /// in handleData/handleWindowUpdate/handleRstStream classifies an evicted
+    /// (id <= highest_peer_id) stream as closed, not idle.
     fn evictStream(self: *Connection, id: u32) void {
         if (self.streams.fetchRemove(id)) |kv| {
             var s = kv.value;
-            // Every map entry was counted once in openStream and this is its sole
-            // removal, so the decrement is unconditional - the stream's state is
-            // already .closed here, so countsTowardConcurrency() would wrongly
-            // skip it.
-            self.live_streams -= 1;
             s.deinit(self.gpa);
         }
+    }
+
+    /// Streams currently counting toward MAX_CONCURRENT_STREAMS (open or
+    /// half-closed). Derived from the map rather than cached: the map is bounded by
+    /// max_concurrent_streams plus a few in-flight, so the scan is cheap and there
+    /// is no counter to drift out of sync.
+    fn liveStreamCount(self: *Connection) u32 {
+        var n: u32 = 0;
+        var it = self.streams.valueIterator();
+        while (it.next()) |s| {
+            if (s.countsTowardConcurrency()) n += 1;
+        }
+        return n;
     }
 
     /// Evict a stream that has reached the fully-closed terminal state with no
@@ -869,7 +874,7 @@ pub const Connection = struct {
     /// finish comes from max_concurrent_streams and the churn caps, not eviction.
     fn maybeEvictDone(self: *Connection, id: u32) void {
         const s = self.streams.getPtr(id) orelse return;
-        if (s.state == .closed and s.send_pending.items.len == 0 and !s.send_end_pending) self.evictStream(id);
+        if (s.isFullyClosed()) self.evictStream(id);
     }
 
     /// Charge one stream reset against the churn budget (CVE-2023-44487).
@@ -1241,7 +1246,7 @@ test "over the concurrency cap, a request is refused not surfaced" {
     try testing.expectEqual(@as(u32, 3), refused.rst_stream.stream_id);
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.refused_stream)), refused.rst_stream.error_code);
     // The refused stream left no record, so only stream 1 is tracked.
-    try testing.expectEqual(@as(u32, 1), c.live_streams);
+    try testing.expectEqual(@as(u32, 1), c.liveStreamCount());
 }
 
 // A client's inbound handshake is just the server's SETTINGS - no preface to
@@ -1568,7 +1573,7 @@ test "rapid open+RST churn keeps the stream map and live counter bounded" {
     }
     try testing.expect(seen >= 100); // at least the 100 rst_stream echoes surfaced
     try testing.expectEqual(@as(usize, 0), c.streams.count());
-    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(u32, 0), c.liveStreamCount());
 }
 
 test "a late WINDOW_UPDATE or RST on an evicted closed stream is tolerated" {
@@ -1588,7 +1593,7 @@ test "a late WINDOW_UPDATE or RST on an evicted closed stream is tolerated" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(Event.need_data, try c.nextEvent());
-    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(u32, 0), c.liveStreamCount());
 }
 
 test "DATA on an evicted closed stream is a stream error STREAM_CLOSED" {
@@ -1607,7 +1612,7 @@ test "DATA on an evicted closed stream is a stream error STREAM_CLOSED" {
     try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.stream_closed)), stale.rst_stream.error_code);
 }
 
-test "live_streams matches reality across read-completion and reset" {
+test "the live-stream count matches reality across read-completion and reset" {
     var c = Connection.init(testing.allocator, .server);
     defer c.deinit();
     var frames: std.ArrayList(u8) = .empty;
@@ -1623,7 +1628,7 @@ test "live_streams matches reality across read-completion and reset" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent())); // 3 request
     try testing.expectEqual(Event.need_data, try c.nextEvent());
     // Both count: stream 1 (half_closed_remote, awaiting response) and stream 3 (open).
-    try testing.expectEqual(@as(u32, 2), c.live_streams);
+    try testing.expectEqual(@as(u32, 2), c.liveStreamCount());
     try testing.expectEqual(@as(usize, 2), c.streams.count());
     // Now RST stream 3: it is evicted; stream 1 still lingers awaiting its response.
     var more: std.ArrayList(u8) = .empty;
@@ -1631,7 +1636,7 @@ test "live_streams matches reality across read-completion and reset" {
     try frameBytes(&more, .rst_stream, 0, 3, &[_]u8{ 0x00, 0x00, 0x00, 0x08 });
     try c.feed(more.items);
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
-    try testing.expectEqual(@as(u32, 1), c.live_streams);
+    try testing.expectEqual(@as(u32, 1), c.liveStreamCount());
     try testing.expectEqual(@as(usize, 1), c.streams.count());
 }
 
@@ -1713,10 +1718,10 @@ test "half-closed-remote requests count toward concurrency until the response fi
     // half-closed-remote streams still occupy concurrency slots.
     try testing.expectEqual(@as(usize, 4), requests);
     try testing.expectEqual(@as(usize, 6), refusals);
-    try testing.expectEqual(@as(u32, 4), c.live_streams);
+    try testing.expectEqual(@as(u32, 4), c.liveStreamCount());
 }
 
-test "a request+response cycle returns live_streams to zero" {
+test "a request+response cycle returns the live-stream count to zero" {
     var c = Connection.init(testing.allocator, .server);
     defer c.deinit();
     var w = writer_mod.Writer.init(testing.allocator, .server);
@@ -1731,12 +1736,12 @@ test "a request+response cycle returns live_streams to zero" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(std.meta.Tag(Event).end_of_message, std.meta.activeTag(try c.nextEvent()));
     try testing.expectEqual(Event.need_data, try c.nextEvent());
-    try testing.expectEqual(@as(u32, 1), c.live_streams); // still awaiting the response
+    try testing.expectEqual(@as(u32, 1), c.liveStreamCount()); // still awaiting the response
     // The app responds: register the send, then a body with END_STREAM. Once the
     // response drains the stream reaches .closed and is evicted - back to zero.
     try w.sendResponse(1, 200, &.{}, false);
     try c.sendStreamData(&w, 1, "hi", true);
-    try testing.expectEqual(@as(u32, 0), c.live_streams);
+    try testing.expectEqual(@as(u32, 0), c.liveStreamCount());
     try testing.expectEqual(@as(usize, 0), c.streams.count());
 }
 
@@ -1765,7 +1770,7 @@ test "many request+response cycles do not leak the concurrency budget" {
         try testing.expectEqual(Event.need_data, try c.nextEvent());
         try w.sendResponse(id, 200, &.{}, false);
         try c.sendStreamData(&w, id, "ok", true);
-        try testing.expectEqual(@as(u32, 0), c.live_streams); // never accumulates
+        try testing.expectEqual(@as(u32, 0), c.liveStreamCount()); // never accumulates
         id += 2;
     }
     try testing.expectEqual(@as(usize, 0), c.streams.count());

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -841,12 +841,19 @@ fn isValidFieldName(name: []const u8) bool {
     return true;
 }
 
-/// A legal field-value byte (RFC 9113 8.2.1): no CR/LF/NUL or other control, no
-/// DEL; obs-text (0x80-0xFF) and inner SP/HTAB are allowed. The same rule the H1
-/// path and the H2 write path enforce, so a re-serialized request cannot split.
+/// A legal field value (RFC 9113 8.2.1): no CR/LF/NUL or other control and no
+/// DEL (obs-text 0x80-0xFF and inner SP/HTAB are allowed), and no leading or
+/// trailing whitespace. The same rule the H2 write path enforces, so a value the
+/// read side accepts the write side can re-serialize without splitting or being
+/// silently re-trimmed by a peer.
 fn validValue(value: []const u8) bool {
     for (value) |ch| {
         if (!tables.is_field_vchar[ch]) return false;
+    }
+    if (value.len > 0) {
+        const first = value[0];
+        const last = value[value.len - 1];
+        if (first == ' ' or first == '\t' or last == ' ' or last == '\t') return false;
     }
     return true;
 }
@@ -1409,6 +1416,46 @@ test "an obs-text value (0x80-0xFF) is accepted" {
     try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
     try testing.expectEqualStrings("x-obs", req.request.headers[0].name);
     try testing.expectEqualStrings(&[_]u8{ 0x80, 0xFF }, req.request.headers[0].value);
+}
+
+test "a trailing-whitespace value resets the stream (RFC 9113 8.2.1)" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, then literal "x-test: val " (trailing SP).
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-test".* ++ [_]u8{ 0x04, 'v', 'a', 'l', ' ' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
+}
+
+test "a leading-whitespace value resets the stream (RFC 9113 8.2.1)" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // literal "x-test: \tval" (leading HTAB).
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x06 } ++ "x-test".* ++ [_]u8{ 0x04, 0x09, 'v', 'a', 'l' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "an inner-whitespace value is accepted (only edge OWS is rejected)" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // literal "x-test: a b" - an inner SP is legal (e.g. media-type parameters).
+    const block = GET_BLOCK ++ [_]u8{ 0x00, 0x06 } ++ "x-test".* ++ [_]u8{ 0x03, 'a', ' ', 'b' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    const req = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(req));
+    try testing.expectEqualStrings("a b", req.request.headers[0].value);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -142,14 +142,23 @@ pub const Stream = struct {
         };
     }
 
-    /// Apply the local side sending END_STREAM (the send-side mirror of
-    /// halfCloseRemote): open -> half_closed_local, half_closed_remote -> closed.
-    pub fn sendEndStream(self: *Stream) void {
-        self.state = switch (self.state) {
+    /// Apply the local side sending a frame, mirroring recvApply for the send
+    /// direction. END_STREAM half-closes locally: open -> half_closed_local,
+    /// half_closed_remote -> closed.
+    pub fn sendApply(self: *Stream, end_stream: bool) void {
+        if (end_stream) self.state = switch (self.state) {
             .open => .half_closed_local,
             .half_closed_remote => .closed,
             else => self.state,
         };
+    }
+
+    /// Whether the stream has reached the fully-closed terminal state with no
+    /// outbound send still owed - i.e. it can be evicted from the connection map.
+    /// A half_closed_* stream is NOT done: it still counts toward concurrency and
+    /// stays addressable until both directions finish.
+    pub fn isFullyClosed(self: *const Stream) bool {
+        return self.state == .closed and self.send_pending.items.len == 0 and !self.send_end_pending;
     }
 
     /// Account for inbound DATA against the receive window. Returns a transition:

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -142,6 +142,16 @@ pub const Stream = struct {
         };
     }
 
+    /// Apply the local side sending END_STREAM (the send-side mirror of
+    /// halfCloseRemote): open -> half_closed_local, half_closed_remote -> closed.
+    pub fn sendEndStream(self: *Stream) void {
+        self.state = switch (self.state) {
+            .open => .half_closed_local,
+            .half_closed_remote => .closed,
+            else => self.state,
+        };
+    }
+
     /// Account for inbound DATA against the receive window. Returns a transition:
     /// a window overrun is a connection FLOW_CONTROL_ERROR. `len` is the full
     /// frame payload length (including padding), which is what counts against the


### PR DESCRIPTION
Replaces #39 (which became conflicting after #38 was squash-merged into main; GitHub does not allow repointing a PR's head branch, so this is a fresh PR from a clean branch with the same change).

The connection never removed a stream from its map: RST_STREAM moved a stream to closed but never removed it, and a completed request lingered in half_closed_remote. A peer could open-then-reset streams (HTTP/2 Rapid Reset, CVE-2023-44487) to grow per-connection memory without bound, and a long-lived connection would refuse every request past `max_concurrent_streams` once enough streams had completed.

Evict a stream once it reaches a terminal state with no outbound send owed: on RST receipt, on a stream-error reset, and on read-completion. Replace the O(n) live-stream scan with an O(1) counter. A server registering a response re-creates the stream in half_closed_remote, so the response drains to eviction and late peer DATA is a STREAM_CLOSED stream error rather than silently reopening the receive side. Add `max_streams`/`max_stream_resets` caps that trip `EnhanceYourCalm`, and fix DATA on an evicted closed stream to be a stream error rather than a connection error.

An adversarial review pass caught a half-closed accounting leak and a response-cycle leak that are fixed and regression-tested here (a request+response cycle returns the concurrency counter to zero; 500 sequential read-only requests all surface). Benchmark: ~3-5% on the H2 read path from the per-request eviction bookkeeping; H1 is unchanged.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.