### PR TITLE
Add the QUIC send path: packetize, seal, and queue datagrams

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -72,6 +72,12 @@ pub const Connection = struct {
     conn_received_total: u64 = 0,
     conn_consumed_total: u64 = 0,
     streams: std.AutoHashMapUnmanaged(u64, *stream.RecvStream) = .empty,
+    send_streams: std.AutoHashMapUnmanaged(u64, *stream.SendStream) = .empty,
+    /// Datagrams built by the send path, waiting to be drained by datagramsToSend.
+    out: std.ArrayListUnmanaged(u8) = .empty,
+    /// Per-datagram boundaries into `out` (each entry is a datagram length), so the
+    /// drain API can hand them out one UDP payload at a time.
+    out_lengths: std.ArrayListUnmanaged(usize) = .empty,
     closed: bool = false,
 
     /// `client_dcid` is the destination connection id on the client's first
@@ -105,6 +111,14 @@ pub const Connection = struct {
             self.gpa.destroy(s.*);
         }
         self.streams.deinit(self.gpa);
+        var sit = self.send_streams.valueIterator();
+        while (sit.next()) |s| {
+            s.*.deinit();
+            self.gpa.destroy(s.*);
+        }
+        self.send_streams.deinit(self.gpa);
+        self.out.deinit(self.gpa);
+        self.out_lengths.deinit(self.gpa);
         for (&self.spaces) |*s| s.deinit(self.gpa);
     }
 
@@ -278,6 +292,116 @@ pub const Connection = struct {
         }
         return n;
     }
