### PR TITLE
Cover HTTP/2 and HTTP/3 in the README body

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,16 @@ h3.next_event()  # the same Request / Data / EndOfMessage, tagged with stream_id
 
 ## Performance
 
-Against httptools on the same requests (macOS arm64, CPython 3.14,
-`ReleaseFast`), both verified to extract identical data:
+Against httptools on the same requests (macOS arm64, CPython 3.14, httptools
+0.8.0, the safety-checked `ReleaseSafe` build), both verified to extract
+identical data:
 
-| Workload          | zttp        | httptools    | Speedup    |
-| ----------------- | -----------: | -----------: | ---------: |
-| Simple GET        | ~1.25M req/s | ~880k req/s  | **1.41x**  |
-| POST + JSON body  | ~6.7M req/s  | ~1.84M req/s | **3.62x**  |
+| Workload          | zttp         | httptools    | zttp vs httptools |
+| ----------------- | -----------: | -----------: | ----------------: |
+| Simple GET        | ~1.16M req/s | ~1.2M req/s  | **~0.97x**        |
+| POST + JSON body  | ~4.9M req/s  | ~2.4M req/s  | **~2.0x**         |
 
-Run it yourself: `uv run --group bench python bench.py`.
+Run it yourself: `./scripts/bench`.
 
 ## Why it is fast
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ h2 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # HTTP/2
 h3 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)  # HTTP/3
 ```
 
-On **HTTP/2**, one connection multiplexes many requests, so every event carries a
-`stream_id` and you send on a `Stream` handle. Outbound flow control is handled
-for you: `send_data` emits what the peer's window allows and parks the rest until
-credit arrives.
+On **HTTP/2**, one connection multiplexes many requests, so the `Request` /
+`Response` / `Data` / `EndOfMessage` events carry a `stream_id` and you send on
+a `Stream` handle (connection-level control events like `Settings` and `Ping`
+have no stream to name). Outbound flow control is handled for you: `send_data`
+emits what the peer's window allows and parks the rest until credit arrives.
 
 ```python
 stream = h2.stream(request.stream_id)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ hand-written Zig engine underneath that is fast enough to be the HTTP parser in
 ## Sans-IO
 
 **zttp** does no I/O. You feed it bytes and pull out events; you ask it for bytes to
-send. It never touches a socket. This is the h11 model:
+send. It never touches a socket, so it works with any I/O you like:
 
 ```python
 import zttp
@@ -40,15 +40,52 @@ The read side yields `Request` / `Response` / `Data` / `EndOfMessage`, or the
 head, body data, and the end of the message, framing the body (Content-Length or
 chunked) for you.
 
+## One API, three protocols
+
+The `protocol=` argument selects the wire format; the event API stays the same:
+
+```python
+import zttp
+
+h1 = zttp.Connection(zttp.SERVER)                       # HTTP/1.1
+h2 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # HTTP/2
+h3 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)  # HTTP/3
+```
+
+On **HTTP/2**, one connection multiplexes many requests, so every event carries a
+`stream_id` and you send on a `Stream` handle. Outbound flow control is handled
+for you: `send_data` emits what the peer's window allows and parks the rest until
+credit arrives.
+
+```python
+stream = h2.stream(request.stream_id)
+stream.send_response(200, [(b"content-type", b"text/plain")])
+stream.send_data(b"Hello, HTTP/2!")
+stream.end_message()
+h2.data_to_send()  # the HTTP/2 frames to put on the wire
+```
+
+On **HTTP/3**, the wire is UDP, so you feed whole datagrams with
+`receive_datagram` and pull the same events. The QUIC transport underneath
+(packet protection, loss recovery, congestion control, stream reassembly) is
+written from scratch in the Zig core. The server read path is implemented end to
+end; the TLS 1.3 handshake driver, the write side, and the client read path are
+still in progress.
+
+```python
+h3.receive_datagram(datagram)
+h3.next_event()  # the same Request / Data / EndOfMessage, tagged with stream_id
+```
+
 ## Performance
 
-Against httptools and h11 on the same requests (macOS arm64, CPython 3.14,
-`ReleaseFast`), all three verified to extract identical data:
+Against httptools on the same requests (macOS arm64, CPython 3.14,
+`ReleaseFast`), both verified to extract identical data:
 
-| Workload          | zttp        | httptools    | h11        | zttp vs httptools |
-| ----------------- | -----------: | -----------: | ---------: | -----------------: |
-| Simple GET        | ~1.25M req/s | ~880k req/s  | ~57k req/s | **1.41x**          |
-| POST + JSON body  | ~6.7M req/s  | ~1.84M req/s | ~616k req/s| **3.62x**          |
+| Workload          | zttp        | httptools    | Speedup    |
+| ----------------- | -----------: | -----------: | ---------: |
+| Simple GET        | ~1.25M req/s | ~880k req/s  | **1.41x**  |
+| POST + JSON body  | ~6.7M req/s  | ~1.84M req/s | **3.62x**  |
 
 Run it yourself: `uv run --group bench python bench.py`.
 
@@ -73,6 +110,10 @@ bounded (`Limits`) so a malicious peer cannot exhaust memory, and the outbound
 serializer rejects CR/LF/control bytes to prevent response splitting. The build
 defaults to Zig's safety-checked `ReleaseSafe` mode. Malformed input raises
 `RemoteProtocolError`; misusing the send API raises `LocalProtocolError`.
+
+The HTTP/2 layer applies the same posture: the per-stream state machine enforces
+RFC 9113's stream lifecycle, with the exact stream-vs-connection error
+classification the RFC requires.
 
 The parser has been through two adversarial security audits (a code review and a
 CVE-driven review against real HTTP-parser CVEs across Node, Go, Python, Rust, and

--- a/docs/architecture/http3.md
+++ b/docs/architecture/http3.md
@@ -12,8 +12,6 @@ conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
 conn.receive_datagram(udp_payload)          # one UDP datagram in
 while (event := conn.next_event()) is not zttp.NEED_DATA:
     ...                                      # Request / Data / EndOfMessage, each with .stream_id
-for dgram in conn.datagrams_to_send():       # UDP datagrams out
-    sock.sendto(dgram, addr)
 ```
 
 The difference from HTTP/1.1 and HTTP/2 is the layer underneath. HTTP/1.1 and
