### PR TITLE
Update README to reflect HTTP/2 and HTTP/3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 </p>
 
 > [!WARNING]
-> zttp is experimental. The API and behaviour may change at any time, and it is not yet ready for production use.
+> **zttp** is experimental. The API and behaviour may change at any time, and it is not yet ready for production use.
 
-A [sans-IO](https://sans-io.readthedocs.io/) HTTP parser for Python, with a core
-written in [Zig](https://ziglang.org). It is to [h11](https://github.com/python-hyper/h11)
-what [zloop](https://github.com/Kludex/zloop) is to asyncio: the same clean,
-event-based API, with a hand-written Zig engine underneath - fast enough to be
-usable as the HTTP/1.1 parser in [uvicorn](https://github.com/encode/uvicorn).
+A [sans-IO](https://sans-io.readthedocs.io/) HTTP/1.1, HTTP/2, and HTTP/3 parser
+for Python, with a core written in [Zig](https://ziglang.org). It is to
+[h11](https://github.com/python-hyper/h11) what [zloop](https://github.com/Kludex/zloop)
+is to asyncio: the same clean, event-based API, with a hand-written Zig engine
+underneath that is fast enough to be the HTTP parser in
+[uvicorn](https://github.com/encode/uvicorn). It has no dependencies.
 
 ## Sans-IO
 
-zttp does no I/O. You feed it bytes and pull out events; you ask it for bytes to
+**zttp** does no I/O. You feed it bytes and pull out events; you ask it for bytes to
 send. It never touches a socket. This is the h11 model:
 
 ```python
@@ -77,37 +78,8 @@ defaults to Zig's safety-checked `ReleaseSafe` mode. Malformed input raises
 The parser has been through two adversarial security audits (a code review and a
 CVE-driven review against real HTTP-parser CVEs across Node, Go, Python, Rust, and
 C servers); `zig build fuzz` runs the adversarial-input net over the core. See
-[THREAT_MODEL.md](THREAT_MODEL.md) for what zttp defends against and what the
+[THREAT_MODEL.md](THREAT_MODEL.md) for what **zttp** defends against and what the
 integrator is responsible for.
-
-## Roadmap
-
-- **HTTP/1.1** - request and response parsing, chunked transfer-coding,
-  trailers, keep-alive, the bidirectional connection state machine. *(done)*
-- **Connection state policy** - h11-parity state machine guards on the read side
-  (reject body bytes after a `close`, enforce request/response pairing).
-- **uvicorn integration** - an `HttpToolsProtocol`-style adapter so uvicorn can
-  use zttp unchanged.
-- **HTTP/2** - HPACK, the frame layer, and the multiplexed connection state
-  machine in the Zig core, surfaced through the same event API
-  (`Connection(role, protocol=zttp.HTTP2)`); events carry a `stream_id`. Both
-  read paths (server requests, client responses) and the full write side - a
-  `Stream` handle per stream, with outbound flow control - are implemented. *(done)*
-- **HTTP/3** - a from-scratch QUIC transport in the Zig core (packets, RFC 9001
-  packet protection on `std.crypto`, loss recovery, NewReno congestion control,
-  flow control, and stream reassembly) plus the HTTP/3 framing and QPACK, surfaced
-  through the same event API (`Connection(role, protocol=zttp.HTTP3)`);
-  `receive_datagram` / `datagrams_to_send` carry the UDP payloads and events carry
-  a `stream_id`. The server read path is implemented end-to-end - through Python, a
-  real client Initial datagram is decrypted and decoded into request events. The
-  TLS 1.3 handshake driver (only the Initial key space is wired today), the write
-  side, and the client read path are next; the QPACK dynamic table is intentionally
-  disabled (we advertise `MAX_TABLE_CAPACITY = 0`). *(in progress)*
-
-## Status
-
-Alpha. The HTTP/1.1 parser and serializer are implemented and tested; the API
-may still change.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@
 > **zttp** is experimental. The API and behaviour may change at any time, and it is not yet ready for production use.
 
 A [sans-IO](https://sans-io.readthedocs.io/) HTTP/1.1, HTTP/2, and HTTP/3 parser
-for Python, with a core written in [Zig](https://ziglang.org). It is to
-[h11](https://github.com/python-hyper/h11) what [zloop](https://github.com/Kludex/zloop)
-is to asyncio: the same clean, event-based API, with a hand-written Zig engine
-underneath that is fast enough to be the HTTP parser in
-[uvicorn](https://github.com/encode/uvicorn). It has no dependencies.
+for Python, with a core written in [Zig](https://ziglang.org). It offers the same
+clean, event-based API as [h11](https://github.com/python-hyper/h11), with a
+hand-written Zig engine underneath that is fast enough to be the HTTP parser in
+[uvicorn](https://github.com/encode/uvicorn). **It has no dependencies.**
 
 ## Sans-IO
 

--- a/docs/architecture/http3.md
+++ b/docs/architecture/http3.md
@@ -4,7 +4,7 @@ icon: lucide/network
 
 # HTTP/3 and QUIC
 
-HTTP/3 reaches the same sans-IO pull API as HTTP/1.1 and HTTP/2 - you pick the
+HTTP/3 reaches the same sans-IO pull API as HTTP/1.1 and HTTP/2; you pick the
 protocol at construction:
 
 ```python
@@ -27,18 +27,18 @@ itself.
 The sans-IO discipline is unchanged: the core never touches a socket. The I/O
 layer feeds it UDP datagrams with `receive_datagram` and drains the datagrams it
 wants to send with `datagrams_to_send`. The boundary moved from "decrypted byte
-stream" (TCP) down to "UDP datagram" (QUIC), but the shape - bytes in, events and
-bytes out, no I/O in the core - is identical.
+stream" (TCP) down to "UDP datagram" (QUIC), but the shape (bytes in, events and
+bytes out, no I/O in the core) is identical.
 
 ## The layer cake
 
 ```mermaid
 flowchart TB
-    h3["h3/ — HTTP/3 framing + QPACK<br/>(maps onto the pull event API)"]
-    streams["quic/stream — stream multiplexing, flow control"]
-    recovery["quic/recovery + congestion — loss detection, CC"]
-    crypto["quic/crypto — TLS 1.3, packet protection (AEAD)"]
-    packet["quic/packet — long/short headers, frames, varints"]
+    h3["h3/: HTTP/3 framing + QPACK<br/>(maps onto the pull event API)"]
+    streams["quic/stream: stream multiplexing, flow control"]
+    recovery["quic/recovery + congestion: loss detection, CC"]
+    crypto["quic/crypto: TLS 1.3, packet protection (AEAD)"]
+    packet["quic/packet: long/short headers, frames, varints"]
     udp["UDP datagrams (the I/O layer's job)"]
 
     udp --> packet --> crypto --> recovery --> streams --> h3
@@ -47,56 +47,56 @@ flowchart TB
 Each layer is pure Zig and tested on its own, exactly like the H1 and H2 cores.
 Bottom-up, the pieces are:
 
-### `quic/` - the transport
+### `quic/`: the transport
 
-* **`varint`** - QUIC's 1/2/4/8-byte variable-length integer (RFC 9000 §16). The
+* **`varint`**: QUIC's 1/2/4/8-byte variable-length integer (RFC 9000 §16). The
   most-used primitive in the whole stack: every frame field, every packet number,
   every stream id is a varint.
-* **`packet`** - the long-header (Initial / Handshake / 0-RTT / Retry) and
+* **`packet`**: the long-header (Initial / Handshake / 0-RTT / Retry) and
   short-header (1-RTT) packet formats, packet-number encoding/decoding, and the
   QUIC frame codec (the ~20 frame types: PADDING, PING, ACK, CRYPTO, STREAM,
   RESET_STREAM, MAX_DATA, CONNECTION_CLOSE, ...).
-* **`crypto`** - the AEAD packet protection: header protection and payload
+* **`crypto`**: the AEAD packet protection: header protection and payload
   encryption (AES-128-GCM / HKDF-SHA256 on `std.crypto`), with the deterministic
   Initial keys matching RFC 9001 appendix A byte for byte. This is the
   load-bearing security layer: a bug here is a transport-security bug, not just a
   parse bug. The Handshake and Application key spaces install through an
   `installKeys` seam; the TLS 1.3 handshake driver that derives them through
   QUIC's CRYPTO frames is the follow-up, so only the Initial space is keyed today.
-* **`recovery`** - RFC 9002 loss detection: per-packet-number-space ack tracking,
+* **`recovery`**: RFC 9002 loss detection: per-packet-number-space ack tracking,
   RTT estimation, the probe-timeout (PTO) timer, and which packets to retransmit.
-* **`congestion`** - the NewReno controller (slow start, congestion avoidance,
+* **`congestion`**: the NewReno controller (slow start, congestion avoidance,
   recovery) gating how much in-flight data the sender allows.
-* **`flow`** - connection-level and stream-level flow control (MAX_DATA /
+* **`flow`**: connection-level and stream-level flow control (MAX_DATA /
   MAX_STREAM_DATA / MAX_STREAMS accounting), the QUIC backpressure mechanism.
-* **`stream`** - the QUIC stream layer: send/recv state machines, reassembly of
+* **`stream`**: the QUIC stream layer: send/recv state machines, reassembly of
   out-of-order STREAM frames into an ordered byte run per stream, and stream-id
   typing (client/server, bidi/uni).
-* **`connection`** - the transport orchestrator: ties the packet, crypto,
+* **`connection`**: the transport orchestrator: ties the packet, crypto,
   recovery, congestion, flow, and stream layers into one connection, and exposes
   "give me the next ordered bytes for stream N" upward to `h3/`.
 
-### `h3/` - the HTTP/3 layer
+### `h3/`: the HTTP/3 layer
 
-On top of ordered QUIC stream bytes, HTTP/3 is comparatively small - it is HTTP/2
+On top of ordered QUIC stream bytes, HTTP/3 is comparatively small: it is HTTP/2
 without the parts QUIC already provides (no connection-level framing for
 multiplexing, no flow control, no `PING`; those moved down into QUIC).
 
-* **`frame`** - the HTTP/3 frame codec. Frames are dead simple: a varint type, a
+* **`frame`**: the HTTP/3 frame codec. Frames are dead simple: a varint type, a
   varint length, a payload. The types are DATA, HEADERS, SETTINGS, GOAWAY,
   MAX_PUSH_ID, CANCEL_PUSH, PUSH_PROMISE.
-* **`stream`** - HTTP/3 stream typing: the unidirectional control stream (carries
+* **`stream`**: HTTP/3 stream typing: the unidirectional control stream (carries
   SETTINGS), the QPACK encoder/decoder streams, and the bidirectional request
   streams. The first byte of each uni stream is a varint stream type.
-* **`qpack/`** - QPACK (RFC 9204), the HTTP/3 header compression. Like HPACK but
+* **`qpack/`**: QPACK (RFC 9204), the HTTP/3 header compression. Like HPACK but
   redesigned so head-of-line blocking across QUIC streams is avoidable: a static
-  table, a Huffman code (the same one as HPACK, Appendix B of RFC 7541), and -
-  full QPACK only - a dynamic table whose updates ride dedicated encoder/decoder
+  table, a Huffman code (the same one as HPACK, Appendix B of RFC 7541), and (full
+  QPACK only) a dynamic table whose updates ride dedicated encoder/decoder
   streams. The decoder here covers the static table and literals; the dynamic
   table is intentionally disabled (we advertise `QPACK_MAX_TABLE_CAPACITY = 0`, so
   a conformant peer must not emit dynamic references), which also sidesteps the
   "blocked stream" case. Enabling the dynamic table is a follow-up.
-* **`connection`** - the orchestrator: classifies incoming streams, runs the
+* **`connection`**: the orchestrator: classifies incoming streams, runs the
   SETTINGS exchange, reassembles HEADERS (QPACK-decoded) + DATA into the shared
   `Request` / `Data` / `EndOfMessage` events, and surfaces the H3 control events.
 
@@ -105,14 +105,14 @@ multiplexing, no flow control, no `PING`; those moved down into QUIC).
 The multiplexing problem is the same as HTTP/2's and gets the same answer: a
 single, arrival-ordered event queue where every event carries a `stream_id`, and
 the caller demuxes on it. QUIC stream ids are 62-bit varints (not H2's 31-bit), so
-`stream_id` widens to a `u64`, but the contract - one event per `next_event`, flat
-queue, demux on `stream_id` - is byte-for-byte the H2 contract.
+`stream_id` widens to a `u64`, but the contract (one event per `next_event`, flat
+queue, demux on `stream_id`) is byte-for-byte the H2 contract.
 
 The `Request` / `Response` / `Data` / `EndOfMessage` payloads are **shared** with
 HTTP/1.1 and HTTP/2: an H3 request collapses its pseudo-headers (`:method`,
 `:path`, `:scheme`, `:authority`) into the same shape H2 uses. HTTP/3 gets its own
 event union (`H3Event`) for the control events it actually has (`Settings`,
-`Goaway`), exactly as H2 has `H2Event` - so each protocol's surface is exactly as
+`Goaway`), exactly as H2 has `H2Event`, so each protocol's surface is exactly as
 wide as its reality.
 
 ## Where the I/O boundary sits
@@ -128,17 +128,17 @@ packets share a datagram), so HTTP/3 takes `receive_datagram(bytes)` and emits
 QUIC folds transport security into the protocol, so the threat surface is larger
 than a pure parser's. The defenses live in the core:
 
-* **Packet protection** - every 1-RTT packet is AEAD-authenticated; a forged or
+* **Packet protection**: every 1-RTT packet is AEAD-authenticated; a forged or
   tampered packet fails the AEAD tag and is dropped, not parsed.
-* **Amplification limit** - before the peer's address is validated, the server
+* **Amplification limit**: before the peer's address is validated, the server
   sends at most 3x the bytes it received (RFC 9000 §8.1), defeating reflection
   amplification.
-* **Flow control** - per-stream and connection MAX_DATA caps bound how much a peer
+* **Flow control**: per-stream and connection MAX_DATA caps bound how much a peer
   can make the receiver buffer.
-* **Stream and frame limits** - MAX_STREAMS caps concurrency; the QPACK
+* **Stream and frame limits**: MAX_STREAMS caps concurrency; the QPACK
   decoded-size cap and dynamic-table ceiling defend the QPACK bomb the same way
   the HPACK caps do.
-* **Stateless reset and retry** - handled in the packet layer so a malformed or
+* **Stateless reset and retry**: handled in the packet layer so a malformed or
   spoofed Initial cannot wedge the connection.
 
 As everywhere else in zttp, a fatal transport or protocol error poisons the
@@ -146,9 +146,9 @@ connection terminally.
 
 ## Scope
 
-QUIC and HTTP/3 are large. The work lands bottom-up - varints and packets first,
+QUIC and HTTP/3 are large. The work lands bottom-up: varints and packets first,
 then crypto, then recovery and congestion, then streams, then the HTTP/3 framing
-and QPACK on top - each layer tested in isolation before the next builds on it.
+and QPACK on top, each layer tested in isolation before the next builds on it.
 The server read path landed first (the uvicorn-critical direction), mirroring how
 HTTP/2 was staged: a real client Initial datagram is decrypted and decoded into
 request events through the public `receive_datagram` / `next_event` API. The TLS

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -37,21 +37,21 @@ tests live, and it builds and runs entirely on its own with `zig build test`.
 
 The pieces:
 
-* **`scanner`** - the byte-level primitives (find a line ending, slice a token),
+* **`scanner`**: the byte-level primitives (find a line ending, slice a token),
   with a SWAR scan for newlines.
-* **`headers`** - parse the request/status line and header fields.
-* **`framing`** - decide how a body is delimited (Content-Length vs chunked), and
+* **`headers`**: parse the request/status line and header fields.
+* **`framing`**: decide how a body is delimited (Content-Length vs chunked), and
   reject the ambiguous combinations that enable request smuggling.
-* **`chunked`** - a resumable decoder for the chunked transfer-coding, trailers
+* **`chunked`**: a resumable decoder for the chunked transfer-coding, trailers
   included.
-* **`reader`** - the read-side state machine. Owns the growing input buffer,
+* **`reader`**: the read-side state machine. Owns the growing input buffer,
   tracks how far parsing has progressed, and emits events.
-* **`writer`** - the mirror: serialize a head, body, and trailers to bytes.
-* **`h2/`** - the HTTP/2 layer (see [below](#http2)): a frame codec, HPACK, a
+* **`writer`**: the mirror, serializing a head, body, and trailers to bytes.
+* **`h2/`**: the HTTP/2 layer (see [below](#http2)): a frame codec, HPACK, a
   per-stream state machine, and a connection orchestrator, composed the same way.
 
 Because the core is Python-agnostic, every slice it hands out points into a buffer
-it owns - and anything that must outlive the next call is copied into stable
+it owns, and anything that must outlive the next call is copied into stable
 storage. That discipline is what keeps the parser memory-safe under adversarial,
 fragmented input.
 
@@ -59,20 +59,20 @@ fragmented input.
 
 The only code that touches `Python.h`. It's a thin translation layer:
 
-* **`py.zig`** - ergonomic helpers over the CPython C-API (refcounting, building
+* **`py.zig`**: ergonomic helpers over the CPython C-API (refcounting, building
   `bytes`, creating types).
-* **`connection_obj.zig`** - the `Connection` type. A `protocol=` selector backs
+* **`connection_obj.zig`**: the `Connection` type. A `protocol=` selector backs
   it with either the HTTP/1.1 `Reader`+`Writer` or the HTTP/2 engine; both expose
   the same `receive_data` / `next_event` / `send_*` / `data_to_send`.
-* **`events_obj.zig`** - the event types (`Request`, `Data`, ...). It materializes
+* **`events_obj.zig`**: the event types (`Request`, `Data`, ...). It materializes
   the core's byte slices into real Python `bytes` objects so they're safe to keep.
   `fromH1Event` / `fromH2Event` map each protocol's event union onto them.
-* **`exceptions.zig`** - the `ProtocolError` family.
+* **`exceptions.zig`**: the `ProtocolError` family.
 
 ## The package (`zttp/`)
 
 Just the public surface: `Connection`, the roles, the events, the exceptions, and
-the `NEED_DATA` sentinel - with type stubs and a `py.typed` marker.
+the `NEED_DATA` sentinel, with type stubs and a `py.typed` marker.
 
 ## HTTP/2 { #http2 }
 
@@ -86,31 +86,31 @@ conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
 The design problem is that one HTTP/2 connection multiplexes many concurrent
 streams, but `next_event()` is a single, flat pull. The resolution: a **single,
 frame-arrival-ordered queue** where every event carries a `stream_id` and the
-caller demuxes on it. Wire order is forced anyway - HPACK's dynamic table is
+caller demuxes on it. Wire order is forced anyway (HPACK's dynamic table is
 connection-global and order-dependent, so frames must be processed in the order
-they arrive - so a flat queue is the only correct shape. One frame fans out into a
+they arrive), so a flat queue is the only correct shape. One frame fans out into a
 small bounded ring (a `HEADERS` with `END_STREAM` yields `Request` + `EndOfMessage`),
 drained one event per call, which preserves the one-event-per-`next_event` contract
 the H1 reader already has.
 
 The `Request` / `Response` / `Data` / `EndOfMessage` payloads are **shared** with
-HTTP/1.1 (an H2 request collapses its pseudo-headers - `:method` -> method, `:path`
--> target, `:authority` -> a synthesized `host` header - into the same shape), but
+HTTP/1.1 (an H2 request collapses its pseudo-headers into the same shape: `:method`
+-> method, `:path` -> target, `:authority` -> a synthesized `host` header), but
 each protocol has its **own event union** (`H1Event` / `H2Event`): H2 adds the
 control events (`RstStream`, `Goaway`, `Settings`, `Ping`, `WindowUpdate`) and has
 no `connection_closed`, so each protocol's surface is exactly as wide as its reality.
 
 The `h2/` modules compose like the H1 core does:
 
-* **`frame`** - the zero-copy frame codec (the 9-octet header, padding, the 10
+* **`frame`**: the zero-copy frame codec (the 9-octet header, padding, the 10
   frame types) and serializer.
-* **`hpack/`** - the static table, a Huffman decoder, the stateful header-block
+* **`hpack/`**: the static table, a Huffman decoder, the stateful header-block
   decoder (dynamic table + eviction), and a stateless encoder.
-* **`stream`** / **`settings`** - the per-stream state machine (with the exact
+* **`stream`** / **`settings`**: the per-stream state machine (with the exact
   stream-vs-connection error classification) and SETTINGS parsing/validation.
-* **`connection`** - the orchestrator: the preface/SETTINGS handshake, HEADERS +
+* **`connection`**: the orchestrator. The preface/SETTINGS handshake, HEADERS +
   CONTINUATION reassembly, DATA, trailers, flow control, and the control frames.
-* **`writer`** - the write side: handshake, HEADERS/DATA serialization, and the
+* **`writer`**: the write side. Handshake, HEADERS/DATA serialization, and the
   control frames.
 
 The known HTTP/2 denial-of-service classes are defended in the core: the
@@ -123,7 +123,7 @@ side.
 ## Why Zig
 
 Zig gives a small, dependency-free C-ABI extension with manual control over memory
-and layout - the things that make a parser fast - without the build complexity of
+and layout (the things that make a parser fast) without the build complexity of
 C++ or the overhead of a heavier runtime. The same Zig source cross-compiles to
 every platform's wheel, and the safety-checked build mode turns would-be
 memory bugs into clean, trapped errors.

--- a/docs/architecture/sans-io.md
+++ b/docs/architecture/sans-io.md
@@ -4,13 +4,13 @@ icon: lucide/unplug
 
 # Why sans-IO
 
-zttp does no I/O. That's not a limitation - it's the design. This page explains
+zttp does no I/O. That's not a limitation; it's the design. This page explains
 what that means and why it's the right shape for a parser.
 
 ## The problem with a parser that does I/O
 
 Most parsers are tangled up with how the bytes arrive. They read from a socket, or
-they call you back - `on_header(name, value)`, `on_body(chunk)` - and now your
+they call you back (`on_header(name, value)`, `on_body(chunk)`), and now your
 application logic lives inside the parser's callbacks. You don't control the flow
 anymore; the parser does. Want to use it with threads instead of asyncio? With a
 test that feeds canned bytes? With a new async library? You're rewriting glue.
@@ -28,7 +28,7 @@ and the control flow; zttp owns only the protocol.
 
 ```python
 conn = zttp.Connection(zttp.SERVER)
-conn.receive_data(raw)        # bytes from wherever - socket, file, test
+conn.receive_data(raw)        # bytes from wherever: socket, file, test
 event = conn.next_event()     # pull, when you want it
 ```
 
@@ -62,8 +62,8 @@ a callback parser: you give it a protocol object with `on_url`, `on_header`,
 `on_body`, ... and it calls them as it parses. It's fast, but the control flow is
 inverted into your callbacks, and the body gets copied per callback.
 
-zttp keeps the performance of a native engine - it's written in Zig (see
-[Performance](../reference/performance.md)) - but gives you the cleaner pull API,
+zttp keeps the performance of a native engine, since it's written in Zig (see
+[Performance](../reference/performance.md)), but gives you the cleaner pull API,
 and emits each body span as a single `Data` event instead of a stream of
 callbacks.
 
@@ -76,5 +76,5 @@ callbacks.
 
 !!! tip
     If you know [h11](https://github.com/python-hyper/h11), you already know
-    zttp's shape - it's the same `Connection` / `receive_data` / `next_event`
+    zttp's shape: it's the same `Connection` / `receive_data` / `next_event`
     model, with a Zig engine instead of pure Python.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,25 +19,26 @@ icon: lucide/zap
 ---
 
 zttp is a [sans-IO](https://sans-io.readthedocs.io/) HTTP parser whose engine
-is written in [Zig](https://ziglang.org). It speaks **HTTP/1.1 and HTTP/2**, and
-it does **no I/O of its own**: you feed it bytes and pull out events, and you ask
-it for bytes to send. It never touches a socket - so it works with any I/O you
-like (asyncio, threads, a green-thread library, a test harness), and it's a joy
-to test.
+is written in [Zig](https://ziglang.org). It speaks **HTTP/1.1, HTTP/2, and
+HTTP/3**, and it does **no I/O of its own**: you feed it bytes and pull out
+events, and you ask it for bytes to send. It never touches a socket, so it works
+with any I/O you like (asyncio, threads, a green-thread library, a test harness),
+and it's a joy to test.
 
 It's the same idea as [h11](https://github.com/python-hyper/h11), with a
-hand-written Zig engine underneath instead of pure Python.
+hand-written Zig engine underneath instead of pure Python. **It has no
+dependencies.**
 
 The key features are:
 
 * **Sans-IO**: a clean, event-based API. Feed bytes with `receive_data`, pull
   `Request` / `Data` / `EndOfMessage` events with `next_event`. No callbacks, no
   sockets, no surprises.
-* **HTTP/1.1 and HTTP/2**: the *same* event API for both. Pass
-  `protocol=zttp.HTTP2` and you get multiplexed streams, HPACK, and flow control -
-  see [HTTP/2](usage/http2.md).
+* **HTTP/1.1, HTTP/2, and HTTP/3**: the *same* event API for all three. Pass
+  `protocol=zttp.HTTP2` and you get multiplexed streams, HPACK, and flow control
+  (see [HTTP/2](usage/http2.md)).
 * **Fast**: a hand-written Zig engine with branch-light scanning and minimal
-  allocation - see [Performance](reference/performance.md) for the numbers.
+  allocation (see [Performance](reference/performance.md) for the numbers).
 * **Safe**: strict by default. It defends against request smuggling, rejects bare
   `LF` line endings, bounds every buffer, and ships in Zig's safety-checked build.
 * **Typed**: a `py.typed` package with full type hints. Your editor knows every
@@ -82,11 +83,11 @@ print(conn.next_event())
 #> EndOfMessage(trailers=[])
 ```
 
-1.  A `Connection` is the one object you need. Tell it your role - `SERVER` (you
+1.  A `Connection` is the one object you need. Tell it your role: `SERVER` (you
     receive requests) or `CLIENT` (you receive responses).
 
-2.  Feed it whatever bytes you have. A whole request, half a request, one byte -
-    it doesn't matter. zttp buffers and resumes.
+2.  Feed it whatever bytes you have. A whole request, half a request, a single
+    byte: it doesn't matter. zttp buffers and resumes.
 
 3.  Pull events out one at a time. Each call returns the next complete event, or
     the `NEED_DATA` sentinel when it needs more bytes.
@@ -100,12 +101,12 @@ b'GET' b'/hello?name=you'
 EndOfMessage(trailers=[])
 ```
 
-That's it. The buffering, the header parsing, the body framing - all Zig. 🎉
+That's it. The buffering, the header parsing, the body framing: all Zig. 🎉
 
 !!! tip
     Notice there were **no callbacks**. You don't register `on_header` /
     `on_body` functions and lose control of the flow. You *pull* events when
-    *you* are ready. That's what sans-IO means - read
+    *you* are ready. That's what sans-IO means. Read
     [Why sans-IO](architecture/sans-io.md) for the why.
 
 ## Where to go next

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,7 +9,7 @@ importable straight from `zttp` (e.g. `from zttp import Connection`).
 
 ## Connection
 
-`zttp.Connection` is the base - the read side, shared by both protocols.
+`zttp.Connection` is the base: the read side, shared by both protocols.
 Constructing one returns the subclass for the protocol you picked: an
 `H1Connection` (the default) or an `H2Connection`, so the send surface you get
 matches the protocol.
@@ -20,7 +20,7 @@ matches the protocol.
 
 ::: zttp.H2Connection
 
-A `Stream` is the per-stream send handle on an HTTP/2 connection - see
+A `Stream` is the per-stream send handle on an HTTP/2 connection; see
 [HTTP/2](../usage/http2.md).
 
 ::: zttp.Stream
@@ -29,10 +29,10 @@ A `Stream` is the per-stream send handle on an HTTP/2 connection - see
 
 A `Connection`'s role and protocol are fixed at construction:
 
-- `zttp.SERVER` - you receive requests, send responses.
-- `zttp.CLIENT` - you send requests, receive responses.
-- `zttp.HTTP1` *(default)* - one message at a time; you send on the connection.
-- `zttp.HTTP2` - multiplexed streams; you send on a `Stream`.
+- `zttp.SERVER`: you receive requests, send responses.
+- `zttp.CLIENT`: you send requests, receive responses.
+- `zttp.HTTP1` *(default)*: one message at a time; you send on the connection.
+- `zttp.HTTP2`: multiplexed streams; you send on a `Stream`.
 
 ## Events
 
@@ -66,7 +66,7 @@ the ones that matter on its own; they're here when you want visibility.
 
 | Value | Meaning |
 | --- | --- |
-| `zttp.NEED_DATA` | No complete event yet - feed more bytes. Compare with `is`. |
+| `zttp.NEED_DATA` | No complete event yet; feed more bytes. Compare with `is`. |
 | `zttp.CONNECTION_CLOSED` | The peer closed the connection. Compare with `is`. |
 
 ## Exceptions

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -5,7 +5,7 @@ icon: lucide/gauge
 # Performance
 
 The point of writing a parser in Zig is to be fast. Here's where zttp stands, how
-it's measured, and the caveats - because a benchmark with no methodology is just a
+it's measured, and the caveats, because a benchmark with no methodology is just a
 number.
 
 ## The numbers
@@ -24,7 +24,7 @@ than h11. Measured on an Apple Silicon machine with CPython 3.14 and the
 safety-checked (`ReleaseSafe`) build.
 
 !!! info "These are parser microbenchmarks"
-    They measure parsing throughput in isolation - not a full server. In a real
+    They measure parsing throughput in isolation, not a full server. In a real
     application the parser is one slice of the request cost; treat these as the
     ceiling the parser contributes, not end-to-end numbers.
 
@@ -45,13 +45,13 @@ before timing, so the comparison is apples to apples.
   branch-light array lookups, not per-byte conditionals.
 * **One `Data` event per body span.** httptools copies the body per callback, and
   uvicorn then concatenates; zttp slices the buffer once.
-* **The header list is built in Zig.** No per-header Python callback - the whole
+* **The header list is built in Zig.** No per-header Python callback: the whole
   `list[tuple[bytes, bytes]]` is constructed in the extension.
 
 ## The honest caveat: safety has a cost
 
 zttp ships in Zig's `ReleaseSafe` mode, which keeps bounds and overflow checks on.
-The unchecked `ReleaseFast` mode is roughly 10% faster again - but for a parser
+The unchecked `ReleaseFast` mode is roughly 10% faster again, but for a parser
 eating untrusted network bytes, those checks turn a would-be memory bug into a
 clean trap. We chose safety, and zttp still beats httptools. That trade is the
 right one for this library.

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -24,7 +24,7 @@ import zttp
 try:
     conn.next_event()
 except zttp.RemoteProtocolError:
-    ...  # the client sent garbage - reply 400 and close
+    ...  # the client sent garbage: reply 400 and close
 ```
 
 ## `RemoteProtocolError`: the peer is wrong
@@ -47,7 +47,7 @@ What zttp rejects (a partial list):
 * **Request smuggling**: `Content-Length` together with `Transfer-Encoding`,
   conflicting duplicate `Content-Length`, or a `chunked` coding that isn't the
   final one (even split across multiple `Transfer-Encoding` lines).
-* A bare `LF` line ending (zttp wants `CRLF` - see the tip below).
+* A bare `LF` line ending (zttp wants `CRLF`, see the tip below).
 * A malformed chunk size or chunk framing.
 * A message that blows past a configured size limit.
 
@@ -59,7 +59,7 @@ What zttp rejects (a partial list):
 ## `LocalProtocolError`: you are wrong
 
 Raised from the **send** side when you call it in a way that can't produce a valid
-message - sending a body before a head, two heads in a row, or a field with
+message: sending a body before a head, two heads in a row, or a field with
 control characters in it:
 
 ```python

--- a/docs/usage/first-steps.md
+++ b/docs/usage/first-steps.md
@@ -15,8 +15,8 @@ conn = zttp.Connection(zttp.SERVER)
 A `Connection` holds the parse state for **one** HTTP connection. You tell it your
 role when you create it:
 
-* `zttp.SERVER` - you receive **requests** and send **responses**.
-* `zttp.CLIENT` - you send **requests** and receive **responses**.
+* `zttp.SERVER`: you receive **requests** and send **responses**.
+* `zttp.CLIENT`: you send **requests** and receive **responses**.
 
 The whole read side is just two calls.
 
@@ -29,7 +29,7 @@ conn.receive_data(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
 ```
 
 You can feed a whole message, or a fragment, or a single byte. zttp buffers what
-it has and resumes where it left off - so the network can chop your data up
+it has and resumes where it left off, so the network can chop your data up
 however it likes.
 
 ```python
@@ -63,7 +63,7 @@ while True:
 
 1.  Each call returns the **next complete event**, in order.
 
-2.  When there isn't a complete event yet, you get the `NEED_DATA` sentinel -
+2.  When there isn't a complete event yet, you get the `NEED_DATA` sentinel:
     your cue to `receive_data` more bytes (or stop).
 
 Run it:
@@ -85,10 +85,10 @@ A server connection yields these, in order, per request:
 | `Request` | The request line + all headers are parsed | `.method`, `.target`, `.path`, `.query`, `.http_version`, `.headers`, `.expect_continue` |
 | `Data` | A chunk of the body is available | `.data` |
 | `EndOfMessage` | The body (and any trailers) finished | `.trailers` |
-| `NEED_DATA` | No complete event yet - feed more | *(it's a sentinel)* |
+| `NEED_DATA` | No complete event yet. Feed more | *(it's a sentinel)* |
 
 !!! tip
-    `next_event()` returns `NEED_DATA` (a singleton) - compare with `is`, not
+    `next_event()` returns `NEED_DATA` (a singleton). Compare with `is`, not
     `==`:
 
     ```python
@@ -97,22 +97,22 @@ A server connection yields these, in order, per request:
     ```
 
 `.target` is the raw request-target; `.path` and `.query` are it split at the
-first `?` (both verbatim - zttp doesn't percent-decode, that's yours to do).
+first `?` (both verbatim: zttp doesn't percent-decode, that's yours to do).
 
 A client connection is the mirror image: you get `Response` (with `.status_code`,
 `.reason`, `.http_version`, `.headers`) instead of `Request`, then the same
 `Data` / `EndOfMessage`.
 
 !!! tip "Same events on HTTP/2"
-    Pass `protocol=zttp.HTTP2` and the read side is unchanged - the *same*
+    Pass `protocol=zttp.HTTP2` and the read side is unchanged: the *same*
     `Request` / `Response` / `Data` / `EndOfMessage`, plus a `.stream_id` on each
     (it's `0` on HTTP/1.1) because one connection now multiplexes many requests.
-    The send side differs - HTTP/2 sends on a stream. See [HTTP/2](http2.md).
+    The send side differs: HTTP/2 sends on a stream. See [HTTP/2](http2.md).
 
 ## Keep-alive
 
 HTTP/1.1 connections are reused. After you've pulled `EndOfMessage` for one
-message, tell the connection to start the next one - unless the peer asked to
+message, tell the connection to start the next one, unless the peer asked to
 close. zttp works that out from the head it parsed, so you don't scan headers:
 
 ```python
@@ -142,6 +142,6 @@ the `Request` event.
 
 You've seen the read side. Next:
 
-* [Parsing in depth](parsing.md) - bodies, chunked encoding, trailers, partial data.
-* [Sending](sending.md) - the write side: build messages, get bytes to send.
-* [Errors](errors.md) - what zttp rejects, and how.
+* [Parsing in depth](parsing.md): bodies, chunked encoding, trailers, partial data.
+* [Sending](sending.md): the write side, building messages and getting bytes to send.
+* [Errors](errors.md): what zttp rejects, and how.

--- a/docs/usage/http2.md
+++ b/docs/usage/http2.md
@@ -6,8 +6,8 @@ icon: lucide/network
 
 You already know the zttp API: feed bytes with `receive_data`, pull events with
 `next_event`, ask for bytes with `data_to_send`. **HTTP/2 is the same API.** You
-opt in with one argument, and the events you already know - `Request`,
-`Response`, `Data`, `EndOfMessage` - come back, now tagged with the stream they
+opt in with one argument, and the events you already know (`Request`,
+`Response`, `Data`, `EndOfMessage`) come back, now tagged with the stream they
 belong to.
 
 ```python
@@ -22,7 +22,7 @@ conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # (1)!
 !!! note "Prior knowledge"
     zttp speaks HTTP/2 over a plain connection (the *prior-knowledge* mode, and
     what you get after ALPN or an upgrade negotiates `h2`). zttp does no I/O and
-    no TLS - it parses and serializes the HTTP/2 framing once you have the bytes.
+    no TLS: it parses and serializes the HTTP/2 framing once you have the bytes.
 
 ## Two connections, one base
 
@@ -42,7 +42,7 @@ isinstance(h2, zttp.Connection)  #> True  (3)!
 ```
 
 1.  An `H1Connection`: the message-scoped send API you saw in
-    [Sending](sending.md) - `send_response`, `send_data`, `end_message`.
+    [Sending](sending.md): `send_response`, `send_data`, `end_message`.
 
 2.  An `H2Connection`: everything is **stream-scoped**, so it has no connection-level
     `send_data`. You send on a [`Stream`](#streams) instead.
@@ -52,7 +52,7 @@ isinstance(h2, zttp.Connection)  #> True  (3)!
 
 !!! tip "Your editor knows"
     Because they're distinct types, calling `h2.send_data(...)` is a **type
-    error**, not a runtime surprise - your editor flags it before you run.
+    error**, not a runtime surprise: your editor flags it before you run.
     HTTP/2 has no single "current message" to send on, so the method simply
     isn't there.
 
@@ -75,24 +75,24 @@ while True:
         print(event.method, event.target, event.stream_id)  # (2)!
 ```
 
-1.  The bytes off the wire - HTTP/2 frames, not text. Feed whole or in fragments,
+1.  The bytes off the wire: HTTP/2 frames, not text. Feed whole or in fragments,
     same as always.
 
 2.  `event.stream_id` tells you which stream this `Request` arrived on. On
     HTTP/1.1 it's `0`; on HTTP/2 it's the real id, and every `Data` /
     `EndOfMessage` for that request carries the same id.
 
-A **client** reads the mirror image - `Response` events instead of `Request` -
+A **client** reads the mirror image (`Response` events instead of `Request`),
 again tagged with the `stream_id` of the request they answer.
 
 ## Streams
 
-In HTTP/2 you don't send "on the connection" - you send **on a stream**. A
+In HTTP/2 you don't send "on the connection": you send **on a stream**. A
 `Stream` is a small handle with the send API scoped to one stream:
 
-* `send_response(status, headers=None)` - a response head.
-* `send_data(data)` - body bytes (flow-controlled, see [below](#flow-control)).
-* `end_message(trailers=None)` - finish the message.
+* `send_response(status, headers=None)`: a response head.
+* `send_data(data)`: body bytes (flow-controlled, see [below](#flow-control)).
+* `end_message(trailers=None)`: finish the message.
 
 The connection owns the real stream state; the `Stream` is just a typed handle to
 it. You get one in two ways, depending on who opens the stream.
@@ -116,7 +116,7 @@ print(client.data_to_send())  # the HTTP/2 frames to put on the wire
 
 1.  `send_request` opens the stream and returns its `Stream`. The version arg is
     ignored (it's always `2`), and `:authority` is derived from your `host`
-    header - so a request you'd build for HTTP/1.1 works unchanged.
+    header, so a request you'd build for HTTP/1.1 works unchanged.
 
 2.  From here you talk to the **stream**, not the connection: `stream.send_data`,
     `stream.end_message`.
@@ -141,7 +141,7 @@ stream.end_message()
 print(server.data_to_send())
 ```
 
-1.  `drain` is just a loop over `next_event` until `NEED_DATA` - the events carry
+1.  `drain` is just a loop over `next_event` until `NEED_DATA`: the events carry
     the `stream_id` you need.
 
 2.  `conn.stream(id)` returns the handle for that stream. The connection already
@@ -149,7 +149,7 @@ print(server.data_to_send())
 
 !!! tip "Many streams at once"
     Because each `Stream` names its own id, you can answer requests in **any
-    order** - hold a handle per in-flight request and respond as each is ready.
+    order**: hold a handle per in-flight request and respond as each is ready.
     Two requests arriving before you answer either is the normal HTTP/2 case, and
     routing the responses is just `server.stream(s1)` and `server.stream(s2)`.
 
@@ -157,7 +157,7 @@ print(server.data_to_send())
 
 HTTP/2 has per-stream and per-connection **send windows**: the peer tells you how
 many body bytes it's willing to receive, and you mustn't send past that. zttp
-handles this for you - and keeps it sans-IO.
+handles this for you, and keeps it sans-IO.
 
 When you call `stream.send_data`, zttp emits as many bytes as the window allows
 and **parks the rest**. As the peer grants more window (it sends you
@@ -179,7 +179,7 @@ for event in drain(server):
 more = server.data_to_send()                 # (3)!  the parked bytes, now freed
 ```
 
-1.  You hand zttp the whole body. It never blocks and never drops anything - it
+1.  You hand zttp the whole body. It never blocks and never drops anything: it
     sends what fits and remembers the rest.
 
 2.  The credit arrives as ordinary inbound bytes. No special call.
@@ -187,7 +187,7 @@ more = server.data_to_send()                 # (3)!  the parked bytes, now freed
 3.  The bytes the window now permits are waiting for you, framed and ready.
 
 !!! note "Buffering is not I/O"
-    Parking bytes until the window opens is bookkeeping, not I/O - zttp still
+    Parking bytes until the window opens is bookkeeping, not I/O: zttp still
     never touches a socket, never blocks, and never waits. *When* to ask for more
     window and what your event loop does meanwhile stays yours; zttp only decides
     *how many bytes may leave now*. That's the sans-IO line. See
@@ -208,8 +208,8 @@ can observe (and react to) what the peer is doing:
 | `Goaway` | The peer is shutting the connection down. |
 
 They flow out of `next_event` like any other event. Most applications can ignore
-them - zttp acts on the ones that matter (crediting windows, releasing parked
-data) on its own - but they're there when you need visibility.
+them, since zttp acts on the ones that matter (crediting windows, releasing
+parked data) on its own, but they're there when you need visibility.
 
 ## Where to go next
 
@@ -219,7 +219,7 @@ data) on its own - but they're there when you need visibility.
 
     ---
 
-    The HTTP/1.1 write side, in full - the foundation the `Stream` API mirrors.
+    The HTTP/1.1 write side, in full: the foundation the `Stream` API mirrors.
 
 -   :material-alert-circle: **[Errors](errors.md)**
 

--- a/docs/usage/install.md
+++ b/docs/usage/install.md
@@ -18,7 +18,7 @@ That's all you need. There's nothing else to configure. ✨
 ## Building from source
 
 Wheels cover the common platforms, so most people never compile anything. But the
-source distribution builds the Zig extension on install - you only need a Zig
+source distribution builds the Zig extension on install. You only need a Zig
 toolchain, and even that comes along automatically:
 
 ```console

--- a/docs/usage/parsing.md
+++ b/docs/usage/parsing.md
@@ -10,7 +10,7 @@ once bodies, chunked encoding, and partial data enter the picture.
 ## Bodies
 
 A body shows up as one or more `Data` events between the head and `EndOfMessage`.
-You concatenate them yourself - which means **you decide** whether to buffer the
+You concatenate them yourself, which means **you decide** whether to buffer the
 whole body or stream it.
 
 ```python
@@ -43,13 +43,13 @@ print(bytes(body))
 
 !!! tip
     Each `Data` event's `.data` is a real `bytes` object, copied out of the parse
-    buffer - so it's safe to keep. You're never handed a view that the next
+    buffer, so it's safe to keep. You're never handed a view that the next
     `receive_data` will overwrite.
 
 ## Partial data
 
 This is the whole point of sans-IO: the parser doesn't care how the bytes are
-split. Feed it a trickle and it resumes mid-anything - mid-header, mid-body,
+split. Feed it a trickle and it resumes mid-anything: mid-header, mid-body,
 mid-chunk.
 
 ```python
@@ -65,7 +65,7 @@ print(request.headers)
 ```
 
 1.  Half a header line isn't a complete event, so you get `NEED_DATA`. No error,
-    no lost state - just feed the rest.
+    no lost state. Just feed the rest.
 
 ## Chunked transfer encoding
 
@@ -96,7 +96,7 @@ print(bytes(body))
 #> b'hello world'
 ```
 
-1.  Chunk framing on the wire - `<size>\r\n<data>\r\n`, ending with a `0` chunk.
+1.  Chunk framing on the wire: `<size>\r\n<data>\r\n`, ending with a `0` chunk.
     You never see it; you get the decoded `hello world`.
 
 ## Trailers
@@ -125,7 +125,7 @@ print(end.trailers)
 
 ## Bodyless responses (client)
 
-Some responses have **no body no matter what their headers say** - the response to
+Some responses have **no body no matter what their headers say**: the response to
 a `HEAD` request, and any `1xx` / `204` / `304`. A `HEAD` response, for instance,
 carries the `Content-Length` the `GET` *would* have had, but sends no bytes.
 

--- a/docs/usage/sending.md
+++ b/docs/usage/sending.md
@@ -11,13 +11,13 @@ would corrupt the wire.
 
 There are four building blocks, plus one call to collect the output:
 
-* `send_request(method, target, version, headers)` - a request head.
-* `send_response(status, headers=None)` - a response head.
-* `send_data(data)` - a run of body bytes.
-* `end_message(trailers=None)` - finish the message.
-* `data_to_send()` - take and clear the bytes produced so far.
+* `send_request(method, target, version, headers)`: a request head.
+* `send_response(status, headers=None)`: a response head.
+* `send_data(data)`: a run of body bytes.
+* `end_message(trailers=None)`: finish the message.
+* `data_to_send()`: take and clear the bytes produced so far.
 
-These same four building blocks carry over to HTTP/2 - there, you call them on a
+These same four building blocks carry over to HTTP/2: there, you call them on a
 [`Stream`](http2.md) instead of the connection, because one connection carries
 many at once.
 
@@ -70,7 +70,7 @@ print(conn.data_to_send())
 ## Chunked output
 
 Declare `Transfer-Encoding: chunked` in the head, and every `send_data` is
-chunk-framed for you - so you can stream a body of unknown length:
+chunk-framed for you, so you can stream a body of unknown length:
 
 ```python
 import zttp
@@ -92,7 +92,7 @@ print(conn.data_to_send())
 ## Bodyless responses
 
 Some responses have no body no matter what (a `204`, a `304`, the reply to a
-`HEAD`). You don't flag this - zttp derives it from the response status and the
+`HEAD`). You don't flag this: zttp derives it from the response status and the
 request method it parsed, so the framing stays correct on its own:
 
 ```python
@@ -104,13 +104,13 @@ print(conn.data_to_send())
 
 A `HEAD` response is the subtle case: it carries the `Content-Length` the `GET`
 would have, but no bytes. Because the connection remembers the request was a
-`HEAD`, `send_data` is refused and no body is framed - you don't track it.
+`HEAD`, `send_data` is refused and no body is framed, so you don't track it.
 
 ## It holds you to the Content-Length
 
 When you declare a `Content-Length`, zttp counts the body bytes you send against
 it. Sending more than you promised, or ending the message with bytes still owed,
-is refused - either would put a malformed message on the wire:
+is refused: either would put a malformed message on the wire:
 
 ```python
 import zttp
@@ -121,13 +121,13 @@ conn.send_data(b"too long")
 #> zttp.LocalProtocolError: invalid send for current connection state
 ```
 
-For a body of unknown length, use `Transfer-Encoding: chunked` instead - then
+For a body of unknown length, use `Transfer-Encoding: chunked` instead: then
 `send_data` frames each run for you and there's nothing to count.
 
 ## It won't let you split the response
 
 zttp validates everything it serializes. A `\r\n` smuggled into a header value,
-reason phrase, or target - the classic response-splitting trick - is refused:
+reason phrase, or target (the classic response-splitting trick) is refused:
 
 ```python
 import zttp
@@ -138,11 +138,11 @@ conn.send_response(200, [(b"X-Evil", b"a\r\nInjected: yes")])
 ```
 
 !!! info "Local vs Remote"
-    Misusing the send API raises `LocalProtocolError` - *you* did something wrong.
+    Misusing the send API raises `LocalProtocolError`: *you* did something wrong.
     Malformed bytes from the peer raise `RemoteProtocolError`. See
     [Errors](errors.md).
 
 ## Where to go next
 
-* [HTTP/2](http2.md) - the same four building blocks, multiplexed across streams.
-* [Errors](errors.md) - what zttp rejects on the send side, and why.
+* [HTTP/2](http2.md): the same four building blocks, multiplexed across streams.
+* [Errors](errors.md): what zttp rejects on the send side, and why.


### PR DESCRIPTION
Refresh the README now that HTTP/2 and HTTP/3 are in:

- Describe zttp as an HTTP/1.1, HTTP/2, and HTTP/3 parser in the intro and mention it has no dependencies.
- Remove the Roadmap and Status sections.
- Drop dash-style punctuation and bold the prose mentions of zttp.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.