+
+    // -- send path -----------------------------------------------------------
+    //
+    // Queue outbound stream bytes, then `flushSend` packetizes them: frame the
+    // STREAM data, build a packet header, place the packet number, seal (AEAD),
+    // and apply header protection - the inverse of the receive path, and exactly
+    // what testBuildInitial does inline. Sent packets are registered with recovery
+    // and congestion so incoming ACKs keep the in-flight set consistent;
+    // retransmission/PTO are a follow-up. The built datagrams drain through
+    // `datagramsToSend`.
+
+    fn sendStream(self: *Connection, id: u64) Error!*stream.SendStream {
+        if (self.send_streams.get(id)) |s| return s;
+        const s = try self.gpa.create(stream.SendStream);
+        s.* = stream.SendStream.init(self.gpa);
+        self.send_streams.put(self.gpa, id, s) catch {
+            s.deinit();
+            self.gpa.destroy(s);
+            return error.OutOfMemory;
+        };
+        return s;
+    }
+
+    /// Queue `data` (and/or a FIN) to be sent on stream `id`. Call `flushSend` to
+    /// turn the queue into datagrams.
+    pub fn sendStreamData(self: *Connection, id: u64, data: []const u8, fin: bool) Error!void {
+        const s = try self.sendStream(id);
+        try s.write(data, fin);
+    }
+
+    /// Whether any stream still has bytes (or an owed FIN) waiting to be sent.
+    pub fn hasPendingSend(self: *Connection) bool {
+        var it = self.send_streams.valueIterator();
+        while (it.next()) |s| if (s.*.pending()) return true;
+        return false;
+    }
+
+    /// Packetize the queued stream data into datagrams (Initial space, one STREAM
+    /// frame per packet for now). Each packet is sealed and header-protected and
+    /// appended to the outbound queue. Idempotent when nothing is pending.
+    pub fn flushSend(self: *Connection) Error!void {
+        const space = Space.initial;
+        const st = &self.spaces[@intFromEnum(space)];
+        const keys = st.send_keys orelse return; // no send keys for this space yet
+
+        var it = self.send_streams.iterator();
+        while (it.next()) |entry| {
+            const id = entry.key_ptr.*;
+            const s = entry.value_ptr.*;
+            while (s.pending()) {
+                // Leave room for the frame header overhead and the AEAD tag inside
+                // a conservative max datagram; one STREAM frame per packet for now.
+                const room = constants.MIN_INITIAL_DATAGRAM - 64;
+                const chunk = s.peek(room) orelse break;
+                try self.buildStreamPacket(keys, st, id, chunk);
+                s.commit(chunk.data.len, chunk.fin);
+            }
+        }
+    }
+
+    /// Build one Initial-space packet carrying a single STREAM frame, seal and
+    /// protect it, and append it (and its length) to the outbound queue.
+    fn buildStreamPacket(self: *Connection, keys: crypto.Keys, st: *SpaceState, id: u64, chunk: stream.SendStream.Chunk) Error!void {
+        // Frame the STREAM data.
+        var frames: std.ArrayListUnmanaged(u8) = .empty;
+        defer frames.deinit(self.gpa);
+        frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
+
+        const pn = st.next_pn;
+        const pn_len: usize = 1; // 1-byte pn for the first cut (matches testBuildInitial)
+        const length = pn_len + frames.items.len + crypto.TAG_LEN;
+
+        // Header through the Length field (Initial: empty scid/token here).
+        var hdr: std.ArrayListUnmanaged(u8) = .empty;
+        defer hdr.deinit(self.gpa);
+        const pn_offset = packet.writeLongHeader(&hdr, self.gpa, .initial, constants.VERSION_1, self.dcid, &.{}, &.{}, length, pn_len) catch return error.OutOfMemory;
+        packet.writePacketNumber(&hdr, self.gpa, pn, pn_len) catch return error.OutOfMemory;
+
+        // Assemble: header(incl pn) + sealed(frames). seal writes ciphertext+tag.
+        const start = self.out.items.len;
+        self.out.appendSlice(self.gpa, hdr.items) catch return error.OutOfMemory;
+        const ct = self.out.addManyAsSlice(self.gpa, frames.items.len + crypto.TAG_LEN) catch return error.OutOfMemory;
+        _ = crypto.seal(keys, pn, hdr.items, frames.items, ct);
+        crypto.protectHeader(keys.hp, self.out.items[start..], pn_offset, true) catch return error.ProtocolViolation;
+
+        const datagram_len = self.out.items.len - start;
+        self.out_lengths.append(self.gpa, datagram_len) catch return error.OutOfMemory;
+
+        // Register the sent packet so an incoming ACK clears the in-flight set.
+        st.rec.onSent(self.gpa, .{ .pn = pn, .sent_time = 0, .size = datagram_len, .ack_eliciting = true, .in_flight = true }) catch return error.OutOfMemory;
+        self.cc.onSent(datagram_len);
+        st.next_pn += 1;
+    }
+
+    /// The built datagrams as one contiguous buffer; pair with `datagramLengths`
+    /// to split it into individual UDP payloads. Valid until `clearSend`.
+    pub fn datagramsToSend(self: *Connection) []const u8 {
+        return self.out.items;
+    }
+
+    /// The byte length of each queued datagram, in order.
+    pub fn datagramLengths(self: *Connection) []const usize {
+        return self.out_lengths.items;
+    }
+
+    /// Drop the drained datagrams (the integrator has sent them).
+    pub fn clearSend(self: *Connection) void {
+        self.out.clearRetainingCapacity();
+        self.out_lengths.clearRetainingCapacity();
+    }
 };
 
 const testing = std.testing;
