### PR TITLE
Add QUIC frame and packet-header serializers for the write side

### DIFF
--- a/src/core/quic/frame.zig
+++ b/src/core/quic/frame.zig
@@ -190,6 +190,50 @@ fn decodeClose(cur: *Cursor, app: bool) Error!Frame {
     return .{ .connection_close = .{ .app = app, .error_code = error_code, .frame_type = frame_type, .reason = reason } };
 }
 
+// -- encode (the write side) -------------------------------------------------
+//
+// The inverse of `decode` for the frames an outbound packet carries: STREAM (the
+// response bytes) and ACK (acknowledging the peer). Each appends to the caller's
+// payload buffer; the connection layer seals and protects the assembled packet.
+
+/// Append a STREAM frame (RFC 9000 19.8). The length is always written (LEN bit
+/// set) so frames can be followed by others in the same packet; OFF is written
+/// only for a nonzero offset. `fin` sets the FIN bit.
+pub fn encodeStream(
+    out: *std.ArrayListUnmanaged(u8),
+    gpa: std.mem.Allocator,
+    stream_id: u64,
+    offset: u64,
+    data: []const u8,
+    fin: bool,
+) !void {
+    var ty: u64 = constants.STREAM_BASE | constants.STREAM_LEN;
+    if (offset != 0) ty |= constants.STREAM_OFF;
+    if (fin) ty |= constants.STREAM_FIN;
+    try varint.append(out, gpa, ty);
+    try varint.append(out, gpa, stream_id);
+    if (offset != 0) try varint.append(out, gpa, offset);
+    try varint.append(out, gpa, data.len);
+    try out.appendSlice(gpa, data);
+}
+
+/// Append an ACK frame (RFC 9000 19.3) acknowledging `largest` and the
+/// `first_range` packets below it, with no additional ranges (the common case:
+/// one contiguous run). `delay` is the ack-delay varint.
+pub fn encodeAck(
+    out: *std.ArrayListUnmanaged(u8),
+    gpa: std.mem.Allocator,
+    largest: u64,
+    delay: u64,
+    first_range: u64,
+) !void {
+    try varint.append(out, gpa, @intFromEnum(FrameType.ack));
+    try varint.append(out, gpa, largest);
+    try varint.append(out, gpa, delay);
+    try varint.append(out, gpa, 0); // ACK Range Count: no additional ranges
+    try varint.append(out, gpa, first_range);
+}
+
 /// Iterate the ranges of a parsed ACK frame. The recovery layer walks these to
 /// learn which packet numbers the peer acknowledged.
 pub fn ackRanges(ack_ranges: []const u8) AckRangeIterator {
@@ -289,4 +333,55 @@ test "empty NEW_TOKEN is a frame encoding error" {
 test "NEW_CONNECTION_ID with retire_prior_to past seq is rejected" {
     // seq=1, retire_prior_to=2 (invalid), ...
     try std.testing.expectError(error.FrameEncodingError, decode(&.{ 0x18, 0x01, 0x02 }));
+}
+
+test "encodeStream round-trips through decode" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try encodeStream(&out, gpa, 4, 8, "abc", true);
+    const d = try decode(out.items);
+    const s = d.frame.stream;
+    try std.testing.expectEqual(@as(u64, 4), s.stream_id);
+    try std.testing.expectEqual(@as(u64, 8), s.offset);
+    try std.testing.expectEqualStrings("abc", s.data);
+    try std.testing.expect(s.fin);
+    try std.testing.expectEqual(out.items.len, d.len);
+}
+
+test "encodeStream omits the offset field when offset is zero" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try encodeStream(&out, gpa, 0, 0, "hi", false);
+    // type 0x0a (BASE|LEN, no OFF, no FIN), id 0, len 2, "hi".
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x0a, 0x00, 0x02, 'h', 'i' }, out.items);
+    const s = (try decode(out.items)).frame.stream;
+    try std.testing.expectEqual(@as(u64, 0), s.offset);
+    try std.testing.expect(!s.fin);
+}
+
+test "encodeAck round-trips through decode" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try encodeAck(&out, gpa, 10, 0, 2);
+    const ack = (try decode(out.items)).frame.ack;
+    try std.testing.expectEqual(@as(u64, 10), ack.largest);
+    try std.testing.expectEqual(@as(u64, 2), ack.first_range);
+    var it = ackRanges(ack.ranges);
+    try std.testing.expect(it.next() == null); // no additional ranges
+}
+
+test "two encoded frames decode back to back in one payload" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try encodeAck(&out, gpa, 5, 0, 0);
+    try encodeStream(&out, gpa, 0, 0, "ok", true);
+    const first = try decode(out.items);
+    try std.testing.expect(first.frame == .ack);
+    const second = try decode(out.items[first.len..]);
+    try std.testing.expectEqualStrings("ok", second.frame.stream.data);
+    try std.testing.expect(second.frame.stream.fin);
 }