@@ -25,8 +23,9 @@ multiplexing. Everything QUIC normally delegates to the OS for TCP, zttp does
 itself.
 
 The sans-IO discipline is unchanged: the core never touches a socket. The I/O
-layer feeds it UDP datagrams with `receive_datagram` and drains the datagrams it
-wants to send with `datagrams_to_send`. The boundary moved from "decrypted byte
+layer feeds it UDP datagrams with `receive_datagram`; the outbound half (a
+`datagrams_to_send` drain, mirroring `data_to_send`) arrives with the write
+side, which is still in progress. The boundary moved from "decrypted byte
 stream" (TCP) down to "UDP datagram" (QUIC), but the shape (bytes in, events and
 bytes out, no I/O in the core) is identical.
 
@@ -120,8 +119,8 @@ wide as its reality.
 The one API shift HTTP/3 forces: TCP gives an ordered byte stream, so HTTP/1.1 and
 HTTP/2 take `receive_data(bytes)`. QUIC is packet-oriented and the transport needs
 to see datagram boundaries (a packet number space is per-datagram, coalesced
-packets share a datagram), so HTTP/3 takes `receive_datagram(bytes)` and emits
-`datagrams_to_send()`. The event side is unchanged.
+packets share a datagram), so HTTP/3 takes `receive_datagram(bytes)`; its
+outbound mirror lands with the write side. The event side is unchanged.
 
 ## Security
 

--- a/docs/architecture/sans-io.md
+++ b/docs/architecture/sans-io.md
@@ -73,8 +73,3 @@ callbacks.
 | Control flow | inverted into your callbacks | yours |
 | Body | copied per callback | one `Data` event per span |
 | I/O coupling | none (also sans-IO at the core) | none |
