### PR TITLE
Restore the fuzz build and extend it to the HTTP/2 engine

### DIFF
--- a/fuzz/harness.py
+++ b/fuzz/harness.py
@@ -58,3 +58,31 @@ def consume(data: bytes) -> None:
         _drive(role, chunks)
     except ALLOWED:
         return
+
+
+# A valid client preface + empty SETTINGS frame: enough to push the mutated tail
+# past the handshake and into the connection/HPACK/frame/stream state machine.
+H2_PREAMBLE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+H2_PREFIX = H2_PREAMBLE + b"\x00\x00\x00\x04\x00\x00\x00\x00\x00"
+
+
+def _drive_h2(role: int, chunks: list[bytes]) -> None:
+    conn = zttp.Connection(role, protocol=zttp.HTTP2)
+    # A client has no inbound preface; only a server consumes it.
+    conn.receive_data(H2_PREFIX if role == zttp.SERVER else H2_PREFIX[len(H2_PREAMBLE) :])
+    for chunk in chunks:
+        conn.receive_data(chunk)
+        while True:
+            event = conn.next_event()
+            if event is zttp.NEED_DATA or event is zttp.CONNECTION_CLOSED:
+                break
+
+
+def consume_h2(data: bytes) -> None:
+    """H2 fuzz iteration: drive the HTTP/2 engine. Raises only on a real bug."""
+    role = ROLES[data[0] & 1] if data else zttp.SERVER
+    chunks = _split(data[1:] if data else data)
+    try:
+        _drive_h2(role, chunks)
+    except ALLOWED:
+        return

--- a/fuzz/run.py
+++ b/fuzz/run.py
@@ -37,13 +37,16 @@ SEEDS = (
     b"\r\n\n: \r\n\x00\xff",
 )
 
-# H2 wire fragments: preface + empty SETTINGS, then a HEADERS frame whose HPACK
-# block is fully indexed (:method GET, :scheme http, :path /) with END_HEADERS.
+# Post-handshake H2 frames only: consume_h2 already prepends the preface + empty
+# SETTINGS, so seeding the handshake here would make the parser treat the second
+# preface as a frame header and bail before reaching these frames. HEADERS with a
+# fully-indexed HPACK block (:method GET, :scheme http, :path /, END_HEADERS), a
+# DATA frame, a RST_STREAM, and a WINDOW_UPDATE - all on stream 1.
 H2_SEEDS = (
-    b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
-    b"\x00\x00\x00\x04\x00\x00\x00\x00\x00",
-    b"\x00\x00\x03\x01\x05\x00\x00\x00\x01\x82\x86\x84",
+    b"\x00\x00\x03\x01\x04\x00\x00\x00\x01\x82\x86\x84",
+    b"\x00\x00\x05\x00\x01\x00\x00\x00\x01hello",
     b"\x00\x00\x04\x03\x00\x00\x00\x00\x01\x00\x00\x00\x08",
+    b"\x00\x00\x04\x08\x00\x00\x00\x00\x01\x00\x00\x00\x10",
 )
 
 ORACLES: tuple[Callable[[bytes], None], ...] = (consume, consume_h2, roundtrip)

--- a/fuzz/run.py
+++ b/fuzz/run.py
@@ -21,7 +21,7 @@ import traceback
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
-from fuzz.harness import consume
+from fuzz.harness import consume, consume_h2
 from fuzz.roundtrip import roundtrip
 
 CORPUS = Path(__file__).parent / "corpus"
@@ -37,7 +37,16 @@ SEEDS = (
     b"\r\n\n: \r\n\x00\xff",
 )
 
-ORACLES: tuple[Callable[[bytes], None], ...] = (consume, roundtrip)
+# H2 wire fragments: preface + empty SETTINGS, then a HEADERS frame whose HPACK
+# block is fully indexed (:method GET, :scheme http, :path /) with END_HEADERS.
+H2_SEEDS = (
+    b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+    b"\x00\x00\x00\x04\x00\x00\x00\x00\x00",
+    b"\x00\x00\x03\x01\x05\x00\x00\x00\x01\x82\x86\x84",
+    b"\x00\x00\x04\x03\x00\x00\x00\x00\x01\x00\x00\x00\x08",
+)
+
+ORACLES: tuple[Callable[[bytes], None], ...] = (consume, consume_h2, roundtrip)
 
 
 def _mutate(rng: random.Random, sample: bytes) -> bytes:
@@ -64,9 +73,11 @@ def _mutate(rng: random.Random, sample: bytes) -> bytes:
 def _inputs(rng: random.Random, runs: int) -> Iterator[bytes]:
     for _ in range(runs):
         roll = rng.random()
-        if roll < 0.5:
+        if roll < 0.4:
             yield _mutate(rng, rng.choice(SEEDS))
-        elif roll < 0.75:
+        elif roll < 0.65:
+            yield _mutate(rng, b"".join(H2_SEEDS) + rng.randbytes(rng.randint(0, 32)))
+        elif roll < 0.8:
             yield rng.randbytes(rng.randint(0, 256))
         else:
             yield _mutate(rng, b"".join(rng.sample(SEEDS, rng.randint(1, 3))))

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -10,8 +10,11 @@
 const std = @import("std");
 const core = @import("core");
 