--- a/src/core/quic/packet.zig
+++ b/src/core/quic/packet.zig
@@ -145,6 +145,73 @@ pub fn packetNumberLen(pn: u64, largest_acked: ?u64) usize {
     return 4;
 }
 
+// -- write (the header writers, the inverse of parseLong/parseShort) ----------
+//
+// These append a cleartext header through the Length field; the caller then
+// writes the `pn_len`-byte packet number and the payload, seals (AEAD), and
+// applies header protection. `pn_len` (1-4) is encoded into the first byte's low
+// two bits as pn_len-1. The returned pn_offset is where the packet number goes -
+// the start of the header-protected region.
+
+/// Write a long header (Initial/Handshake/0-RTT) through the Length field.
+/// `length` must cover the packet number plus the protected payload (RFC 9000
+/// 17.2). `token` is written only for an Initial (pass empty otherwise). Returns
+/// the packet-number offset.
+pub fn writeLongHeader(
+    out: *std.ArrayListUnmanaged(u8),
+    gpa: std.mem.Allocator,
+    ltype: LongType,
+    version: u32,
+    dcid: []const u8,
+    scid: []const u8,
+    token: []const u8,
+    length: u64,
+    pn_len: usize,
+) !usize {
+    std.debug.assert(pn_len >= 1 and pn_len <= 4);
+    const first: u8 = constants.HEADER_FORM_LONG | constants.FIXED_BIT |
+        (@as(u8, @intFromEnum(ltype)) << 4) | @as(u8, @intCast(pn_len - 1));
+    try out.append(gpa, first);
+    var ver: [4]u8 = undefined;
+    std.mem.writeInt(u32, &ver, version, .big);
+    try out.appendSlice(gpa, &ver);
+    try out.append(gpa, @intCast(dcid.len));
+    try out.appendSlice(gpa, dcid);
+    try out.append(gpa, @intCast(scid.len));
+    try out.appendSlice(gpa, scid);
+    if (ltype == .initial) {
+        try varint.append(out, gpa, token.len);
+        try out.appendSlice(gpa, token);
+    }
+    try varint.append(out, gpa, length);
+    return out.items.len;
+}
+
+/// Write a short (1-RTT) header through the dcid. Returns the packet-number
+/// offset (right after the dcid); the caller writes the pn and payload next.
+pub fn writeShortHeader(
+    out: *std.ArrayListUnmanaged(u8),
+    gpa: std.mem.Allocator,
+    dcid: []const u8,
+    pn_len: usize,
+) !usize {
+    std.debug.assert(pn_len >= 1 and pn_len <= 4);
+    // Short header: the form bit is clear (1-RTT); fixed bit set, pn_len-1 in the
+    // low two bits. The spin and key-phase bits are 0.
+    const first: u8 = constants.FIXED_BIT | @as(u8, @intCast(pn_len - 1));
+    try out.append(gpa, first);
+    try out.appendSlice(gpa, dcid);
+    return out.items.len;
+}
+
+/// Write a packet number in its minimal `pn_len`-byte big-endian truncated form
+/// (RFC 9000 17.1). The matching length comes from `packetNumberLen`.
+pub fn writePacketNumber(out: *std.ArrayListUnmanaged(u8), gpa: std.mem.Allocator, pn: u64, pn_len: usize) !void {
+    var buf: [4]u8 = undefined;
+    std.mem.writeInt(u32, &buf, @intCast(pn & 0xFFFF_FFFF), .big);
+    try out.appendSlice(gpa, buf[4 - pn_len ..]);
+}
+
 test "isLong reads the form bit" {
     try std.testing.expect(isLong(0xC0));
     try std.testing.expect(!isLong(0x40));
@@ -194,4 +261,55 @@ test "packetNumberLen grows with the gap" {
     try std.testing.expectEqual(@as(usize, 1), packetNumberLen(5, 0));
     try std.testing.expectEqual(@as(usize, 2), packetNumberLen(1000, 0));
     try std.testing.expectEqual(@as(usize, 1), packetNumberLen(1000, 999));
+}
+
+test "writeLongHeader round-trips through parseLong" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    // An Initial header: dcid "abcd", empty scid, empty token, length 5, 1-byte pn.
+    const pn_off = try writeLongHeader(&out, gpa, .initial, constants.VERSION_1, "abcd", "", "", 5, 1);
+    // Append the 1-byte pn + 4 payload octets so parseLong's length check passes.
+    try out.appendSlice(gpa, &.{ 0x00, 0xAA, 0xBB, 0xCC, 0xDD });
+    const h = try parseLong(out.items);
+    try std.testing.expectEqual(LongType.initial, h.ltype);
+    try std.testing.expectEqual(constants.VERSION_1, h.version);
+    try std.testing.expectEqualStrings("abcd", h.dcid);
+    try std.testing.expectEqual(@as(usize, 0), h.scid.len);
+    try std.testing.expectEqual(@as(u64, 5), h.length);
+    try std.testing.expectEqual(pn_off, h.pn_offset);
+}
+
+test "writeLongHeader encodes pn_len into the first byte" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    _ = try writeLongHeader(&out, gpa, .handshake, constants.VERSION_1, "", "", "", 1, 3);
+    // first byte: long(0x80) | fixed(0x40) | type handshake(2<<4=0x20) | pn_len-1(2).
+    try std.testing.expectEqual(@as(u8, 0x80 | 0x40 | 0x20 | 0x02), out.items[0]);
+}
+
+test "writeShortHeader round-trips through parseShort" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    const pn_off = try writeShortHeader(&out, gpa, "cid", 2);
+    try out.appendSlice(gpa, &.{ 0x00, 0x01 }); // 2-byte pn
+    const h = try parseShort(out.items, 3);
+    try std.testing.expectEqualStrings("cid", h.dcid);
+    try std.testing.expectEqual(pn_off, h.pn_offset);
+    // form bit clear, fixed bit set, pn_len-1 = 1.
+    try std.testing.expect(!isLong(out.items[0]));
+    try std.testing.expectEqual(@as(u8, 0x40 | 0x01), out.items[0]);
+}
+
+test "writePacketNumber writes the minimal big-endian form" {
+    const gpa = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try writePacketNumber(&out, gpa, 0x1234, 2);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x12, 0x34 }, out.items);
+    out.clearRetainingCapacity();
+    try writePacketNumber(&out, gpa, 0x05, 1);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x05}, out.items);
 }