-
-!!! tip
-    If you know [h11](https://github.com/python-hyper/h11), you already know
-    zttp's shape: it's the same `Connection` / `receive_data` / `next_event`
-    model, with a Zig engine instead of pure Python.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,9 @@ The key features are:
   sockets, no surprises.
 * **HTTP/1.1, HTTP/2, and HTTP/3**: the *same* event API for all three. Pass
   `protocol=zttp.HTTP2` and you get multiplexed streams, HPACK, and flow control
-  (see [HTTP/2](usage/http2.md)).
+  (see [HTTP/2](usage/http2.md)); pass `protocol=zttp.HTTP3` and a from-scratch
+  QUIC transport feeds the same events from UDP datagrams (see
+  [HTTP/3](usage/http3.md)).
 * **Fast**: a hand-written Zig engine with branch-light scanning and minimal
   allocation (see [Performance](reference/performance.md) for the numbers).
 * **Safe**: strict by default. It defends against request smuggling, rejects bare
@@ -130,6 +132,12 @@ That's it. The buffering, the header parsing, the body framing: all Zig. 🎉
     ---
 
     The same API, multiplexed: streams, flow control, and the control events.
+
+-   :material-radio-tower: **[HTTP/3](usage/http3.md)**
+
+    ---
+
+    The same events again, fed by UDP datagrams through a QUIC transport.
 
 -   :material-sitemap: **[Why sans-IO](architecture/sans-io.md)**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -9,16 +9,18 @@ importable straight from `zttp` (e.g. `from zttp import Connection`).
 
 ## Connection
 
-`zttp.Connection` is the base: the read side, shared by both protocols.
+`zttp.Connection` is the base: the read side, shared by every protocol.
 Constructing one returns the subclass for the protocol you picked: an
-`H1Connection` (the default) or an `H2Connection`, so the send surface you get
-matches the protocol.
+`H1Connection` (the default), an `H2Connection`, or an `H3Connection`, so the
+send surface you get matches the protocol.
 
 ::: zttp.Connection
 
 ::: zttp.H1Connection
 
 ::: zttp.H2Connection
+
+::: zttp.H3Connection
 
 A `Stream` is the per-stream send handle on an HTTP/2 connection; see
 [HTTP/2](../usage/http2.md).
@@ -33,11 +35,13 @@ A `Connection`'s role and protocol are fixed at construction:
 - `zttp.CLIENT`: you send requests, receive responses.
 - `zttp.HTTP1` *(default)*: one message at a time; you send on the connection.
 - `zttp.HTTP2`: multiplexed streams; you send on a `Stream`.
+- `zttp.HTTP3`: the same streams over QUIC; you feed UDP datagrams with
+  `receive_datagram` (see [HTTP/3](../usage/http3.md)).
 
 ## Events
 
-[`next_event`](#zttp.Connection.next_event) returns one of these. On HTTP/2 each
-also carries a `.stream_id`.
+[`next_event`](#zttp.Connection.next_event) returns one of these. On HTTP/2 and
+HTTP/3 each also carries a `.stream_id`.
 
 ::: zttp.Request
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -10,18 +10,18 @@ number.
 
 ## The numbers
 
-Parsing the same requests through zttp, [httptools](https://github.com/MagicStack/httptools)
-(the parser uvicorn uses), and [h11](https://github.com/python-hyper/h11), with
-all three driven to extract the **same** information (method, headers, body):
+Parsing the same requests through zttp and
+[httptools](https://github.com/MagicStack/httptools) (the parser uvicorn uses),
+with both driven to extract the **same** information (method, headers, body):
 
-| Workload | zttp | httptools | h11 | zttp vs httptools |
-| --- | ---: | ---: | ---: | ---: |
-| Simple `GET` (7 headers) | ~1.1M req/s | ~0.87M req/s | ~57k req/s | **~1.25x** |
-| `POST` + JSON body | ~5.0M req/s | ~1.8M req/s | ~0.6M req/s | **~2.7x** |
+| Workload | zttp | httptools | zttp vs httptools |
+| --- | ---: | ---: | ---: |
+| Simple `GET` (7 headers) | ~1.16M req/s | ~1.2M req/s | **~0.97x** |
+| `POST` + JSON body | ~4.9M req/s | ~2.4M req/s | **~2.0x** |
 
-zttp is faster than httptools on both, and roughly an order of magnitude faster
-than h11. Measured on an Apple Silicon machine with CPython 3.14 and the
-safety-checked (`ReleaseSafe`) build.
+zttp matches httptools on the small `GET` and roughly doubles it as soon as a
+body is involved. Measured on an Apple Silicon machine with CPython 3.14,
+httptools 0.8.0, and the safety-checked (`ReleaseSafe`) build.
 
 !!! info "These are parser microbenchmarks"
     They measure parsing throughput in isolation, not a full server. In a real
@@ -30,10 +30,10 @@ safety-checked (`ReleaseSafe`) build.
 
 ## Run it yourself
 
-The benchmark lives in `bench.py` and compares all three parsers:
+The benchmark lives in `bench.py`:
 
 ```console
-uv run --group bench python bench.py
+./scripts/bench
 ```
 
 It feeds each parser identical bytes and verifies they extract identical data
@@ -51,10 +51,9 @@ before timing, so the comparison is apples to apples.
 ## The honest caveat: safety has a cost
 
 zttp ships in Zig's `ReleaseSafe` mode, which keeps bounds and overflow checks on.
-The unchecked `ReleaseFast` mode is roughly 10% faster again, but for a parser
+The unchecked `ReleaseFast` mode is a few percent faster again, but for a parser
 eating untrusted network bytes, those checks turn a would-be memory bug into a
-clean trap. We chose safety, and zttp still beats httptools. That trade is the
-right one for this library.
+clean trap. We chose safety. That trade is the right one for this library.
 
 !!! tip
     If you have a workload where the last 10% matters and you trust your input,

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -54,7 +54,7 @@ What zttp rejects (a partial list):
 !!! info "Strict CRLF"
     A bare `LF` (without the preceding `CR`) is a known smuggling vector when a
     strict front-end and a lenient back-end disagree on where a line ends. zttp
-    rejects it by default, matching h11's stance.
+    rejects it by default.
 
 ## `LocalProtocolError`: you are wrong
 

--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -1,0 +1,82 @@
+---
+icon: lucide/radio
+---
+
+# HTTP/3
+
+HTTP/3 is the same zttp API again: opt in with one argument, pull the same
+events. The difference is the wire. HTTP/3 runs over **QUIC** on UDP, so instead
+of feeding a byte stream you feed whole datagrams:
+
+```python
+import zttp
+
+conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)  # (1)!
+```
+
+1.  Construction returns an `H3Connection`. Like HTTP/2, the protocol picks the
+    subtype, so the surface you get matches the wire you chose.
+
+!!! warning "Scope"
+    The HTTP/3 **server read path** is implemented end to end: a client Initial
+    datagram is decrypted, its stream bytes are reassembled, and the request
+    comes out as events. The TLS 1.3 handshake driver (only the Initial key
+    space is wired today), the write side, and the client read path are still
+    in progress, and the QPACK dynamic table is intentionally disabled.
+
+## Datagrams in, events out
+
+TCP hands you an ordered byte stream, so HTTP/1.1 and HTTP/2 take
+`receive_data(bytes)`. QUIC is packet-oriented and the transport must see
+datagram boundaries, so HTTP/3 takes `receive_datagram` instead. The event side
+is unchanged:
+
+```python title="server_read.py" hl_lines="4"
+import zttp
+
+conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+conn.receive_datagram(udp_payload)  # (1)!
+
+while (event := conn.next_event()) is not zttp.NEED_DATA:
+    if isinstance(event, zttp.Request):
+        print(event.method, event.path, event.stream_id)  # (2)!
+```
+
+1.  One UDP payload per call, exactly as it came off the socket. The QUIC layer
+    underneath decrypts the packets, tracks acks, and reassembles the stream
+    bytes for you.
+
+2.  The same `Request` / `Data` / `EndOfMessage` events, tagged with the QUIC
+    `stream_id`. An HTTP/3 request collapses its pseudo-headers into the same
+    shape the other protocols use, and `http_version` is `b"3"`.
+
+## The transport is inside
+
+For HTTP/1.1 and HTTP/2, the kernel's TCP gives zttp an ordered, reliable byte
+stream and the core only parses it. For HTTP/3, the core also *is* the
+transport: packet protection, loss recovery, congestion control, flow control,
+and stream reassembly all live in the Zig core, written from scratch on
+`std.crypto`. The sans-IO line holds: the core never touches a socket; your I/O
+layer moves the datagrams.
+
+Read [HTTP/3 and QUIC](../architecture/http3.md) for the full layer-by-layer
+tour, including the security posture (amplification limits, AEAD packet
+protection, and the QPACK bomb defenses).
+
+## Where to go next
+
+<div class="grid cards" markdown>
+
+-   :material-transit-connection-variant: **[HTTP/2](http2.md)**
+
+    ---
+
+    The same multiplexed event model over TCP, with the full write side.
+
+-   :material-sitemap: **[HTTP/3 and QUIC](../architecture/http3.md)**
+
+    ---
+
+    How the from-scratch QUIC transport is built, layer by layer.
+
+</div>

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,6 +1,6 @@
 [project]
 site_name = "zttp"
-site_description = "A sans-IO HTTP/1.1 and HTTP/2 parser for Python with a Zig core."
+site_description = "A sans-IO HTTP/1.1, HTTP/2, and HTTP/3 parser for Python with a Zig core."
 site_author = "Marcelo Trylesinski"
 #site_url = "https://zttp.dev/"
 repo_url = "https://github.com/Kludex/zttp"
@@ -19,11 +19,13 @@ nav = [
     "usage/parsing.md",
     "usage/sending.md",
     "usage/http2.md",
+    "usage/http3.md",
     "usage/errors.md",
   ] },
   { "Architecture" = [
     "architecture/overview.md",
     "architecture/sans-io.md",
+    "architecture/http3.md",
   ] },
   { "Reference" = [
     "reference/performance.md",


### PR DESCRIPTION
The README body still described only HTTP/1.1. This updates it, and the docs, to match the current protocol support:

- README: add a "One API, three protocols" section covering the `protocol=` selector, the HTTP/2 `Stream` send API with parked flow control, and the HTTP/3 datagram read path with its current scope stated honestly.
- Docs: new `usage/http3.md` page, `architecture/http3.md` and the new page added to the nav, `H3Connection` and `zttp.HTTP3` documented in the API reference, and the site description updated.
- h11 is mentioned exactly once in the README and once in the docs (the design inspiration in each intro).
- Benchmarks rerun against httptools 0.8.0 in `ReleaseSafe` (how wheels ship): httptools got notably faster since the last measurement, so the README and performance page now show ~0.97x on the simple GET and ~2x on POST + body.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.