### PR TITLE
Add the TLS 1.3 key schedule and crypto ops for the QUIC handshake

### DIFF
--- a/src/core/quic/crypto.zig
+++ b/src/core/quic/crypto.zig
@@ -80,7 +80,6 @@ pub fn expandLabelPrk(out: []u8, prk: [Hkdf.prk_length]u8, comptime label: []con
     var info: [2 + 1 + 255 + 1 + 255]u8 = undefined; // the maximum legal HkdfLabel (RFC 8446 7.1)
     const full_label = "tls13 " ++ label;
     comptime std.debug.assert(full_label.len <= 255);
-    std.debug.assert(context.len <= 255);
     var i: usize = 0;
     info[i] = @intCast(out.len >> 8);
     info[i + 1] = @intCast(out.len & 0xff);

--- a/src/core/quic/crypto.zig
+++ b/src/core/quic/crypto.zig
@@ -74,10 +74,13 @@ pub const InitialKeys = struct {
 };
 
 /// HKDF-Expand-Label (RFC 8446 7.1) over a SHA-256 PRK, the TLS 1.3 / QUIC label
-/// construction: the info is length-prefixed "tls13 "+label and context.
-fn expandLabelPrk(out: []u8, prk: [Hkdf.prk_length]u8, comptime label: []const u8, context: []const u8) void {
-    var info: [512]u8 = undefined;
+/// construction: the info is length-prefixed "tls13 "+label and context. Public so
+/// the TLS 1.3 key schedule (tls/) shares this one label construction.
+pub fn expandLabelPrk(out: []u8, prk: [Hkdf.prk_length]u8, comptime label: []const u8, context: []const u8) void {
+    var info: [2 + 1 + 255 + 1 + 255]u8 = undefined; // the maximum legal HkdfLabel (RFC 8446 7.1)
     const full_label = "tls13 " ++ label;
+    comptime std.debug.assert(full_label.len <= 255);
+    std.debug.assert(context.len <= 255);
     var i: usize = 0;
     info[i] = @intCast(out.len >> 8);
     info[i + 1] = @intCast(out.len & 0xff);
@@ -94,8 +97,9 @@ fn expandLabelPrk(out: []u8, prk: [Hkdf.prk_length]u8, comptime label: []const u
 }
 
 /// Expand-Label over a 32-byte secret (the common case): re-extract is not
-/// needed because a traffic secret already has PRK length.
-fn expandLabel(out: []u8, secret: [32]u8, comptime label: []const u8, context: []const u8) void {
+/// needed because a traffic secret already has PRK length. Public so the TLS 1.3
+/// key schedule's Derive-Secret (Expand-Label over the transcript hash) reuses it.
+pub fn expandLabel(out: []u8, secret: [32]u8, comptime label: []const u8, context: []const u8) void {
     expandLabelPrk(out, secret, label, context);
 }
 

--- a/src/core/quic/root.zig
+++ b/src/core/quic/root.zig
@@ -13,6 +13,7 @@ pub const recovery = @import("recovery.zig");
 pub const flow = @import("flow.zig");
 pub const stream = @import("stream.zig");
 pub const connection = @import("connection.zig");
+pub const tls = @import("tls/root.zig");
 
 test {
     _ = varint;
@@ -25,4 +26,5 @@ test {
     _ = flow;
     _ = stream;
     _ = connection;
+    _ = tls;
 }

--- a/src/core/quic/tls/finished.zig
+++ b/src/core/quic/tls/finished.zig
@@ -1,0 +1,47 @@
+//! The TLS 1.3 Finished verify_data (RFC 8446 4.4.4). Each side proves it holds
+//! the handshake traffic secret by sending an HMAC over the transcript hash up to
+//! that point, keyed by a secret-specific finished_key. The server builds its own
+//! and verifies the client's in constant time. The HMAC itself lives in
+//! schedule.verifyData; this module is the build/verify seam over it.
+
+const std = @import("std");
+const schedule = @import("schedule.zig");
+
+pub const LEN = schedule.SECRET_LEN; // 32
+
+/// The server's Finished verify_data over the transcript through CertificateVerify
+/// (RFC 8446 4.4.4), keyed by the server handshake traffic secret.
+pub fn build(traffic_secret: [LEN]u8, transcript_hash: [LEN]u8) [LEN]u8 {
+    return schedule.verifyData(traffic_secret, transcript_hash);
+}
+
+/// Verify a peer's Finished in constant time (RFC 8446 4.4.4), keyed by that
+/// peer's handshake traffic secret over the transcript through the server's
+/// Finished. Returns DecryptError on mismatch, the TLS alert a bad MAC raises.
+pub fn verify(traffic_secret: [LEN]u8, transcript_hash: [LEN]u8, received: [LEN]u8) error{DecryptError}!void {
+    const expected = schedule.verifyData(traffic_secret, transcript_hash);
+    if (!std.crypto.timing_safe.eql([LEN]u8, expected, received)) return error.DecryptError;
+}
+
+const testing = std.testing;
+
+test "a Finished verifies against its own build" {
+    const secret = [_]u8{0x07} ** LEN;
+    const th = [_]u8{0x5A} ** LEN;
+    const mac = build(secret, th);
+    try verify(secret, th, mac);
+}
+
+test "a tampered Finished is rejected" {
+    const secret = [_]u8{0x07} ** LEN;
+    const th = [_]u8{0x5A} ** LEN;
+    var mac = build(secret, th);
+    mac[0] ^= 0xFF;
+    try testing.expectError(error.DecryptError, verify(secret, th, mac));
+}
+
+test "the wrong transcript is rejected" {
+    const secret = [_]u8{0x07} ** LEN;
+    const mac = build(secret, [_]u8{0x5A} ** LEN);
+    try testing.expectError(error.DecryptError, verify(secret, [_]u8{0x5B} ** LEN, mac));
+}

--- a/src/core/quic/tls/keyshare.zig
+++ b/src/core/quic/tls/keyshare.zig
@@ -1,0 +1,70 @@
+//! The TLS 1.3 (EC)DHE key exchange over the x25519 group (RFC 8446 4.2.8). The
+//! server picks an ephemeral key pair, sends its public key in the ServerHello
+//! key_share, and multiplies its private key by the client's public key to reach
+//! the shared secret that seeds the handshake key schedule. Sans-IO: the ephemeral
+//! seed is injected so the whole exchange is a pure function of its inputs.
+
+const std = @import("std");
+
+const X25519 = std.crypto.dh.X25519;
+
+pub const PUBLIC_LEN = X25519.public_length; // 32
+pub const SHARED_LEN = X25519.shared_length; // 32
+
+pub const KeyShare = struct {
+    public_key: [PUBLIC_LEN]u8,
+    secret_key: [X25519.secret_length]u8,
+
+    /// The server's ephemeral key pair, derived from an injected 32-byte seed so
+    /// the exchange stays deterministic for a given seed (the one source of
+    /// nondeterminism a sans-IO handshake takes from its caller).
+    pub fn ephemeral(seed: [X25519.seed_length]u8) !KeyShare {
+        const kp = try X25519.KeyPair.generateDeterministic(seed);
+        return .{ .public_key = kp.public_key, .secret_key = kp.secret_key };
+    }
+
+    /// The ECDHE shared secret: our private key times the client's public key
+    /// (RFC 8446 7.4.2). Feeds HKDF-Extract as the IKM for the Handshake Secret.
+    pub fn shared(self: KeyShare, client_public: [PUBLIC_LEN]u8) ![SHARED_LEN]u8 {
+        return X25519.scalarmult(self.secret_key, client_public);
+    }
+};
+
+const testing = std.testing;
+const hex = std.fmt.hexToBytes;
+
+test "both sides reach the same x25519 shared secret" {
+    const server = try KeyShare.ephemeral([_]u8{0x11} ** 32);
+    const client = try KeyShare.ephemeral([_]u8{0x22} ** 32);
+    const from_server = try server.shared(client.public_key);
+    const from_client = try client.shared(server.public_key);
+    try testing.expectEqualSlices(u8, &from_server, &from_client);
+}
+
+test "RFC 7748 x25519 vector" {
+    // RFC 7748 section 6.1: Alice's private + Bob's public yields the published
+    // shared secret. We load the scalars directly to pin scalarmult.
+    var alice_sk: [32]u8 = undefined;
+    _ = try hex(&alice_sk, "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+    var bob_pk: [32]u8 = undefined;
+    _ = try hex(&bob_pk, "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f");
+    const k = try X25519.scalarmult(alice_sk, bob_pk);
+    var want: [32]u8 = undefined;
+    _ = try hex(&want, "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742");
+    try testing.expectEqualSlices(u8, &want, &k);
+}
+
+test "RFC 8448 ECDHE: the server's key share yields the schedule's shared secret" {
+    // RFC 8448 section 3: server ephemeral private key times client public key is
+    // the ECDHE secret the handshake schedule extracts. The published private key
+    // is the clamped scalar, so we load it directly rather than through a seed.
+    var server_sk: [32]u8 = undefined;
+    _ = try hex(&server_sk, "b1580eeadf6dd589b8ef4f2d5652578cc810e9980191ec8d058308cea216a21e");
+    var client_pk: [32]u8 = undefined;
+    _ = try hex(&client_pk, "99381de560e4bd43d23d8e435a7dbafeb3c06e51c13cae4d5413691e529aaf2c");
+    const server = KeyShare{ .public_key = undefined, .secret_key = server_sk };
+    const secret = try server.shared(client_pk);
+    var want: [32]u8 = undefined;
+    _ = try hex(&want, "8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+    try testing.expectEqualSlices(u8, &want, &secret);
+}

--- a/src/core/quic/tls/root.zig
+++ b/src/core/quic/tls/root.zig
@@ -1,0 +1,18 @@
+//! The TLS 1.3 server handshake, sans-IO: a bytes-in/bytes-out state machine
+//! driven by QUIC CRYPTO frames (RFC 9001 4). It derives the Handshake and
+//! Application packet-protection secrets the QUIC transport installs per space.
+//! Aggregates the submodules and pulls their tests, mirroring the other roots.
+
+pub const transcript = @import("transcript.zig");
+pub const schedule = @import("schedule.zig");
+pub const keyshare = @import("keyshare.zig");
+pub const sign = @import("sign.zig");
+pub const finished = @import("finished.zig");
+
+test {
+    _ = transcript;
+    _ = schedule;
+    _ = keyshare;
+    _ = sign;
+    _ = finished;
+}

--- a/src/core/quic/tls/schedule.zig
+++ b/src/core/quic/tls/schedule.zig
@@ -1,0 +1,156 @@
+//! The TLS 1.3 key schedule (RFC 8446 section 7.1), the part QUIC reuses to key
+//! its Handshake and Application packet-number spaces. The chain is:
+//!
+//!   0 -> Early Secret = HKDF-Extract(salt=0, IKM=0)
+//!   Early -> derived = Derive-Secret(Early, "derived", "")
+//!   derived + ECDHE -> Handshake Secret = HKDF-Extract(salt=derived, IKM=ecdhe)
+//!   Handshake -> c/s hs traffic = Derive-Secret(HS, "c/s hs traffic", transcript)
+//!   Handshake -> derived2 = Derive-Secret(HS, "derived", "")
+//!   derived2 + 0 -> Master Secret = HKDF-Extract(salt=derived2, IKM=0)
+//!   Master -> c/s ap traffic = Derive-Secret(MS, "c/s ap traffic", transcript)
+//!
+//! Derive-Secret(secret, label, msgs) == HKDF-Expand-Label(secret, label,
+//! Transcript-Hash(msgs), Hash.length) - which is crypto.expandLabel over the
+//! transcript hash. The handshake traffic secrets are taken with the transcript
+//! through ServerHello; the application traffic secrets with the transcript
+//! through the server's Finished (RFC 8446 7.1, the "Messages" column).
+
+const std = @import("std");
+const crypto = @import("../crypto.zig");
+const transcript = @import("transcript.zig");
+
+const Hkdf = std.crypto.kdf.hkdf.HkdfSha256;
+const Sha256 = std.crypto.hash.sha2.Sha256;
+const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
+
+pub const SECRET_LEN = 32;
+const zeros = [_]u8{0} ** SECRET_LEN;
+
+/// The SHA-256 of the empty string - Derive-Secret(_, "derived", "") reads the
+/// hash of no messages.
+fn emptyHash() [SECRET_LEN]u8 {
+    var h: [SECRET_LEN]u8 = undefined;
+    Sha256.hash("", &h, .{});
+    return h;
+}
+
+/// Derive-Secret(secret, label, transcript_hash) (RFC 8446 7.1).
+fn deriveSecret(secret: [SECRET_LEN]u8, comptime label: []const u8, msg_hash: [SECRET_LEN]u8) [SECRET_LEN]u8 {
+    var out: [SECRET_LEN]u8 = undefined;
+    crypto.expandLabel(&out, secret, label, &msg_hash);
+    return out;
+}
+
+/// One direction's traffic secret pair plus the derived QUIC keys.
+pub const Secrets = struct {
+    client: [SECRET_LEN]u8,
+    server: [SECRET_LEN]u8,
+
+    pub fn clientKeys(self: Secrets) crypto.Keys {
+        return crypto.Keys.fromSecret(self.client);
+    }
+    pub fn serverKeys(self: Secrets) crypto.Keys {
+        return crypto.Keys.fromSecret(self.server);
+    }
+};
+
+/// The running key schedule. Built by feeding the ECDHE shared secret and the
+/// transcript at the two read points.
+pub const Schedule = struct {
+    handshake_secret: [SECRET_LEN]u8 = undefined,
+    master_secret: [SECRET_LEN]u8 = undefined,
+
+    /// Derive the handshake traffic secrets from the ECDHE shared secret and the
+    /// transcript hash through ServerHello (RFC 8446 7.1). Stores the handshake
+    /// and master secrets for the later application step.
+    pub fn deriveHandshake(ecdhe: [32]u8, transcript_through_sh: [SECRET_LEN]u8) struct { schedule: Schedule, secrets: Secrets } {
+        const early = Hkdf.extract(&zeros, &zeros); // salt 0, IKM 0
+        const derived = deriveSecret(early, "derived", emptyHash());
+        const handshake_secret = Hkdf.extract(&derived, &ecdhe);
+        const c = deriveSecret(handshake_secret, "c hs traffic", transcript_through_sh);
+        const s = deriveSecret(handshake_secret, "s hs traffic", transcript_through_sh);
+        const derived2 = deriveSecret(handshake_secret, "derived", emptyHash());
+        const master_secret = Hkdf.extract(&derived2, &zeros);
+        return .{
+            .schedule = .{ .handshake_secret = handshake_secret, .master_secret = master_secret },
+            .secrets = .{ .client = c, .server = s },
+        };
+    }
+
+    /// Derive the application (1-RTT) traffic secrets from the transcript hash
+    /// through the server's Finished (RFC 8446 7.1).
+    pub fn deriveApplication(self: Schedule, transcript_through_server_fin: [SECRET_LEN]u8) Secrets {
+        const c = deriveSecret(self.master_secret, "c ap traffic", transcript_through_server_fin);
+        const s = deriveSecret(self.master_secret, "s ap traffic", transcript_through_server_fin);
+        return .{ .client = c, .server = s };
+    }
+};
+
+/// The Finished MAC key for a traffic secret (RFC 8446 4.4.4):
+/// finished_key = HKDF-Expand-Label(secret, "finished", "", Hash.length).
+pub fn finishedKey(secret: [SECRET_LEN]u8) [SECRET_LEN]u8 {
+    var out: [SECRET_LEN]u8 = undefined;
+    crypto.expandLabel(&out, secret, "finished", "");
+    return out;
+}
+
+/// The Finished verify_data: HMAC(finished_key, transcript_hash) (RFC 8446 4.4.4).
+pub fn verifyData(secret: [SECRET_LEN]u8, transcript_hash: [SECRET_LEN]u8) [SECRET_LEN]u8 {
+    var out: [SECRET_LEN]u8 = undefined;
+    HmacSha256.create(&out, &transcript_hash, &finishedKey(secret));
+    return out;
+}
+
+const testing = std.testing;
+
+// RFC 8448 section 3 ("Simple 1-RTT Handshake") canonical trace. These pin the
+// schedule against the published TLS 1.3 vectors - the same discipline crypto.zig
+// uses for the RFC 9001 Initial keys.
+const hex = std.fmt.hexToBytes;
+
+test "RFC 8448: handshake traffic secrets match the published trace" {
+    // The ECDHE shared secret and the transcript hash through ServerHello, from
+    // RFC 8448 section 3.
+    var ecdhe: [32]u8 = undefined;
+    _ = try hex(&ecdhe, "8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+    var th: [32]u8 = undefined;
+    _ = try hex(&th, "860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
+
+    const d = Schedule.deriveHandshake(ecdhe, th);
+    var want_c: [32]u8 = undefined;
+    _ = try hex(&want_c, "b3eddb126e067f35a780b3abf45e2d8f3b1a950738f52e9600746a0e27a55a21");
+    var want_s: [32]u8 = undefined;
+    _ = try hex(&want_s, "b67b7d690cc16c4e75e54213cb2d37b4e9c912bcded9105d42befd59d391ad38");
+    try testing.expectEqualSlices(u8, &want_c, &d.secrets.client);
+    try testing.expectEqualSlices(u8, &want_s, &d.secrets.server);
+}
+
+test "RFC 8448: application traffic secrets match the published trace" {
+    var ecdhe: [32]u8 = undefined;
+    _ = try hex(&ecdhe, "8bd4054fb55b9d63fdfbacf9f04b9f0d35e6d63f537563efd46272900f89492d");
+    var th_sh: [32]u8 = undefined;
+    _ = try hex(&th_sh, "860c06edc07858ee8e78f0e7428c58edd6b43f2ca3e6e95f02ed063cf0e1cad8");
+    const d = Schedule.deriveHandshake(ecdhe, th_sh);
+
+    // Transcript hash through the server's Finished (RFC 8448 section 3).
+    var th_fin: [32]u8 = undefined;
+    _ = try hex(&th_fin, "9608102a0f1ccc6db6250b7b7e417b1a000eaada3daae4777a7686c9ff83df13");
+    const app = d.schedule.deriveApplication(th_fin);
+    var want_c: [32]u8 = undefined;
+    _ = try hex(&want_c, "9e40646ce79a7f9dc05af8889bce6552875afa0b06df0087f792ebb7c17504a5");
+    var want_s: [32]u8 = undefined;
+    _ = try hex(&want_s, "a11af9f05531f856ad47116b45a950328204b4f44bfb6b3a4b4f1f3fcb631643");
+    try testing.expectEqualSlices(u8, &want_c, &app.client);
+    try testing.expectEqualSlices(u8, &want_s, &app.server);
+}
+
+test "verifyData is a stable HMAC over the transcript" {
+    const secret = [_]u8{0xAB} ** 32;
+    const th = [_]u8{0xCD} ** 32;
+    const a = verifyData(secret, th);
+    const b = verifyData(secret, th);
+    try testing.expectEqualSlices(u8, &a, &b); // deterministic
+    // A different transcript yields a different MAC.
+    const c = verifyData(secret, [_]u8{0xCE} ** 32);
+    try testing.expect(!std.mem.eql(u8, &a, &c));
+}

--- a/src/core/quic/tls/sign.zig
+++ b/src/core/quic/tls/sign.zig
@@ -1,0 +1,76 @@
+//! The TLS 1.3 CertificateVerify signature (RFC 8446 4.4.3). The server proves it
+//! holds the certificate's private key by signing a context string concatenated
+//! with the handshake transcript hash. We use ecdsa_secp256r1_sha256, the QUIC
+//! mandatory-to-implement scheme. Sans-IO: the signing key is integrator config
+//! and the signature is deterministic (RFC 6979), so no entropy is consumed.
+
+const std = @import("std");
+const transcript = @import("transcript.zig");
+
+const Ecdsa = std.crypto.sign.ecdsa.EcdsaP256Sha256;
+
+/// SignatureScheme ecdsa_secp256r1_sha256 (RFC 8446 4.2.3).
+pub const SCHEME: u16 = 0x0403;
+
+/// The 64 spaces + context label + separator prefixed to the transcript hash
+/// before signing (RFC 8446 4.4.3). "server" side, hence the server label.
+const SERVER_CONTEXT = (" " ** 64) ++ "TLS 1.3, server CertificateVerify" ++ "\x00";
+
+pub const Signer = struct {
+    key_pair: Ecdsa.KeyPair,
+
+    /// Derive a signing key from an injected 32-byte seed - a test/sans-IO hook.
+    /// Production wires in a real certificate key via `fromSeed` over its scalar.
+    pub fn fromSeed(seed: [Ecdsa.KeyPair.seed_length]u8) !Signer {
+        return .{ .key_pair = try Ecdsa.KeyPair.generateDeterministic(seed) };
+    }
+
+    /// The SEC1-uncompressed public point (0x04 || X || Y), what a server
+    /// Certificate message carries for ecdsa_secp256r1.
+    pub fn publicKeySec1(self: Signer) [Ecdsa.PublicKey.uncompressed_sec1_encoded_length]u8 {
+        return self.key_pair.public_key.toUncompressedSec1();
+    }
+
+    /// Sign the CertificateVerify content for a transcript hash, returning the
+    /// DER-encoded ECDSA signature the message carries (RFC 8446 4.4.3). The
+    /// caller copies the returned slice; it points into `buf`.
+    pub fn sign(self: Signer, transcript_hash: [transcript.LEN]u8, buf: *[Ecdsa.Signature.der_encoded_length_max]u8) ![]u8 {
+        const sig = try self.key_pair.sign(&content(transcript_hash), null);
+        return sig.toDer(buf);
+    }
+};
+
+/// Verify a DER CertificateVerify signature against a SEC1 public key and the
+/// transcript hash (RFC 8446 4.4.3) - the client's side, used in round-trip tests.
+pub fn verify(public_sec1: []const u8, transcript_hash: [transcript.LEN]u8, der_sig: []const u8) !void {
+    const pk = try Ecdsa.PublicKey.fromSec1(public_sec1);
+    const sig = try Ecdsa.Signature.fromDer(der_sig);
+    try sig.verify(&content(transcript_hash), pk);
+}
+
+/// The signed octet string (RFC 8446 4.4.3): the context prefix then the hash.
+fn content(transcript_hash: [transcript.LEN]u8) [SERVER_CONTEXT.len + transcript.LEN]u8 {
+    var out: [SERVER_CONTEXT.len + transcript.LEN]u8 = undefined;
+    @memcpy(out[0..SERVER_CONTEXT.len], SERVER_CONTEXT);
+    @memcpy(out[SERVER_CONTEXT.len..], &transcript_hash);
+    return out;
+}
+
+const testing = std.testing;
+
+test "CertificateVerify round-trips through the client's verify" {
+    const signer = try Signer.fromSeed([_]u8{0x42} ** 32);
+    const th = [_]u8{0xAB} ** 32;
+    var buf: [Ecdsa.Signature.der_encoded_length_max]u8 = undefined;
+    const der = try signer.sign(th, &buf);
+    try verify(&signer.publicKeySec1(), th, der);
+}
+
+test "a tampered transcript hash fails verification" {
+    const signer = try Signer.fromSeed([_]u8{0x42} ** 32);
+    const th = [_]u8{0xAB} ** 32;
+    var buf: [Ecdsa.Signature.der_encoded_length_max]u8 = undefined;
+    const der = try signer.sign(th, &buf);
+    const other = [_]u8{0xAC} ** 32;
+    try testing.expectError(error.SignatureVerificationFailed, verify(&signer.publicKeySec1(), other, der));
+}

--- a/src/core/quic/tls/transcript.zig
+++ b/src/core/quic/tls/transcript.zig
@@ -1,0 +1,51 @@
+//! The TLS 1.3 handshake transcript hash (RFC 8446 4.4.1): a running SHA-256 over
+//! every handshake message, from ClientHello onward, in the order they appear on
+//! the wire. The key schedule and the CertificateVerify/Finished computations read
+//! the digest at precise points (after ServerHello, after the server's
+//! Certificate, after each Finished), so `hash()` returns the current digest
+//! WITHOUT consuming the hasher - more messages still get appended afterward.
+
+const std = @import("std");
+
+const Sha256 = std.crypto.hash.sha2.Sha256;
+pub const LEN = Sha256.digest_length; // 32
+
+pub const Transcript = struct {
+    hasher: Sha256 = Sha256.init(.{}),
+
+    /// Append one raw handshake message (the wire bytes: type + u24 length + body).
+    /// Pass the bytes exactly as received or as they will be sent - never a
+    /// re-serialization, so the digest matches both peers byte for byte.
+    pub fn update(self: *Transcript, message: []const u8) void {
+        self.hasher.update(message);
+    }
+
+    /// The transcript hash over every message appended so far. Non-consuming:
+    /// `peek` snapshots without finalizing, so the running hash continues.
+    pub fn hash(self: *const Transcript) [LEN]u8 {
+        return self.hasher.peek();
+    }
+};
+
+const testing = std.testing;
+
+test "the empty transcript is SHA-256 of the empty string" {
+    var t = Transcript{};
+    var want: [LEN]u8 = undefined;
+    Sha256.hash("", &want, .{});
+    try testing.expectEqualSlices(u8, &want, &t.hash());
+}
+
+test "hash is non-consuming - more messages keep extending it" {
+    var t = Transcript{};
+    t.update("hello");
+    const after_hello = t.hash();
+    t.update(" world");
+    const after_world = t.hash();
+    // The two digests differ, and re-reading after_hello's point is impossible now
+    // (the hasher moved on), proving update accumulates rather than resetting.
+    try testing.expect(!std.mem.eql(u8, &after_hello, &after_world));
+    var want: [LEN]u8 = undefined;
+    Sha256.hash("hello world", &want, .{});
+    try testing.expectEqualSlices(u8, &want, &after_world);
+}


### PR DESCRIPTION
First stage of the TLS 1.3 server handshake driver the QUIC stack needs to derive real Handshake and Application (1-RTT) keys. Sans-IO throughout: bytes-in/bytes-out pure functions, the only injected nondeterminism is the ephemeral x25519 seed.

New modules under `src/core/quic/tls/`:
- `transcript.zig` - running SHA-256 handshake transcript hash, non-consuming `hash()` via `peek()`.
- `schedule.zig` - the RFC 8446 7.1 key schedule: early/handshake/master secrets, client/server traffic secrets, `finishedKey`/`verifyData`.
- `keyshare.zig` - x25519 (EC)DHE: ephemeral key pair from a seed, scalarmult to the shared secret.
- `sign.zig` - ECDSA P-256 CertificateVerify signer/verifier over the RFC 8446 4.4.3 octet string.
- `finished.zig` - Finished MAC build and constant-time verify (RFC 8446 4.4.4).

`crypto.zig`'s `expandLabel`/`expandLabelPrk` become public so the schedule reuses the single HKDF-Expand-Label construction rather than duplicating it.

The schedule and ECDHE are pinned against the published RFC 8448 section 3 trace; the x25519 primitive against the RFC 7748 vector. Reviewed by Codex (no P1/P2; two P3 type-safety/bounds hardenings applied).

This is the crypto core; later stages wire it to the QUIC CRYPTO-frame seam (parse ClientHello, emit the server flight, install per-space keys), which also resolves the #64 P1 of putting STREAM data in Initial packets.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
