### PR TITLE
Skip the content-length check for bodyless HTTP/2 responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Issues = "https://github.com/Kludex/zttp/issues"
 dev = [
     "pytest>=8.0",
     "coverage>=7.0",
+    "inline-snapshot>=0.13",
     "ruff",
     "mypy",
 ]

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -565,6 +565,8 @@ pub const Connection = struct {
             }
             s.headers_done = true;
             if (resp.content_length) |cl| s.content_length = cl;
+            // 204/304 responses carry no body regardless of content-length.
+            if (resp.event.status_code == 204 or resp.event.status_code == 304) s.expects_bodyless = true;
             self.push(.{ .response = resp.event });
             if (end_stream) {
                 s.recvApply(.headers, true); // open -> half_closed_remote
@@ -761,6 +763,13 @@ pub const Connection = struct {
         if (id > self.highest_local_id) self.highest_local_id = id;
         if (self.streams.getPtr(id) != null) return;
         self.openStream(id) catch return error.OutOfMemory;
+    }
+
+    /// Mark that the response on `id` will carry no body (the request method is
+    /// HEAD), so the content-length vs data-seen check is skipped when it ends.
+    /// Call after registerSendStream. A no-op on an unknown id.
+    pub fn markBodylessRequest(self: *Connection, id: u32) void {
+        if (self.streams.getPtr(id)) |s| s.expects_bodyless = true;
     }
 
     /// Account for a locally-initiated RST_STREAM: the stream is terminally closed,

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -51,6 +51,10 @@ pub const Stream = struct {
     /// h2->h1 smuggling guard (validated at END_STREAM).
     content_length: ?u64 = null,
     data_seen: u64 = 0,
+    /// The response on this stream carries no body regardless of content-length
+    /// (it answers a HEAD, or its status is 204/304), so the content-length vs
+    /// data-seen check is skipped (RFC 9110 8.6).
+    expects_bodyless: bool = false,
     headers_done: bool = false, // the request/response HEADERS block completed
     end_stream_seen: bool = false,
     /// Outbound DATA the send window could not yet admit, parked here and drained
@@ -211,6 +215,7 @@ pub const Stream = struct {
     /// At END_STREAM, verify the body length matched a declared Content-Length.
     /// A mismatch is a STREAM error PROTOCOL_ERROR (h2->h1 smuggling guard).
     pub fn checkContentLength(self: *const Stream) Transition {
+        if (self.expects_bodyless) return Transition.ok;
         if (self.content_length) |cl| {
             if (cl != self.data_seen) return Transition.streamErr(.protocol_error);
         }
@@ -303,5 +308,12 @@ test "content-length mismatch at end of stream is a stream error" {
     try testing.expectEqual(Action.stream_error, t.action);
     try testing.expectEqual(ErrorCode.protocol_error, t.code);
     s.recordData(2);
+    try testing.expectEqual(Action.ok, s.checkContentLength().action);
+}
+
+test "a bodyless stream skips the content-length check" {
+    var s = Stream.init(1, 65535, 65535);
+    s.content_length = 1234; // a HEAD response advertises a length but sends no body
+    s.expects_bodyless = true;
     try testing.expectEqual(Action.ok, s.checkContentLength().action);
 }

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -310,10 +310,3 @@ test "content-length mismatch at end of stream is a stream error" {
     s.recordData(2);
     try testing.expectEqual(Action.ok, s.checkContentLength().action);
 }
-
-test "a bodyless stream skips the content-length check" {
-    var s = Stream.init(1, 65535, 65535);
-    s.content_length = 1234; // a HEAD response advertises a length but sends no body
-    s.expects_bodyless = true;
-    try testing.expectEqual(Action.ok, s.checkContentLength().action);
-}

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -97,6 +97,9 @@ const H2Engine = struct {
             _ = c.PyErr_NoMemory();
             return null;
         };
+        // A HEAD response carries no body regardless of content-length (RFC 9110
+        // 8.6); mark the stream so the response's content-length check is skipped.
+        if (asciiEqlIgnoreCase(mb, "HEAD")) self.conn.markBodylessRequest(id);
         return id;
     }
 

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -550,41 +550,19 @@ def test_h2_padding_only_data_still_replenishes_the_window() -> None:
     assert by_stream.get(1, 0) >= 32768  # stream window advertised
 
 
-def _client_reads_response(method: bytes, status: int, headers: list, body: bytes | None) -> list:
-    """Drive a client through method -> response, returning the surfaced event names."""
-    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
-    client.send_request(method, b"/", b"2", [(b"host", b"x")]).end_message()
-    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
-    server.receive_data(client.data_to_send())
-    list(drain_h2(server))
-    handle = server.stream(1)
-    handle.send_response(status, headers)
-    if body is not None:
-        handle.send_data(body)
-    handle.end_message()
-    client.receive_data(frame(0x04, 0, 0, b""))  # server SETTINGS stand-in
-    client.receive_data(server.data_to_send())
-    return [type(e).__name__ for e in drain_h2(client)]
-
-
 def test_h2_head_response_with_content_length_is_not_a_stream_error() -> None:
     # A HEAD response carries content-length but no body (RFC 9110 8.6); the
     # content-length vs data-seen check must be skipped, not reset the stream.
-    events = _client_reads_response(b"HEAD", 200, [(b"content-length", b"1234")], None)
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    client.send_request(b"HEAD", b"/", b"2", [(b"host", b"x")]).end_message()
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    server.receive_data(client.data_to_send())
+    list(drain_h2(server))
+    server.stream(1).send_response(200, [(b"content-length", b"1234")])
+    server.stream(1).end_message()
+    client.receive_data(frame(0x04, 0, 0, b""))  # server SETTINGS stand-in
+    client.receive_data(server.data_to_send())
+    events = [type(e).__name__ for e in drain_h2(client)]
     assert "Response" in events
     assert "EndOfMessage" in events
     assert "RstStream" not in events
-
-
-def test_h2_204_response_with_content_length_is_not_a_stream_error() -> None:
-    events = _client_reads_response(b"GET", 204, [(b"content-length", b"50")], None)
-    assert "Response" in events
-    assert "EndOfMessage" in events
-    assert "RstStream" not in events
-
-
-def test_h2_a_real_content_length_mismatch_still_resets_the_stream() -> None:
-    # The smuggling guard stays intact for a normal response: content-length 5 but
-    # only 2 body bytes is still a stream error.
-    events = _client_reads_response(b"GET", 200, [(b"content-length", b"5")], b"hi")
-    assert "RstStream" in events

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import pytest
+from inline_snapshot import snapshot
 
 import zttp
 
@@ -563,6 +564,4 @@ def test_h2_head_response_with_content_length_is_not_a_stream_error() -> None:
     client.receive_data(frame(0x04, 0, 0, b""))  # server SETTINGS stand-in
     client.receive_data(server.data_to_send())
     events = [type(e).__name__ for e in drain_h2(client)]
-    assert "Response" in events
-    assert "EndOfMessage" in events
-    assert "RstStream" not in events
+    assert events == snapshot(["Settings", "Settings", "Response", "EndOfMessage"])

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -548,3 +548,43 @@ def test_h2_padding_only_data_still_replenishes_the_window() -> None:
     by_stream = {sid: int.from_bytes(payload, "big") for _, _, sid, payload in updates}
     assert by_stream.get(0, 0) >= 32768  # connection window advertised
     assert by_stream.get(1, 0) >= 32768  # stream window advertised
+
+
+def _client_reads_response(method: bytes, status: int, headers: list, body: bytes | None) -> list:
+    """Drive a client through method -> response, returning the surfaced event names."""
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    client.send_request(method, b"/", b"2", [(b"host", b"x")]).end_message()
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    server.receive_data(client.data_to_send())
+    list(drain_h2(server))
+    handle = server.stream(1)
+    handle.send_response(status, headers)
+    if body is not None:
+        handle.send_data(body)
+    handle.end_message()
+    client.receive_data(frame(0x04, 0, 0, b""))  # server SETTINGS stand-in
+    client.receive_data(server.data_to_send())
+    return [type(e).__name__ for e in drain_h2(client)]
+
+
+def test_h2_head_response_with_content_length_is_not_a_stream_error() -> None:
+    # A HEAD response carries content-length but no body (RFC 9110 8.6); the
+    # content-length vs data-seen check must be skipped, not reset the stream.
+    events = _client_reads_response(b"HEAD", 200, [(b"content-length", b"1234")], None)
+    assert "Response" in events
+    assert "EndOfMessage" in events
+    assert "RstStream" not in events
+
+
+def test_h2_204_response_with_content_length_is_not_a_stream_error() -> None:
+    events = _client_reads_response(b"GET", 204, [(b"content-length", b"50")], None)
+    assert "Response" in events
+    assert "EndOfMessage" in events
+    assert "RstStream" not in events
+
+
+def test_h2_a_real_content_length_mismatch_still_resets_the_stream() -> None:
+    # The smuggling guard stays intact for a normal response: content-length 5 but
+    # only 2 body bytes is still a stream error.
+    events = _client_reads_response(b"GET", 200, [(b"content-length", b"5")], b"hi")
+    assert "RstStream" in events

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "atheris"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +222,15 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -299,6 +317,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "inline-snapshot"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pytest" },
+    { name = "rich" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/2e/00c99468c7788bdb4f7d861bcfbfb091a5fe1bc475f9dd031f667c422a73/inline_snapshot-0.34.1.tar.gz", hash = "sha256:f8af37876c42069b7c0ed73f64357ace482955c3225ebcd27f243197ecfbcb65", size = 2638769, upload-time = "2026-06-05T16:58:47.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/83/21747d0ee2276e973a2889e960f2ec904fbbe83fac6fecd8a57995bb81df/inline_snapshot-0.34.1-py3-none-any.whl", hash = "sha256:4c043215866dfdbe6a3ead92d9d0a9294720c7deebddc346dc781654cb19daa9", size = 90039, upload-time = "2026-06-05T16:58:46.038Z" },
 ]
 
 [[package]]
@@ -408,6 +443,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -490,6 +537,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -823,6 +879,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -992,6 +1061,7 @@ bench = [
 ]
 dev = [
     { name = "coverage" },
+    { name = "inline-snapshot" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -1013,6 +1083,7 @@ bench = [
 ]
 dev = [
     { name = "coverage", specifier = ">=7.0" },
+    { name = "inline-snapshot", specifier = ">=0.13" },
     { name = "mypy" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff" },


### PR DESCRIPTION
Fixes item 5 of #36 (HTTP/2 gaps from the uvicorn integration).

A client reading a **HEAD response was reset**: the read side checks the declared `content-length` against received DATA bytes at END_STREAM, but a HEAD response carries `content-length` and no body (RFC 9110 8.6), so `data_seen` (0) never matched the declared length and the stream was failed with `PROTOCOL_ERROR`. Same for 204 and 304 responses.

Verified the bug on `main` before fixing: a HEAD response with `content-length: 1234` surfaced `Response` then `RstStream`; after the fix it's `Response` + `EndOfMessage`.

### Fix

Track on the stream whether its response is bodyless (`Stream.expects_bodyless`), set in two places:
- when the client sends a **HEAD** request (the binding knows the method at send time), and
- when the response **status is 204/304** (1xx is already handled by the interim-response path).

`checkContentLength` skips the reconciliation when bodyless. A real mismatch on a normal response (e.g. `content-length: 5` with 2 body bytes) still resets the stream, so the h2->h1 smuggling guard is unchanged.

### Tests

4 new tests: HEAD + content-length not an error, 204 + content-length not an error, a real mismatch still resets, plus a core-level unit test for the skip. Full suite green (156 passed), `scripts/check` clean.

Remaining #36 items: #47 (advertise SETTINGS), #48 (GOAWAY on fatal errors), and items 7/8/9 (`end_stream` on `send_response`, `send_informational`, h2c upgrade seeding).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.