### PR DESCRIPTION
Second of the staged HTTP/3 **write side** (after the QPACK encoder, #62). The QUIC layer could parse frames and headers but not write them; this adds the encode half.

### `frame.zig` - frame serializers

- `encodeStream(id, offset, data, fin)` - a STREAM frame (RFC 9000 19.8). LEN is always set so frames can be packed back to back; OFF is written only for a nonzero offset.
- `encodeAck(largest, delay, first_range)` - an ACK frame with one contiguous range (the common case).

### `packet.zig` - header writers (the inverse of parseLong/parseShort)

- `writeLongHeader(...)` / `writeShortHeader(...)` - generalize the header build that `testBuildInitial` does inline. `pn_len` is encoded into the first byte's low two bits; they return the packet-number offset so the send orchestrator can place the pn, seal (AEAD), and apply header protection.
- `writePacketNumber(pn, pn_len)` - the minimal big-endian truncated form (`packetNumberLen` already existed, "used by the writer").

All pure leaf serializers, no crypto/keys. Tested by round-tripping through the existing `frame.decode` / `packet.parseLong` / `parseShort` (9 tests: each frame and header type back and forth, two frames packed in one payload, pn_len encoding).

Next: the QUIC send orchestrator (SendStream + packetize + seal + datagram queue) builds on these, then the H3 connection send methods, then the Python adapter.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.