-const Reader = core.reader.Reader;
-const Role = core.reader.Role;
+const Reader = core.h1.reader.Reader;
+const Role = core.h1.reader.Role;
+const H2Connection = core.h2.connection.Connection;
+const h2_constants = core.h2.constants;
+const H2Role = core.h2.connection.Role;
 
 fn drive(input: []const u8) void {
     inline for (.{ Role.server, Role.client }) |role| {
@@ -37,6 +40,40 @@ fn drive(input: []const u8) void {
     }
 }
 
+// The connection orchestrator (and the HPACK/frame/stream parsers it drives) is
+// the H2 surface with the least automated assurance; prepending a valid
+// preface+SETTINGS gets the mutated tail past the handshake into that machine.
+fn driveH2(input: []const u8) void {
+    inline for (.{ H2Role.server, H2Role.client }) |role| {
+        var conn = H2Connection.init(std.heap.c_allocator, role);
+        defer conn.deinit();
+        conn.limits.max_buffer = 1 << 20;
+        if (role == .server) conn.feed(h2_constants.CLIENT_PREFACE) catch return;
+        // An empty SETTINGS frame: 9-byte header, type=0x04, no payload.
+        conn.feed(&[_]u8{ 0, 0, 0, 0x04, 0, 0, 0, 0, 0 }) catch return;
+        const split = if (input.len == 0) 0 else input[0] % @as(u8, @intCast(@min(input.len, 255)));
+        const feeds = [_][]const u8{ input[0..split], input[split..], "" };
+        outer: for (feeds) |chunk| {
+            conn.feed(chunk) catch break;
+            for (0..input.len + 4) |_| {
+                const ev = conn.nextEvent() catch continue :outer;
+                switch (ev) {
+                    .need_data => break,
+                    else => {},
+                }
+            }
+        }
+    }
+}
+
 export fn zttp_fuzz_drive(data: [*]const u8, size: usize) callconv(.c) void {
-    drive(data[0..size]);
+    const input = data[0..size];
+    // First byte selects the parser so one corpus exercises both H1 and H2; the
+    // rest is the mutated body. No build wiring changes: `.fuzz` already
+    // instruments the whole `core` import, H2 included.
+    if (input.len != 0 and input[0] & 1 == 1) {
+        driveH2(input[1..]);
+    } else {
+        drive(if (input.len == 0) input else input[1..]);
+    }
 }

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -1458,6 +1458,43 @@ test "an inner-whitespace value is accepted (only edge OWS is rejected)" {
     try testing.expectEqualStrings("a b", req.request.headers[0].value);
 }
 
+test "fuzz: H2 connection never panics on adversarial frame streams" {
+    const seeds = [_][]const u8{
+        &[_]u8{ 0x00, 0x00, 0x03, 0x01, 0x05, 0x00, 0x00, 0x00, 0x01, 0x82, 0x86, 0x84 }, // HEADERS GET
+        &[_]u8{ 0x00, 0x00, 0x04, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08 }, // RST_STREAM
+        &([_]u8{ 0x00, 0x00, 0x08, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00 } ++ [_]u8{0} ** 8), // PING
+        &[_]u8{ 0x00, 0x00, 0x05, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 'h', 'e', 'l', 'l', 'o' }, // DATA END_STREAM
+        &[_]u8{ 0xff, 0xff, 0xff, 0x01, 0x04, 0x00, 0x00, 0x00, 0x01 }, // over-long HEADERS length
+        &[_]u8{ 0x00, 0x00, 0x04, 0x08, 0x00, 0x00, 0x00, 0x00, 0x01, 0x7f, 0xff, 0xff, 0xff }, // WINDOW_UPDATE
+    };
+    var rng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const r = rng.random();
+    var k: usize = 0;
+    while (k < 2000) : (k += 1) {
+        var input: std.ArrayList(u8) = .empty;
+        defer input.deinit(testing.allocator);
+        try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+        try frameBytes(&input, .settings, 0, 0, &.{});
+        const n = r.intRangeAtMost(usize, 1, 6);
+        var j: usize = 0;
+        while (j < n) : (j += 1) {
+            const seed = try testing.allocator.dupe(u8, seeds[r.intRangeLessThan(usize, 0, seeds.len)]);
+            defer testing.allocator.free(seed);
+            if (seed.len != 0 and r.boolean()) seed[r.intRangeLessThan(usize, 0, seed.len)] = r.int(u8);
+            try input.appendSlice(testing.allocator, seed);
+        }
+        var c = Connection.init(testing.allocator, .server);
+        defer c.deinit();
+        c.limits.max_buffer = 1 << 20;
+        c.feed(input.items) catch continue;
+        var iter: usize = 0;
+        while (iter < input.items.len + 16) : (iter += 1) {
+            const ev = c.nextEvent() catch break;
+            if (ev == .need_data) break;
+        }
+    }
+}
+
 fn driveConnection(input: []const u8) void {
     var c = Connection.init(testing.allocator, .server);
     defer c.deinit();


### PR DESCRIPTION
Replaces #41 (rebuilt off main as an independent PR after the stacked series was broken by #38's squash-merge).

The libFuzzer/OSS-Fuzz target still imported `core.reader`, which moved to `core.h1.reader` in the h1/ package reorg, so `zig build fuzz-obj` failed and the only ASan/UBSan oracle was dead. Fix the import.

The HTTP/2 core (connection orchestrator, HPACK, frame, stream) was reached by hostile bytes through the binding but exercised by no fuzzer. Add an H2 drive to the libFuzzer target (selected by a leading input byte, so one corpus covers both protocols with no build wiring change) and a `consume_h2` oracle plus H2 seeds to the random/Atheris runner. Add an in-source property test that drives the connection on randomized adversarial frame streams under `zig build test`.

Independent of #42/#43 - the only shared file is a new test appended to connection.zig.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.