### PR TITLE
Surface allocation failures from the HTTP/2 and upgrade paths to Python

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -121,8 +121,8 @@ const H2Engine = struct {
 
     /// Drain parked DATA that a freshly-parsed WINDOW_UPDATE / SETTINGS credit now
     /// permits. Called from next_event after such an event is produced.
-    fn flushSendable(self: *H2Engine) void {
-        self.conn.flushSendable(self.writer) catch {};
+    fn flushSendable(self: *H2Engine) core.h2.writer.WriteError!void {
+        try self.conn.flushSendable(self.writer);
     }
 
     fn deinit(self: *H2Engine) void {
@@ -461,7 +461,8 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             // A parsed WINDOW_UPDATE / SETTINGS may have credited a send window;
             // drain any DATA that was parked waiting for it. The bytes land in the
             // writer's buffer for the next data_to_send.
-            if (ev == .window_update or ev == .settings) e.flushSendable();
+            if (ev == .window_update or ev == .settings)
+                e.flushSendable() catch |err| return h2RaiseWrite(err);
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {
@@ -470,7 +471,10 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
                 e.rememberMethod(ev.request.method);
                 e.should_close = e.reader.shouldClose();
                 py.xdecref(e.upgrade_obj);
-                e.upgrade_obj = if (e.reader.upgrade()) |u| py.fromBytes(u) else null;
+                if (e.reader.upgrade()) |u| {
+                    e.upgrade_obj = py.fromBytes(u);
+                    if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
+                } else e.upgrade_obj = null;
             }
             return events_obj.fromH1Event(ev);
         },


### PR DESCRIPTION
Replaces #40 (rebuilt off main as an independent PR after the stacked series was broken by #38's squash-merge).

Two error paths in the Python C-API binding swallowed an out-of-memory condition instead of raising it. `next_event` built the H1 Upgrade bytes without checking the result, so an allocation failure there left a `MemoryError` pending while still returning a valid `Request` (a C-API contract violation) and silently dropped the Upgrade value. The H2 `flushSendable` wrapper discarded the error from draining parked DATA after a WINDOW_UPDATE or SETTINGS.

Propagate both: return null to raise the pending `MemoryError` when the Upgrade bytes fail, and map the flush error through `h2RaiseWrite`. Independent of #42 (touches only `connection_obj.zig`).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.