@@ -360,6 +484,68 @@ test "consume re-grants connection flow-control credit" {
     try testing.expectEqualStrings("abc", conn.streamData(0));
     conn.consumeStream(0, 3);
     try testing.expectEqualStrings("", conn.streamData(0));
+}
+
+test "a server-sent STREAM round-trips to a peer client" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    // The server queues a response on stream 0 and packetizes it.
+    var server = try Connection.init(gpa, .server, &dcid);
+    defer server.deinit();
+    try server.sendStreamData(0, "hi", true);
+    try server.flushSend();
+    const lengths = server.datagramLengths();
+    try testing.expectEqual(@as(usize, 1), lengths.len);
+    const dgram = server.datagramsToSend();
+
+    // A peer client (same dcid -> same Initial keys) decrypts and reassembles it.
+    var client = try Connection.init(gpa, .client, &dcid);
+    defer client.deinit();
+    try client.receiveDatagram(dgram, 1000);
+    try testing.expectEqualStrings("hi", client.streamData(0));
+    try testing.expect(client.streamFinished(0));
+}
+
+test "flushSend with nothing queued is a no-op" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    try testing.expect(!conn.hasPendingSend());
+    try conn.flushSend();
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+}
+
+test "a multi-chunk response round-trips in order" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x11, 0x22, 0x33, 0x44 };
+    var server = try Connection.init(gpa, .server, &dcid);
+    defer server.deinit();
+    // Two writes on the same stream: the second carries the FIN. They share one
+    // flush, so two STREAM frames at offsets 0 and 5 reassemble to "helloworld".
+    try server.sendStreamData(3, "hello", false);
+    try server.sendStreamData(3, "world", true);
+    try server.flushSend();
+    const dgram = server.datagramsToSend();
+
+    var client = try Connection.init(gpa, .client, &dcid);
+    defer client.deinit();
+    try client.receiveDatagram(dgram, 1000);
+    try testing.expectEqualStrings("helloworld", client.streamData(3));
+    try testing.expect(client.streamFinished(3));
+}
+
+test "clearSend drops the drained datagrams" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x05, 0x06, 0x07, 0x08 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    try conn.sendStreamData(0, "x", true);
+    try conn.flushSend();
+    try testing.expect(conn.datagramsToSend().len > 0);
+    conn.clearSend();
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+    try testing.expectEqual(@as(usize, 0), conn.datagramLengths().len);
 }
 
 test "connection flow control sums across streams" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -331,8 +331,10 @@ pub const Connection = struct {
 
     /// Packetize the queued stream data into datagrams (Initial space, one STREAM
     /// frame per packet for now). Each packet is sealed and header-protected and
-    /// appended to the outbound queue. Idempotent when nothing is pending.
-    pub fn flushSend(self: *Connection) Error!void {
+    /// appended to the outbound queue. `now` is the monotonic microsecond send
+    /// time, recorded so an incoming ACK measures RTT correctly. Idempotent when
+    /// nothing is pending.
+    pub fn flushSend(self: *Connection, now: u64) Error!void {
         const space = Space.initial;
         const st = &self.spaces[@intFromEnum(space)];
         const keys = st.send_keys orelse return; // no send keys for this space yet
@@ -346,7 +348,7 @@ pub const Connection = struct {
                 // a conservative max datagram; one STREAM frame per packet for now.
                 const room = constants.MIN_INITIAL_DATAGRAM - 64;
                 const chunk = s.peek(room) orelse break;
-                try self.buildStreamPacket(keys, st, id, chunk);
+                try self.buildStreamPacket(keys, st, id, chunk, now);
                 s.commit(chunk.data.len, chunk.fin);
             }
         }
@@ -354,14 +356,16 @@ pub const Connection = struct {
 
     /// Build one Initial-space packet carrying a single STREAM frame, seal and
     /// protect it, and append it (and its length) to the outbound queue.
-    fn buildStreamPacket(self: *Connection, keys: crypto.Keys, st: *SpaceState, id: u64, chunk: stream.SendStream.Chunk) Error!void {
+    fn buildStreamPacket(self: *Connection, keys: crypto.Keys, st: *SpaceState, id: u64, chunk: stream.SendStream.Chunk, now: u64) Error!void {
         // Frame the STREAM data.
         var frames: std.ArrayListUnmanaged(u8) = .empty;
         defer frames.deinit(self.gpa);
         frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
 
         const pn = st.next_pn;
-        const pn_len: usize = 1; // 1-byte pn for the first cut (matches testBuildInitial)
+        // The packet number needs enough bytes that the peer's window resolves it
+        // unambiguously against the largest it has acked (RFC 9000 17.1).
+        const pn_len = packet.packetNumberLen(pn, st.rec.largest_acked);
         const length = pn_len + frames.items.len + crypto.TAG_LEN;
 
         // Header through the Length field (Initial: empty scid/token here).
@@ -380,8 +384,9 @@ pub const Connection = struct {
         const datagram_len = self.out.items.len - start;
         self.out_lengths.append(self.gpa, datagram_len) catch return error.OutOfMemory;
 
-        // Register the sent packet so an incoming ACK clears the in-flight set.
-        st.rec.onSent(self.gpa, .{ .pn = pn, .sent_time = 0, .size = datagram_len, .ack_eliciting = true, .in_flight = true }) catch return error.OutOfMemory;
+        // Register the sent packet so an incoming ACK clears the in-flight set and
+        // measures RTT against the real send time.
+        st.rec.onSent(self.gpa, .{ .pn = pn, .sent_time = now, .size = datagram_len, .ack_eliciting = true, .in_flight = true }) catch return error.OutOfMemory;
         self.cc.onSent(datagram_len);
         st.next_pn += 1;
     }
@@ -493,7 +498,7 @@ test "a server-sent STREAM round-trips to a peer client" {
     var server = try Connection.init(gpa, .server, &dcid);
     defer server.deinit();
     try server.sendStreamData(0, "hi", true);
-    try server.flushSend();
+    try server.flushSend(1000);
     const lengths = server.datagramLengths();
     try testing.expectEqual(@as(usize, 1), lengths.len);
     const dgram = server.datagramsToSend();
@@ -512,7 +517,7 @@ test "flushSend with nothing queued is a no-op" {
     var conn = try Connection.init(gpa, .server, &dcid);
     defer conn.deinit();
     try testing.expect(!conn.hasPendingSend());
-    try conn.flushSend();
+    try conn.flushSend(1000);
     try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
 }
 
@@ -525,7 +530,7 @@ test "a multi-chunk response round-trips in order" {
     // flush, so two STREAM frames at offsets 0 and 5 reassemble to "helloworld".
     try server.sendStreamData(3, "hello", false);
     try server.sendStreamData(3, "world", true);
-    try server.flushSend();
+    try server.flushSend(1000);
     const dgram = server.datagramsToSend();
 
     var client = try Connection.init(gpa, .client, &dcid);
@@ -535,13 +540,81 @@ test "a multi-chunk response round-trips in order" {
     try testing.expect(client.streamFinished(3));
 }
 
+test "a response larger than one packet splits and reassembles in order" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xaa, 0xbb, 0xcc, 0xdd };
+    var server = try Connection.init(gpa, .server, &dcid);
+    defer server.deinit();
+    // 3000 bytes forces more than one packet (room is ~1136), so later STREAM
+    // frames carry a nonzero offset - exercising the OFF-bit and cross-packet
+    // offset accounting.
+    var body: [3000]u8 = undefined;
+    for (&body, 0..) |*b, i| b.* = @intCast(i % 251);
+    try server.sendStreamData(0, &body, true);
+    try server.flushSend(1000);
+    const lengths = server.datagramLengths();
+    try testing.expect(lengths.len >= 3);
+
+    // Feed each datagram to the peer client separately (one UDP payload at a time).
+    var client = try Connection.init(gpa, .client, &dcid);
+    defer client.deinit();
+    const all = server.datagramsToSend();
+    var off: usize = 0;
+    for (lengths) |len| {
+        try client.receiveDatagram(all[off .. off + len], 1000);
+        off += len;
+    }
+    try testing.expectEqualSlices(u8, &body, client.streamData(0));
+    try testing.expect(client.streamFinished(0));
+}
+
+test "packet numbers past one byte still decrypt on the peer" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
+    var server = try Connection.init(gpa, .server, &dcid);
+    defer server.deinit();
+    var client = try Connection.init(gpa, .client, &dcid);
+    defer client.deinit();
+    // Send 200 single-byte responses, each its own flush, so the packet number
+    // climbs past 127 and pn_len grows to 2. Each must still decrypt on the peer.
+    var k: usize = 0;
+    while (k < 200) : (k += 1) {
+        const id: u64 = @as(u64, k) * 4; // distinct client-initiated bidi stream ids
+        try server.sendStreamData(id, "x", true);
+        try server.flushSend(1000);
+        const lengths = server.datagramLengths();
+        const all = server.datagramsToSend();
+        var off: usize = 0;
+        for (lengths) |len| {
+            try client.receiveDatagram(all[off .. off + len], 1000);
+            off += len;
+        }
+        try testing.expectEqualStrings("x", client.streamData(id));
+        server.clearSend();
+    }
+    // The server's Initial-space packet number is now past the 1-byte boundary.
+    try testing.expect(server.spaces[@intFromEnum(Space.initial)].next_pn > 127);
+}
+
+test "writing after a FIN is a final-size error" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x01, 0x02, 0x03, 0x04 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    try conn.sendStreamData(0, "done", true); // FIN
+    // Data after the FIN would push past the final size: rejected.
+    try testing.expectError(error.FinalSizeError, conn.sendStreamData(0, "more", false));
+    // A bare repeat FIN with no new bytes is harmless and idempotent.
+    try conn.sendStreamData(0, "", true);
+}
+
 test "clearSend drops the drained datagrams" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x05, 0x06, 0x07, 0x08 };
     var conn = try Connection.init(gpa, .server, &dcid);
     defer conn.deinit();
     try conn.sendStreamData(0, "x", true);
-    try conn.flushSend();
+    try conn.flushSend(1000);
     try testing.expect(conn.datagramsToSend().len > 0);
     conn.clearSend();
     try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -205,8 +205,11 @@ pub const SendStream = struct {
         self.unsent.deinit(self.gpa);
     }
 
-    /// Queue `data` to be sent and/or mark the stream finished.
+    /// Queue `data` to be sent and/or mark the stream finished. Writing after the
+    /// stream has been finished (FIN owed or sent) would push bytes past the
+    /// declared final size (RFC 9000 4.5), so it is rejected.
     pub fn write(self: *SendStream, data: []const u8, fin: bool) Error!void {
+        if (self.fin and (data.len != 0 or !fin)) return error.FinalSizeError;
         self.unsent.appendSlice(self.gpa, data) catch return error.OutOfMemory;
         if (fin) self.fin = true;
     }

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -180,6 +180,63 @@ pub const RecvStream = struct {
     }
 };
 
+/// The send half of a stream: an outbound byte buffer plus the offset already
+/// handed to the framer and whether the local side has finished (FIN owed). The
+/// connection's send path pops chunks from `unsent`, frames them as STREAM
+/// frames, and advances `send_offset`. Minimal by design - per-stream send-window
+/// (MAX_STREAM_DATA) enforcement is layered on once the peer advertises limits.
+pub const SendStream = struct {
+    gpa: std.mem.Allocator,
+    /// Bytes queued but not yet framed (drained from the front as they are sent).
+    unsent: std.ArrayListUnmanaged(u8) = .empty,
+    /// The offset of the first byte still in `unsent` - what a STREAM frame for the
+    /// next chunk carries.
+    send_offset: u64 = 0,
+    /// The application has finished writing; a FIN is owed on the last frame.
+    fin: bool = false,
+    /// The FIN has been emitted on a frame, so the stream is fully sent.
+    fin_sent: bool = false,
+
+    pub fn init(gpa: std.mem.Allocator) SendStream {
+        return .{ .gpa = gpa };
+    }
+
+    pub fn deinit(self: *SendStream) void {
+        self.unsent.deinit(self.gpa);
+    }
+
+    /// Queue `data` to be sent and/or mark the stream finished.
+    pub fn write(self: *SendStream, data: []const u8, fin: bool) Error!void {
+        self.unsent.appendSlice(self.gpa, data) catch return error.OutOfMemory;
+        if (fin) self.fin = true;
+    }
+
+    /// Whether anything still needs to leave: buffered bytes, or an owed FIN.
+    pub fn pending(self: *const SendStream) bool {
+        return self.unsent.items.len > 0 or (self.fin and !self.fin_sent);
+    }
+
+    /// The next chunk to frame, capped at `max` bytes. Returns the offset, the
+    /// chunk (a slice into `unsent`, valid until the next `commit`), and whether
+    /// this chunk carries the FIN. Call `commit` once the chunk is framed.
+    pub const Chunk = struct { offset: u64, data: []const u8, fin: bool };
+    pub fn peek(self: *const SendStream, max: usize) ?Chunk {
+        const n = @min(max, self.unsent.items.len);
+        const carries_fin = self.fin and !self.fin_sent and n == self.unsent.items.len;
+        if (n == 0 and !carries_fin) return null;
+        return .{ .offset = self.send_offset, .data = self.unsent.items[0..n], .fin = carries_fin };
+    }
+
+    /// Drop the `n` bytes a framed chunk consumed and, if it carried the FIN, mark
+    /// the FIN sent. `n` must be the length of the chunk returned by `peek`.
+    pub fn commit(self: *SendStream, n: usize, sent_fin: bool) void {
+        std.mem.copyForwards(u8, self.unsent.items[0 .. self.unsent.items.len - n], self.unsent.items[n..]);
+        self.unsent.shrinkRetainingCapacity(self.unsent.items.len - n);
+        self.send_offset += n;
+        if (sent_fin) self.fin_sent = true;
+    }
+};
+
 test "stream-id typing reads the low two bits" {
     try std.testing.expectEqual(StreamType.client_bidi, StreamType.of(0));
     try std.testing.expectEqual(StreamType.server_bidi, StreamType.of(1));


### PR DESCRIPTION
Third of the staged HTTP/3 **write side** (after the QPACK encoder #62 and the QUIC serializers #63). This is the critical path - where bytes actually leave the QUIC layer, sealed and header-protected.

### What it adds

- **`stream.SendStream`** - the send half of a stream: an outbound byte buffer, the offset already framed, and an owed FIN. `write` queues, `peek`/`commit` drain chunks. Minimal by design; per-stream send-window (MAX_STREAM_DATA) enforcement layers on once the peer advertises limits.
- **Connection send path**: a send-stream map + an outbound datagram queue.
  - `sendStreamData(id, data, fin)` queues.
  - `flushSend()` packetizes: frame the STREAM data, build an Initial-space long header (`packet.writeLongHeader` from #63), place the packet number, seal (AEAD), apply header protection - the exact inverse of `receiveDatagram`, and what `testBuildInitial` does inline.
  - `datagramsToSend()` / `datagramLengths()` / `clearSend()` - the drain API.
  - Sent packets register with recovery + congestion via `onSent`, so an incoming ACK keeps the in-flight set consistent.

### Scope / follow-ups

Initial key space, one STREAM frame per packet, 1-byte packet numbers. **Retransmission, PTO/pacing, and the 1-RTT short-header path are follow-ups** (the latter needs the TLS handshake driver). This is the smallest correct send path.

### Tested by round-trip

A server seals a STREAM that a peer **client** decrypts and reassembles through the existing receive path - the inverse of how `testBuildInitial` validates the read path. 4 tests: single response round-trips, a multi-chunk response reassembles in order with the FIN, a no-op flush, and `clearSend`.

Next: the H3 connection `sendResponse`/`sendData`/`endStream` build on `sendStreamData`, then the Python adapter.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.