### PR TITLE
Auto-ACK SETTINGS/PING and replenish the HTTP/2 receive window

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -92,6 +92,10 @@ pub const Connection = struct {
     streams: std.AutoHashMapUnmanaged(u32, Stream) = .empty,
     conn_recv_window: i32 = constants.DEFAULT_WINDOW_SIZE,
     conn_send_window: i32 = constants.DEFAULT_WINDOW_SIZE,
+    /// Connection-level receive bytes consumed since the last WINDOW_UPDATE we sent.
+    /// The window is refilled immediately on consume (the core surfaces DATA at
+    /// once), and this accumulates what to advertise back, flushed by a threshold.
+    conn_recv_credit: u32 = 0,
     highest_peer_id: u32 = 0,
     /// High-water of the client's own opened ids (highest_peer_id's local analogue),
     /// so a response for a reset stream is recognized as closed, not a new stream.
@@ -386,6 +390,11 @@ pub const Connection = struct {
             return;
         }
         s.recordData(content.len);
+        // Refill the receive windows immediately (the data is surfaced now) and
+        // accumulate the consumed length to advertise back via WINDOW_UPDATE.
+        self.conn_recv_window += @intCast(f.header.length);
+        self.conn_recv_credit +|= f.header.length;
+        s.creditRecvWindow(f.header.length);
         if (content.len > 0) self.push(.{ .data = .{ .data = content, .stream_id = f.header.stream_id } });
         s.recvApply(.data, end_stream);
         if (end_stream) {
@@ -781,6 +790,27 @@ pub const Connection = struct {
     /// WINDOW_UPDATE or an INITIAL_WINDOW_SIZE change credits a send window.
     /// Flushing mutates only each stream's own fields and the writer (never the
     /// map's shape), so iterating value pointers in place is safe.
+    /// Emit WINDOW_UPDATE frames to advertise the receive credit accumulated as
+    /// DATA was consumed, so the peer's send window never drains to a stall. A
+    /// connection-level update (stream 0) plus one per stream that has consumed
+    /// at least `threshold` bytes; the connection update fires on the same
+    /// threshold against its own accumulator. Auto-replenish to full is the
+    /// pragmatic default for a core that surfaces DATA immediately.
+    pub fn flushRecvWindows(self: *Connection, writer: *writer_mod.Writer) writer_mod.WriteError!void {
+        const threshold: u32 = @intCast(@divTrunc(constants.DEFAULT_WINDOW_SIZE, 2));
+        if (self.conn_recv_credit >= threshold) {
+            try writer.sendWindowUpdate(0, self.conn_recv_credit);
+            self.conn_recv_credit = 0;
+        }
+        var it = self.streams.valueIterator();
+        while (it.next()) |strm| {
+            if (strm.recv_credit >= threshold) {
+                try writer.sendWindowUpdate(strm.id, strm.recv_credit);
+                strm.recv_credit = 0;
+            }
+        }
+    }
+
     pub fn flushSendable(self: *Connection, writer: *writer_mod.Writer) writer_mod.WriteError!void {
         // Flush every stream, then evict the ones that fully closed in a SEPARATE
         // pass. Removing entries while the value iterator is live would be fragile
@@ -1905,6 +1935,56 @@ test "fuzz: H2 connection never panics on adversarial frame streams" {
             if (ev == .need_data) break;
         }
     }
+}
+
+test "consumed DATA refills the receive window and accrues credit to advertise" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    try frameBytes(&input, .headers, Flags.end_headers, 1, &GET_BLOCK); // open, no END_STREAM
+    // Three DATA frames totaling 48000 bytes, past the half-window threshold.
+    const chunk = [_]u8{'x'} ** 16000;
+    var k: usize = 0;
+    while (k < 3) : (k += 1) try frameBytes(&input, .data, 0, 1, &chunk);
+    try c.feed(input.items);
+    while (true) {
+        const ev = try c.nextEvent();
+        if (ev == .need_data) break;
+    }
+    // The window was refilled on consume, so it never dropped below the start.
+    try testing.expectEqual(constants.DEFAULT_WINDOW_SIZE, c.conn_recv_window);
+    try testing.expectEqual(@as(u32, 48000), c.conn_recv_credit);
+    try testing.expectEqual(@as(u32, 48000), c.streams.getPtr(1).?.recv_credit);
+    // Flushing emits WINDOW_UPDATEs and clears the accumulators.
+    try c.flushRecvWindows(&w);
+    try testing.expectEqual(@as(u32, 0), c.conn_recv_credit);
+    try testing.expectEqual(@as(u32, 0), c.streams.getPtr(1).?.recv_credit);
+}
+
+test "a small body stays under the window-update threshold" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var w = writer_mod.Writer.init(testing.allocator, .server);
+    defer w.deinit();
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(testing.allocator);
+    try input.appendSlice(testing.allocator, constants.CLIENT_PREFACE);
+    try frameBytes(&input, .settings, 0, 0, &.{});
+    try frameBytes(&input, .headers, Flags.end_headers, 1, &GET_BLOCK);
+    try frameBytes(&input, .data, Flags.end_stream, 1, "hello");
+    try c.feed(input.items);
+    while (true) {
+        const ev = try c.nextEvent();
+        if (ev == .need_data) break;
+    }
+    const before = w.pending().len;
+    try c.flushRecvWindows(&w); // below threshold -> nothing emitted
+    try testing.expectEqual(before, w.pending().len);
 }
 
 fn driveConnection(input: []const u8) void {

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -45,6 +45,8 @@ pub const Stream = struct {
     /// check against 2^31-1 is done in i64 by the caller before narrowing.
     recv_window: i32,
     send_window: i32,
+    /// Receive bytes consumed on this stream since the last WINDOW_UPDATE we sent.
+    recv_credit: u32 = 0,
     /// Declared Content-Length (if any) and bytes of DATA seen, for the
     /// h2->h1 smuggling guard (validated at END_STREAM).
     content_length: ?u64 = null,
@@ -171,6 +173,13 @@ pub const Stream = struct {
         }
         self.recv_window -= @intCast(len);
         return Transition.ok;
+    }
+
+    /// Refill the receive window by `len` (the data was just consumed) and record
+    /// the same amount as credit to advertise back via WINDOW_UPDATE.
+    pub fn creditRecvWindow(self: *Stream, len: u32) void {
+        self.recv_window += @intCast(len);
+        self.recv_credit +|= len;
     }
 
     /// Apply a WINDOW_UPDATE increment to the send window. A zero increment is a

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -143,9 +143,12 @@ const H2Engine = struct {
         switch (ev) {
             .settings => try self.writer.sendSettingsAck(),
             .ping => |p| if (!p.ack) try self.writer.sendPingAck(p.opaque_data),
-            .data => try self.conn.flushRecvWindows(self.writer),
             else => {},
         }
+        // Advertise consumed receive window. Not gated on the .data event: a DATA
+        // frame of pure padding consumes window but surfaces no event, so flushing
+        // here (threshold-checked, idempotent) keeps the peer's send window open.
+        try self.conn.flushRecvWindows(self.writer);
         // A parsed WINDOW_UPDATE / SETTINGS may have credited a send window; drain
         // any DATA parked waiting for it.
         if (ev == .window_update or ev == .settings) try self.conn.flushSendable(self.writer);

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -135,8 +135,20 @@ const H2Engine = struct {
 
     /// Drain parked DATA that a freshly-parsed WINDOW_UPDATE / SETTINGS credit now
     /// permits. Called from next_event after such an event is produced.
-    fn flushSendable(self: *H2Engine) core.h2.writer.WriteError!void {
-        try self.conn.flushSendable(self.writer);
+    /// Auto-handle the connection-management frames RFC 9113 expects a peer to
+    /// answer without app involvement: ACK the peer's SETTINGS and PING, and
+    /// advertise consumed receive window via WINDOW_UPDATE. The serialized frames
+    /// land in the writer buffer for the next data_to_send.
+    fn autoRespond(self: *H2Engine, ev: events.H2Event) core.h2.writer.WriteError!void {
+        switch (ev) {
+            .settings => try self.writer.sendSettingsAck(),
+            .ping => |p| if (!p.ack) try self.writer.sendPingAck(p.opaque_data),
+            .data => try self.conn.flushRecvWindows(self.writer),
+            else => {},
+        }
+        // A parsed WINDOW_UPDATE / SETTINGS may have credited a send window; drain
+        // any DATA parked waiting for it.
+        if (ev == .window_update or ev == .settings) try self.conn.flushSendable(self.writer);
     }
 
     fn deinit(self: *H2Engine) void {
@@ -482,11 +494,7 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
     switch (engine.*) {
         .h2 => |*e| {
             const ev = e.conn.nextEvent() catch |err| return exceptions.raiseH2(err);
-            // A parsed WINDOW_UPDATE / SETTINGS may have credited a send window;
-            // drain any DATA that was parked waiting for it. The bytes land in the
-            // writer's buffer for the next data_to_send.
-            if (ev == .window_update or ev == .settings)
-                e.flushSendable() catch |err| return h2RaiseWrite(err);
+            e.autoRespond(ev) catch |err| return h2RaiseWrite(err);
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -389,17 +389,18 @@ def test_full_body_round_trips_across_window_updates() -> None:
     assert bytes(body) == b"abcdefghij"
 
 
-def _frames(data: bytes) -> list[tuple[int, int, bytes]]:
-    """Parse (type, stream_id, payload) tuples, skipping a leading client preface."""
+def _frames(data: bytes) -> list[tuple[int, int, int, bytes]]:
+    """Parse (type, flags, stream_id, payload) tuples, skipping a leading preface."""
     if data.startswith(PREFACE):
         data = data[len(PREFACE) :]
-    out: list[tuple[int, int, bytes]] = []
+    out: list[tuple[int, int, int, bytes]] = []
     i = 0
     while i + 9 <= len(data):
         length = int.from_bytes(data[i : i + 3], "big")
         ftype = data[i + 3]
+        flags = data[i + 4]
         sid = int.from_bytes(data[i + 5 : i + 9], "big") & 0x7FFFFFFF
-        out.append((ftype, sid, data[i + 9 : i + 9 + length]))
+        out.append((ftype, flags, sid, data[i + 9 : i + 9 + length]))
         i += 9 + length
     return out
 
@@ -411,7 +412,7 @@ def test_h2_stream_reset_sends_rst_stream() -> None:
 
     rst = [f for f in _frames(client.data_to_send()) if f[0] == 0x03]
     assert len(rst) == 1
-    _, sid, payload = rst[0]
+    _, _, sid, payload = rst[0]
     assert sid == stream.stream_id
     assert int.from_bytes(payload, "big") == 0x08  # CANCEL
 
@@ -422,7 +423,7 @@ def test_h2_stream_reset_accepts_an_explicit_code() -> None:
     stream.reset(0x01)  # PROTOCOL_ERROR
 
     rst = [f for f in _frames(client.data_to_send()) if f[0] == 0x03]
-    assert int.from_bytes(rst[0][2], "big") == 0x01
+    assert int.from_bytes(rst[0][3], "big") == 0x01
 
 
 def test_h2_close_sends_goaway_with_the_highest_peer_stream() -> None:
@@ -435,7 +436,7 @@ def test_h2_close_sends_goaway_with_the_highest_peer_stream() -> None:
     server.close()  # graceful: NO_ERROR, last_stream_id auto
     goaway = [f for f in _frames(server.data_to_send()) if f[0] == 0x07]
     assert len(goaway) == 1
-    _, _, payload = goaway[0]
+    _, _, _, payload = goaway[0]
     last_stream_id = int.from_bytes(payload[0:4], "big")
     error_code = int.from_bytes(payload[4:8], "big")
     assert last_stream_id == 1  # the one request it processed
@@ -447,7 +448,7 @@ def test_h2_close_accepts_an_explicit_code_and_last_stream_id() -> None:
     server.close(0x0B, 0)  # ENHANCE_YOUR_CALM, last_stream_id 0
 
     goaway = [f for f in _frames(server.data_to_send()) if f[0] == 0x07]
-    payload = goaway[0][2]
+    payload = goaway[0][3]
     assert int.from_bytes(payload[0:4], "big") == 0
     assert int.from_bytes(payload[4:8], "big") == 0x0B
 
@@ -479,3 +480,53 @@ def test_h2_response_after_stream_reset_is_ignored() -> None:
     client.receive_data(response)
     events = list(drain_h2(client))
     assert not any(isinstance(e, (zttp.Response, zttp.Data)) for e in events)
+
+
+def test_h2_peer_settings_is_auto_acked() -> None:
+    conn = server_with()  # preface + an empty peer SETTINGS
+    list(drain_h2(conn))
+    ack = [f for f in _frames(conn.data_to_send()) if f[0] == 0x04 and f[1] & 0x01]
+    assert len(ack) == 1  # SETTINGS frame with the ACK flag set
+
+
+def test_h2_peer_ping_is_auto_acked_with_the_same_payload() -> None:
+    conn = server_with()
+    list(drain_h2(conn))
+    conn.data_to_send()  # flush the SETTINGS ack
+    conn.receive_data(frame(0x06, 0, 0, b"PINGDATA"))  # a PING request (not an ack)
+    list(drain_h2(conn))
+    ack = [f for f in _frames(conn.data_to_send()) if f[0] == 0x06 and f[1] & 0x01]
+    assert len(ack) == 1
+    assert ack[0][3] == b"PINGDATA"  # the opaque data is echoed
+
+
+def test_h2_a_ping_ack_is_not_re_acked() -> None:
+    conn = server_with()
+    list(drain_h2(conn))
+    conn.data_to_send()
+    conn.receive_data(frame(0x06, 0x01, 0, b"ACKDATA0"))  # a PING with the ACK flag
+    list(drain_h2(conn))
+    assert [f for f in _frames(conn.data_to_send()) if f[0] == 0x06] == []
+
+
+def test_h2_consumed_receive_window_is_replenished() -> None:
+    conn = server_with(frame(0x01, END_HEADERS, 1, GET_BLOCK))  # open stream 1
+    list(drain_h2(conn))
+    conn.data_to_send()
+    # Three 16 KiB DATA frames (48 KiB) cross the half-window replenish threshold.
+    for _ in range(3):
+        conn.receive_data(frame(0x00, 0, 1, b"x" * 16000))
+    list(drain_h2(conn))
+    updates = [f for f in _frames(conn.data_to_send()) if f[0] == 0x08]
+    by_stream = {sid: int.from_bytes(payload, "big") for _, _, sid, payload in updates}
+    assert by_stream.get(0) == 48000  # connection-level (stream 0)
+    assert by_stream.get(1) == 48000  # the stream
+
+
+def test_h2_a_small_body_does_not_trigger_a_window_update() -> None:
+    conn = server_with(frame(0x01, END_HEADERS, 1, GET_BLOCK))
+    list(drain_h2(conn))
+    conn.data_to_send()
+    conn.receive_data(frame(0x00, END_STREAM, 1, b"hello"))  # tiny body, below threshold
+    list(drain_h2(conn))
+    assert [f for f in _frames(conn.data_to_send()) if f[0] == 0x08] == []

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -530,3 +530,21 @@ def test_h2_a_small_body_does_not_trigger_a_window_update() -> None:
     conn.receive_data(frame(0x00, END_STREAM, 1, b"hello"))  # tiny body, below threshold
     list(drain_h2(conn))
     assert [f for f in _frames(conn.data_to_send()) if f[0] == 0x08] == []
+
+
+def test_h2_padding_only_data_still_replenishes_the_window() -> None:
+    # DATA frames of pure padding consume window but surface no Data event; the
+    # window must still be advertised back, or the peer's send window stalls.
+    conn = server_with(frame(0x01, END_HEADERS, 1, GET_BLOCK))
+    list(drain_h2(conn))
+    conn.data_to_send()
+    PADDED = 0x08
+    padding_only = bytes([255]) + b"\x00" * 255  # 256-byte frame, zero content
+    for _ in range(140):  # 140 * 256 = 35840 bytes, past the 32 KiB threshold
+        conn.receive_data(frame(0x00, PADDED, 1, padding_only))
+    events = list(drain_h2(conn))
+    assert not any(isinstance(e, zttp.Data) for e in events)  # nothing surfaced
+    updates = [f for f in _frames(conn.data_to_send()) if f[0] == 0x08]
+    by_stream = {sid: int.from_bytes(payload, "big") for _, _, sid, payload in updates}
+    assert by_stream.get(0, 0) >= 32768  # connection window advertised
+    assert by_stream.get(1, 0) >= 32768  # stream window advertised


### PR DESCRIPTION
Closes #45. Closes #46. The two un-draft blockers for the uvicorn integration (Kludex/uvicorn#2982), items 1-2 of #36.

A real H2 client couldn't complete a round-trip against the binding: peer SETTINGS/PING were never ACKed (strict peers drop the connection on timeout), and the receive windows only ever debited - past 65535 bytes of body the next DATA frame tripped `FlowControlError` and poisoned the connection.

### What it does

The H2 engine now auto-handles the connection-management frames RFC 9113 expects a peer to answer without app involvement, after each `next_event`:

- **SETTINGS** -> a SETTINGS ACK.
- **PING** (request, not ack) -> a PING ACK echoing the opaque data.
- **DATA** -> a WINDOW_UPDATE advertising the consumed receive window.

Windows are refilled on consume (the core surfaces DATA immediately) and the consumed length is accumulated, flushed at the half-window threshold (32 KiB) for the connection (stream 0) and each stream - auto-replenish to full, matching hyper-h2's default. The window math is debit-then-refill by the same length, so the windows never grow unbounded or overflow.

### Tests

10 new tests: SETTINGS/PING auto-ack (and that a PING-ACK is not re-acked), window replenishment for connection + stream, and that a small body stays under the threshold - at both the core and Python levels. Full suite green (152 passed), `scripts/check` clean.

Follow-ups still open for the uvicorn integration: #47 (advertise real SETTINGS), #48 (emit GOAWAY on fatal errors), plus #36 items 5/7/8/9 (HEAD-response content-length, `end_stream` on `send_response`, `send_informational`, h2c upgrade seeding).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.