### PR TITLE
Expose HTTP/2 stream.reset() and connection.close()

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -737,6 +737,19 @@ pub const Connection = struct {
         self.openStream(id) catch return error.OutOfMemory;
     }
 
+    /// Account for a locally-initiated RST_STREAM: the stream is terminally closed,
+    /// so drop it from the map (the caller serializes the RST_STREAM frame itself).
+    /// A no-op on an unknown id.
+    pub fn localReset(self: *Connection, id: u32) void {
+        self.evictStream(id);
+    }
+
+    /// The highest peer-initiated stream id seen so far - the natural last-stream-id
+    /// for a GOAWAY (everything above it was never processed).
+    pub fn lastPeerStreamId(self: *const Connection) u32 {
+        return self.highest_peer_id;
+    }
+
     /// Queue outbound body bytes on `id`, emitting as much as the connection and
     /// stream send windows (and the peer's max frame) allow, parking the rest.
     pub fn sendStreamData(self: *Connection, writer: *writer_mod.Writer, id: u32, data: []const u8, end_stream: bool) writer_mod.WriteError!void {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -93,6 +93,11 @@ pub const Connection = struct {
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     highest_peer_id: u32 = 0,
+    /// High-water of the client's own (odd) stream ids it has opened to send. Lets
+    /// the client read path tell a response for a still-live stream from a stray
+    /// response for a stream it already reset/closed (the client analogue of
+    /// highest_peer_id, which only tracks peer-initiated ids).
+    highest_local_id: u32 = 0,
     /// Rapid-reset churn budgets: total streams ever opened and total resets.
     /// These count streams that no longer exist (evicted), so unlike the live
     /// concurrency count they are real state, not derivable from the map.
@@ -117,6 +122,7 @@ pub const Connection = struct {
     fb_end_stream: bool = false, // END_STREAM carried by the opening HEADERS
     fb_is_trailer: bool = false, // a second HEADERS block on an open stream
     fb_refused: bool = false, // over the concurrency cap: decode for HPACK sync, then discard
+    fb_ignored: bool = false, // a response for a client stream we already reset: decode for HPACK sync, surface nothing
     fb_buf: std.ArrayList(u8) = .empty, // accumulated fragment bytes
     fb_frames: u32 = 0, // CONTINUATION frame count (flood guard)
     /// Storage for a collapsed request/response: the regular header list and a
@@ -342,8 +348,13 @@ pub const Connection = struct {
 
     /// Is `id` a peer-initiated stream that has never been opened (idle)? An id
     /// above the highest one we have seen open is idle; at/below is closed.
+    /// Is `id` a stream that has never been opened (idle)? An id is idle only if it
+    /// is above BOTH high-water marks: peer-initiated streams (highest_peer_id) and
+    /// the client's own opened streams (highest_local_id). An id at/below either is
+    /// a stream that was opened and is now closed/evicted - stray frames on it are
+    /// tolerated, not a connection error.
     fn isIdle(self: *const Connection, id: u32) bool {
-        return id > self.highest_peer_id;
+        return id > self.highest_peer_id and id > self.highest_local_id;
     }
 
     fn handleData(self: *Connection, f: frame_mod.Frame) H2Error!void {
@@ -421,6 +432,7 @@ pub const Connection = struct {
         const existing = self.streams.getPtr(id);
         var is_trailer = false;
         var refused = false;
+        var ignored = false;
         if (existing) |s| {
             // A second HEADERS block is a trailer ONLY while the stream is still
             // open (body not yet ended). A HEADERS after the peer's END_STREAM
@@ -438,10 +450,17 @@ pub const Connection = struct {
         } else if (self.role == .client) {
             // A client reads HEADERS as a response on a stream IT opened: the id
             // must be odd (client-initiated, 5.1.1) and not server-pushed (push is
-            // out of scope). The stream is created here for the response if the
-            // send side has not already (the H2 write path opens it on request).
+            // out of scope). An id at/below the local high-water that is no longer
+            // in the map is one we already reset/closed; decode the block to keep
+            // the HPACK table in sync but surface nothing. A genuinely new id has
+            // its stream created here for the response (the H2 write path opens it
+            // on request).
             if (id % 2 == 0) return error.ProtocolError;
-            try self.openPeerStream(id);
+            if (id <= self.highest_local_id) {
+                ignored = true;
+            } else {
+                try self.openPeerStream(id);
+            }
         } else {
             // A new request stream. Its id must be odd and exceed the highest peer
             // id (5.1.1: parity + monotonicity).
@@ -461,6 +480,7 @@ pub const Connection = struct {
         self.fb_end_stream = Flags.has(f.header.flags, Flags.end_stream);
         self.fb_is_trailer = is_trailer;
         self.fb_refused = refused;
+        self.fb_ignored = ignored;
         self.fb_frames = 0;
         self.fb_buf.clearRetainingCapacity();
         self.fb_buf.appendSlice(self.gpa, fragment) catch return error.MessageTooLong;
@@ -486,6 +506,7 @@ pub const Connection = struct {
         const end_stream = self.fb_end_stream;
         const is_trailer = self.fb_is_trailer;
         const refused = self.fb_refused;
+        const ignored = self.fb_ignored;
         self.fb_stream = null; // block closed
 
         // Always decode (even when refused/malformed) to keep the dynamic table
@@ -495,6 +516,13 @@ pub const Connection = struct {
             error.MessageTooLong => return error.MessageTooLong,
             error.OutOfMemory => return error.MessageTooLong,
         };
+
+        if (ignored) {
+            // A response for a client stream we already reset: the block was decoded
+            // to keep the HPACK table in sync, but the stream is gone - surface
+            // nothing (we already sent RST_STREAM for it).
+            return;
+        }
 
         if (refused) {
             // Decoded for HPACK sync; the request is not surfaced and no stream
@@ -733,6 +761,7 @@ pub const Connection = struct {
     /// stream by sending; the read side has no entry until then. The send window
     /// is seeded from the peer's INITIAL_WINDOW_SIZE (what the peer will accept).
     pub fn registerSendStream(self: *Connection, id: u32) error{OutOfMemory}!void {
+        if (id > self.highest_local_id) self.highest_local_id = id;
         if (self.streams.getPtr(id) != null) return;
         self.openStream(id) catch return error.OutOfMemory;
     }
@@ -1332,6 +1361,31 @@ test "a request pseudo-header in a response resets the stream" {
     try clientHandshook(&c, frames.items);
     const ev = try c.nextEvent();
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+}
+
+test "a response for a client-reset stream is ignored, not surfaced or re-opened" {
+    var c = Connection.init(testing.allocator, .client);
+    defer c.deinit();
+    // The client opens stream 1 to send, then resets it locally.
+    try c.registerSendStream(1);
+    c.localReset(1);
+    try testing.expectEqual(@as(usize, 0), c.streams.count());
+    // An in-flight response head + body for stream 1 then arrives. The head is
+    // decoded (HPACK sync) but surfaces nothing, and the stray DATA is a tolerated
+    // stream error - never a Response/Data event or a re-opened stream.
+    var frames: std.ArrayList(u8) = .empty;
+    defer frames.deinit(testing.allocator);
+    try frameBytes(&frames, .headers, Flags.end_headers, 1, &STATUS_200_BLOCK);
+    try frameBytes(&frames, .data, Flags.end_stream, 1, "hi");
+    try clientHandshook(&c, frames.items);
+    while (true) {
+        const ev = try c.nextEvent();
+        if (ev == .need_data) break;
+        // The only events allowed are RST_STREAM (the client telling the peer the
+        // stream is closed); never a response or data.
+        try testing.expect(ev != .response and ev != .data);
+    }
+    try testing.expectEqual(@as(usize, 0), c.streams.count()); // not re-opened
 }
 
 test "an even response stream id is a connection error for a client" {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -93,10 +93,8 @@ pub const Connection = struct {
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     highest_peer_id: u32 = 0,
-    /// High-water of the client's own (odd) stream ids it has opened to send. Lets
-    /// the client read path tell a response for a still-live stream from a stray
-    /// response for a stream it already reset/closed (the client analogue of
-    /// highest_peer_id, which only tracks peer-initiated ids).
+    /// High-water of the client's own opened ids (highest_peer_id's local analogue),
+    /// so a response for a reset stream is recognized as closed, not a new stream.
     highest_local_id: u32 = 0,
     /// Rapid-reset churn budgets: total streams ever opened and total resets.
     /// These count streams that no longer exist (evicted), so unlike the live
@@ -348,11 +346,7 @@ pub const Connection = struct {
 
     /// Is `id` a peer-initiated stream that has never been opened (idle)? An id
     /// above the highest one we have seen open is idle; at/below is closed.
-    /// Is `id` a stream that has never been opened (idle)? An id is idle only if it
-    /// is above BOTH high-water marks: peer-initiated streams (highest_peer_id) and
-    /// the client's own opened streams (highest_local_id). An id at/below either is
-    /// a stream that was opened and is now closed/evicted - stray frames on it are
-    /// tolerated, not a connection error.
+    /// Idle = never opened by either side; at/below either high-water is closed.
     fn isIdle(self: *const Connection, id: u32) bool {
         return id > self.highest_peer_id and id > self.highest_local_id;
     }
@@ -448,13 +442,9 @@ pub const Connection = struct {
                 return error.ProtocolError;
             }
         } else if (self.role == .client) {
-            // A client reads HEADERS as a response on a stream IT opened: the id
-            // must be odd (client-initiated, 5.1.1) and not server-pushed (push is
-            // out of scope). An id at/below the local high-water that is no longer
-            // in the map is one we already reset/closed; decode the block to keep
-            // the HPACK table in sync but surface nothing. A genuinely new id has
-            // its stream created here for the response (the H2 write path opens it
-            // on request).
+            // A client reads a response on a stream it opened (odd id, 5.1.1). An id
+            // at/below the local high-water but gone from the map was already reset:
+            // decode for HPACK sync but surface nothing. A new id opens its stream.
             if (id % 2 == 0) return error.ProtocolError;
             if (id <= self.highest_local_id) {
                 ignored = true;
@@ -518,9 +508,7 @@ pub const Connection = struct {
         };
 
         if (ignored) {
-            // A response for a client stream we already reset: the block was decoded
-            // to keep the HPACK table in sync, but the stream is gone - surface
-            // nothing (we already sent RST_STREAM for it).
+            // Response for an already-reset stream: decoded for HPACK sync, dropped.
             return;
         }
 
@@ -1366,13 +1354,10 @@ test "a request pseudo-header in a response resets the stream" {
 test "a response for a client-reset stream is ignored, not surfaced or re-opened" {
     var c = Connection.init(testing.allocator, .client);
     defer c.deinit();
-    // The client opens stream 1 to send, then resets it locally.
     try c.registerSendStream(1);
     c.localReset(1);
     try testing.expectEqual(@as(usize, 0), c.streams.count());
-    // An in-flight response head + body for stream 1 then arrives. The head is
-    // decoded (HPACK sync) but surfaces nothing, and the stray DATA is a tolerated
-    // stream error - never a Response/Data event or a re-opened stream.
+    // An in-flight response for the reset stream must surface no response/data.
     var frames: std.ArrayList(u8) = .empty;
     defer frames.deinit(testing.allocator);
     try frameBytes(&frames, .headers, Flags.end_headers, 1, &STATUS_200_BLOCK);
@@ -1381,8 +1366,6 @@ test "a response for a client-reset stream is ignored, not surfaced or re-opened
     while (true) {
         const ev = try c.nextEvent();
         if (ev == .need_data) break;
-        // The only events allowed are RST_STREAM (the client telling the peer the
-        // stream is closed); never a response or data.
         try testing.expect(ev != .response and ev != .data);
     }
     try testing.expectEqual(@as(usize, 0), c.streams.count()); // not re-opened

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -119,6 +119,20 @@ const H2Engine = struct {
         return py.none();
     }
 
+    fn resetStream(self: *H2Engine, id: u32, code: u32) py.Object {
+        if (!self.ensureHandshake()) return null;
+        self.writer.sendRstStream(id, @enumFromInt(code)) catch |e| return h2RaiseWrite(e);
+        self.conn.localReset(id);
+        return py.none();
+    }
+
+    fn goaway(self: *H2Engine, code: u32, last_stream_id: ?u32) py.Object {
+        if (!self.ensureHandshake()) return null;
+        const last = last_stream_id orelse self.conn.lastPeerStreamId();
+        self.writer.sendGoaway(last, @enumFromInt(code), &.{}) catch |e| return h2RaiseWrite(e);
+        return py.none();
+    }
+
     /// Drain parked DATA that a freshly-parsed WINDOW_UPDATE / SETTINGS credit now
     /// permits. Called from next_event after such an event is produced.
     fn flushSendable(self: *H2Engine) core.h2.writer.WriteError!void {
@@ -248,6 +262,15 @@ fn stream_end_message(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) p
     return e.endStream(self.stream_id);
 }
 
+fn stream_reset(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+    const self: *StreamObject = @ptrCast(self_obj.?);
+    const e = self.engine() orelse return null;
+    var code: c_ulong = @intFromEnum(core.h2.constants.ErrorCode.cancel);
+    if (c.PyArg_ParseTuple(args, "|k", &code) == 0) return null;
+    if (code > 0xFFFF_FFFF) return py.raiseValue("error code out of range");
+    return e.resetStream(self.stream_id, @intCast(code));
+}
+
 fn stream_id_get(self_obj: ?*c.PyObject, _: ?*anyopaque) callconv(.c) py.Object {
     const self: *StreamObject = @ptrCast(self_obj.?);
     return c.PyLong_FromUnsignedLong(self.stream_id);
@@ -262,6 +285,7 @@ var stream_methods = [_]py.MethodDef{
     .{ .ml_name = "send_response", .ml_meth = stream_send_response, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a response head on this stream: send_response(status, headers=None)." },
     .{ .ml_name = "send_data", .ml_meth = stream_send_data, .ml_flags = c.METH_O, .ml_doc = "Queue body bytes on this stream (flow-controlled; parked until the send window allows)." },
     .{ .ml_name = "end_message", .ml_meth = stream_end_message, .ml_flags = c.METH_VARARGS, .ml_doc = "End the outgoing message on this stream (empty END_STREAM DATA)." },
+    .{ .ml_name = "reset", .ml_meth = stream_reset, .ml_flags = c.METH_VARARGS, .ml_doc = "Send RST_STREAM to cancel this stream: reset(error_code=CANCEL)." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
 
@@ -761,6 +785,30 @@ fn stream(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
     return makeStream(self_obj, @intCast(id));
 }
 
+fn h2_close(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+    const self: *ConnectionObject = @ptrCast(self_obj.?);
+    const engine = self.engine orelse return py.raiseRuntime("connection is closed");
+    const h = switch (engine.*) {
+        .h2 => |*x| x,
+        else => return py.raiseRuntime("close() exists only on an HTTP/2 connection"),
+    };
+    var code: c_ulong = @intFromEnum(core.h2.constants.ErrorCode.no_error);
+    var last_obj: ?*c.PyObject = null;
+    if (c.PyArg_ParseTuple(args, "|kO", &code, &last_obj) == 0) return null;
+    if (code > 0xFFFF_FFFF) return py.raiseValue("error code out of range");
+    var last: ?u32 = null;
+    if (last_obj != null and !py.isNone(last_obj)) {
+        const v = c.PyLong_AsLongLong(last_obj);
+        if (v < 0) {
+            if (c.PyErr_Occurred() != null) return null;
+            return py.raiseValue("last_stream_id must be a non-negative integer");
+        }
+        if (v > 0x7FFF_FFFF) return py.raiseValue("last_stream_id exceeds the 31-bit HTTP/2 limit");
+        last = @intCast(v);
+    }
+    return h.goaway(@intCast(code), last);
+}
+
 // The read API, shared by both protocols and inherited by the subtypes. The base
 // Connection is the factory: constructing it picks H1Connection / H2Connection by
 // protocol (new_base), so the runtime type is truthful while isinstance(obj,
@@ -791,6 +839,7 @@ var h1_methods = [_]py.MethodDef{
 var h2_methods = [_]py.MethodDef{
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Open a request stream and return its Stream: send_request(method, target, version, headers). :authority is derived from a host header; the version arg is ignored." },
     .{ .ml_name = "stream", .ml_meth = stream, .ml_flags = c.METH_O, .ml_doc = "Return a Stream handle for stream_id. The connection owns the stream state; the handle is a stream-scoped command surface (send_response / send_data / end_message)." },
+    .{ .ml_name = "close", .ml_meth = h2_close, .ml_flags = c.METH_VARARGS, .ml_doc = "Send GOAWAY to shut the connection down: close(error_code=NO_ERROR, last_stream_id=None). last_stream_id defaults to the highest peer stream processed." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
 

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -387,3 +387,72 @@ def test_full_body_round_trips_across_window_updates() -> None:
         list(drain_h2(conn))
         rounds += 1
     assert bytes(body) == b"abcdefghij"
+
+
+def _frames(data: bytes) -> list[tuple[int, int, bytes]]:
+    """Parse (type, stream_id, payload) tuples, skipping a leading client preface."""
+    if data.startswith(PREFACE):
+        data = data[len(PREFACE) :]
+    out: list[tuple[int, int, bytes]] = []
+    i = 0
+    while i + 9 <= len(data):
+        length = int.from_bytes(data[i : i + 3], "big")
+        ftype = data[i + 3]
+        sid = int.from_bytes(data[i + 5 : i + 9], "big") & 0x7FFFFFFF
+        out.append((ftype, sid, data[i + 9 : i + 9 + length]))
+        i += 9 + length
+    return out
+
+
+def test_h2_stream_reset_sends_rst_stream() -> None:
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"x")])
+    stream.reset()  # defaults to CANCEL
+
+    rst = [f for f in _frames(client.data_to_send()) if f[0] == 0x03]
+    assert len(rst) == 1
+    _, sid, payload = rst[0]
+    assert sid == stream.stream_id
+    assert int.from_bytes(payload, "big") == 0x08  # CANCEL
+
+
+def test_h2_stream_reset_accepts_an_explicit_code() -> None:
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"x")])
+    stream.reset(0x01)  # PROTOCOL_ERROR
+
+    rst = [f for f in _frames(client.data_to_send()) if f[0] == 0x03]
+    assert int.from_bytes(rst[0][2], "big") == 0x01
+
+
+def test_h2_close_sends_goaway_with_the_highest_peer_stream() -> None:
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    client.send_request(b"GET", b"/", b"2", [(b"host", b"x")]).end_message()
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    server.receive_data(client.data_to_send())
+    list(drain_h2(server))
+
+    server.close()  # graceful: NO_ERROR, last_stream_id auto
+    goaway = [f for f in _frames(server.data_to_send()) if f[0] == 0x07]
+    assert len(goaway) == 1
+    _, _, payload = goaway[0]
+    last_stream_id = int.from_bytes(payload[0:4], "big")
+    error_code = int.from_bytes(payload[4:8], "big")
+    assert last_stream_id == 1  # the one request it processed
+    assert error_code == 0  # NO_ERROR
+
+
+def test_h2_close_accepts_an_explicit_code_and_last_stream_id() -> None:
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    server.close(0x0B, 0)  # ENHANCE_YOUR_CALM, last_stream_id 0
+
+    goaway = [f for f in _frames(server.data_to_send()) if f[0] == 0x07]
+    payload = goaway[0][2]
+    assert int.from_bytes(payload[0:4], "big") == 0
+    assert int.from_bytes(payload[4:8], "big") == 0x0B
+
+
+def test_h2_close_on_an_http1_connection_is_an_error() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(AttributeError):
+        conn.close()

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -459,8 +459,7 @@ def test_h2_close_on_an_http1_connection_is_an_error() -> None:
 
 
 def test_h2_response_after_stream_reset_is_ignored() -> None:
-    # A client that reset its own stream must not surface an in-flight response for
-    # it (the reset id is closed, not a fresh stream to re-open).
+    # The reset id is closed, not a fresh stream to re-open.
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
     opener = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
     opener.send_request(b"GET", b"/", b"2", [(b"host", b"x")]).end_message()
@@ -479,5 +478,4 @@ def test_h2_response_after_stream_reset_is_ignored() -> None:
 
     client.receive_data(response)
     events = list(drain_h2(client))
-    # The response head and body are dropped; nothing is surfaced for the reset id.
     assert not any(isinstance(e, (zttp.Response, zttp.Data)) for e in events)

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -456,3 +456,28 @@ def test_h2_close_on_an_http1_connection_is_an_error() -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(AttributeError):
         conn.close()
+
+
+def test_h2_response_after_stream_reset_is_ignored() -> None:
+    # A client that reset its own stream must not surface an in-flight response for
+    # it (the reset id is closed, not a fresh stream to re-open).
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    opener = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    opener.send_request(b"GET", b"/", b"2", [(b"host", b"x")]).end_message()
+    server.receive_data(opener.data_to_send())
+    list(drain_h2(server))
+    handle = server.stream(1)
+    handle.send_response(200, [(b"x", b"y")])
+    handle.send_data(b"hi")
+    handle.end_message()
+    response = server.data_to_send()
+
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"x")])
+    stream.reset()
+    client.data_to_send()  # flush the request + RST_STREAM
+
+    client.receive_data(response)
+    events = list(drain_h2(client))
+    # The response head and body are dropped; nothing is surfaced for the reset id.
+    assert not any(isinstance(e, (zttp.Response, zttp.Data)) for e in events)


### PR DESCRIPTION
Closes #50.

The Zig `Writer` already serializes RST_STREAM and GOAWAY, but neither was reachable from Python. An integrator (uvicorn's drain path) needs explicit per-stream cancellation and graceful connection shutdown, so this exposes them.

### API

```python
stream.reset(error_code=zttp ...CANCEL)          # -> RST_STREAM, drops the stream locally
conn.close(error_code=NO_ERROR, last_stream_id=None)  # -> GOAWAY (last_stream_id defaults to the highest peer stream)
```

- `stream.reset()` sends RST_STREAM on the handle's stream and evicts it from the core's map. Default code is `CANCEL` (0x08); any 32-bit code is accepted.
- `conn.close()` sends GOAWAY. Default is a graceful `NO_ERROR`; `last_stream_id` defaults to the highest peer-initiated stream processed (everything above it was never seen). Both args overridable.
- Two small public core methods back them: `Connection.localReset` (evict a locally-reset stream) and `Connection.lastPeerStreamId`.

### Tests

5 new tests in `tests/test_http2.py` (reset default/explicit code, close auto/explicit last-stream-id + code, close-on-H1-is-an-error). Full suite green (146 passed), `scripts/check` clean.

Follow-up: exposing the RFC 9113 `ErrorCode` enum as `zttp.PROTOCOL_ERROR` etc. (so callers stop passing magic numbers) is tracked in #51.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.