### PR TITLE
Deliver Content-Length bodies with a single copy

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -164,6 +164,31 @@ pub const Reader = struct {
         return self.conn_should_close;
     }
 
+    /// True when every buffered byte has been consumed.
+    pub fn backlogEmpty(self: *const Reader) bool {
+        return self.buf.items.len == self.consumed;
+    }
+
+    /// True when the reader is waiting for the head of a new message.
+    pub fn atMessageStart(self: *const Reader) bool {
+        return self.state == .head;
+    }
+
+    /// Bytes still expected of a Content-Length body, or null when the reader
+    /// is not mid-way through one.
+    pub fn bodyLengthRemaining(self: *const Reader) ?u64 {
+        return if (self.state == .body_length and self.body_remaining > 0) self.body_remaining else null;
+    }
+
+    /// Account for `n` body bytes the caller delivered to the application out
+    /// of band, without buffering them. Only valid while `bodyLengthRemaining`
+    /// is non-null and `n` is at most that remainder.
+    pub fn skipBodyLength(self: *Reader, n: u64) void {
+        std.debug.assert(self.state == .body_length and n <= self.body_remaining);
+        self.body_remaining -= n;
+        if (self.body_remaining == 0) self.state = .eom_pending;
+    }
+
     /// The `Upgrade` value of the most recently parsed request iff its
     /// `Connection` header listed the `upgrade` token; else null. The slice is
     /// borrowed from the head buffer - read it right after the Request event.
@@ -395,7 +420,7 @@ pub const Reader = struct {
 
 /// Find the byte offset just past the blank line terminating the header block,
 /// i.e. the length of the head. Recognizes both CRLFCRLF and bare LFLF.
-fn findHeadEnd(region: []const u8) ?usize {
+pub fn findHeadEnd(region: []const u8) ?usize {
     var i: usize = 0;
     while (i < region.len) {
         // Look for LF, then test what precedes/follows for the blank line.
@@ -737,6 +762,45 @@ fn driveReader(input: []const u8) void {
 // A deterministic property test: run many adversarial and pseudo-random inputs
 // through driveReader and assert it never panics. This is the always-on
 // regression net; coverage-guided fuzzing (`zig build fuzz`) layers on top.
+test "skipBodyLength accounts for out-of-band body bytes" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\n");
+    try t.expect((try r.nextEvent()) == .request);
+    try t.expectEqual(@as(?u64, 10), r.bodyLengthRemaining());
+    try t.expect(r.backlogEmpty());
+
+    r.skipBodyLength(4);
+    try t.expectEqual(@as(?u64, 6), r.bodyLengthRemaining());
+    r.skipBodyLength(6);
+    try t.expectEqual(@as(?u64, null), r.bodyLengthRemaining());
+    try t.expect((try r.nextEvent()) == .end_of_message);
+}
+
+test "skipBodyLength interleaves with buffered body bytes" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 8\r\n\r\nabcd");
+    try t.expect((try r.nextEvent()) == .request);
+    const d = try r.nextEvent();
+    try t.expectEqualStrings("abcd", d.data.data);
+    try t.expect(r.backlogEmpty());
+    r.skipBodyLength(4);
+    try t.expect((try r.nextEvent()) == .end_of_message);
+}
+
+test "atMessageStart and backlogEmpty track parser progress" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try t.expect(r.atMessageStart());
+    try r.feed("GET / HT");
+    try t.expect(r.atMessageStart());
+    try t.expect(!r.backlogEmpty());
+    try r.feed("TP/1.1\r\nHost: x\r\n\r\n");
+    try t.expect((try r.nextEvent()) == .request);
+    try t.expect(!r.atMessageStart());
+}
+
 test "fuzz: reader never panics on adversarial inputs" {
     const seeds = [_][]const u8{
         "",

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -45,6 +45,12 @@ const H1Engine = struct {
     /// they outlive the head buffer. `upgrade_obj` is held Python bytes (or null).
     should_close: bool = false,
     upgrade_obj: py.Object = null,
+    /// Single-copy body path: when a fed buffer's prefix is a Content-Length
+    /// body, the bytes object is held here (incref'd, its memory stable)
+    /// instead of being copied into the reader; next_event materialises Data
+    /// events straight from it. `pending` is the not-yet-consumed remainder.
+    pending_obj: py.Object = null,
+    pending: []const u8 = &.{},
 
     fn rememberMethod(self: *H1Engine, m: []const u8) void {
         if (m.len > self.req_method.len) {
@@ -59,12 +65,62 @@ const H1Engine = struct {
         return self.req_method[0..self.req_method_len];
     }
 
+    fn stash(self: *H1Engine, obj: py.Object, rest: []const u8) void {
+        py.incref(obj);
+        self.pending_obj = obj;
+        self.pending = rest;
+    }
+
+    fn dropPending(self: *H1Engine) void {
+        py.xdecref(self.pending_obj);
+        self.pending_obj = null;
+        self.pending = &.{};
+    }
+
+    /// Move the stashed remainder into the reader's own buffer (the slow path
+    /// the stash bypassed). Returns false with a Python error set on failure.
+    fn flushPending(self: *H1Engine) bool {
+        if (self.pending_obj == null) return true;
+        const rest = self.pending;
+        defer self.dropPending();
+        self.reader.feed(rest) catch |err| {
+            _ = exceptions.raiseParse(err);
+            return false;
+        };
+        return true;
+    }
+
+    /// Feeds smaller than this take the plain buffered path: the head-split
+    /// scan below costs one extra pass over the head, which only pays for
+    /// itself when a sizeable body follows.
+    const head_split_min_feed = 1024;
+
+    fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
+        if (!self.flushPending()) return null;
+        if (data.len > 0 and self.reader.backlogEmpty()) {
+            if (self.reader.bodyLengthRemaining() != null) {
+                self.stash(obj, data);
+                return py.none();
+            }
+            if (data.len >= head_split_min_feed and self.reader.atMessageStart()) {
+                if (core.h1.reader.findHeadEnd(data)) |head_end| {
+                    self.reader.feed(data[0..head_end]) catch |err| return exceptions.raiseParse(err);
+                    if (head_end < data.len) self.stash(obj, data[head_end..]);
+                    return py.none();
+                }
+            }
+        }
+        self.reader.feed(data) catch |err| return exceptions.raiseParse(err);
+        return py.none();
+    }
+
     fn deinit(self: *H1Engine) void {
         self.reader.deinit();
         gpa.destroy(self.reader);
         self.writer.deinit();
         gpa.destroy(self.writer);
         py.xdecref(self.upgrade_obj);
+        py.xdecref(self.pending_obj);
     }
 };
 
@@ -573,10 +629,7 @@ fn receive_data(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Objec
             e.conn.feed(bytes) catch |err| return exceptions.raiseH2(err);
             return py.none();
         },
-        .h1 => |*e| {
-            e.reader.feed(bytes) catch |err| return exceptions.raiseParse(err); // MessageTooLong -> RemoteProtocolError
-            return py.none();
-        },
+        .h1 => |*e| return e.receiveData(bytes, arg),
         .h3 => return py.raiseRuntime("receive_data is not valid for an HTTP/3 connection; use receive_datagram"),
     }
 }
@@ -604,17 +657,50 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {
-            const ev = e.reader.nextEvent() catch |err| return exceptions.raiseParse(err);
-            if (ev == .request) {
-                e.rememberMethod(ev.request.method);
-                e.should_close = e.reader.shouldClose();
-                py.xdecref(e.upgrade_obj);
-                if (e.reader.upgrade()) |u| {
-                    e.upgrade_obj = py.fromBytes(u);
-                    if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
-                } else e.upgrade_obj = null;
+            while (true) {
+                const ev = e.reader.nextEvent() catch |err| {
+                    e.dropPending();
+                    return exceptions.raiseParse(err);
+                };
+                if (ev == .need_data and e.pending_obj != null) {
+                    if (e.reader.backlogEmpty()) {
+                        if (e.reader.bodyLengthRemaining()) |rem| {
+                            // Materialise body bytes straight from the stashed
+                            // buffer - the one copy - and account for them.
+                            const take: usize = @intCast(@min(rem, @as(u64, e.pending.len)));
+                            const out = events_obj.fromH1Event(.{ .data = .{ .data = e.pending[0..take] } });
+                            if (out == null) return null;
+                            e.reader.skipBodyLength(take);
+                            e.pending = e.pending[take..];
+                            if (e.pending.len == 0) {
+                                e.dropPending();
+                            } else if (e.reader.bodyLengthRemaining() == null) {
+                                // The remainder is the next pipelined message.
+                                if (!e.flushPending()) {
+                                    py.decref(out);
+                                    return null;
+                                }
+                            }
+                            return out;
+                        }
+                    }
+                    // The stash cannot be consumed in place (chunked body,
+                    // message done, or buffered bytes precede it): buffer it
+                    // and ask the reader again.
+                    if (!e.flushPending()) return null;
+                    continue;
+                }
+                if (ev == .request) {
+                    e.rememberMethod(ev.request.method);
+                    e.should_close = e.reader.shouldClose();
+                    py.xdecref(e.upgrade_obj);
+                    if (e.reader.upgrade()) |u| {
+                        e.upgrade_obj = py.fromBytes(u);
+                        if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
+                    } else e.upgrade_obj = null;
+                }
+                return events_obj.fromH1Event(ev);
             }
-            return events_obj.fromH1Event(ev);
         },
     }
 }

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -162,3 +162,55 @@ def test_invalid_role_rejected() -> None:
 def test_remote_is_subclass_of_protocol_error() -> None:
     assert issubclass(zttp.RemoteProtocolError, zttp.ProtocolError)
     assert issubclass(zttp.LocalProtocolError, zttp.ProtocolError)
+
+
+def test_body_and_pipelined_request_in_one_feed() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(
+        b"POST /a HTTP/1.1\r\nContent-Length: 5\r\n\r\nfirstPOST /b HTTP/1.1\r\nContent-Length: 6\r\n\r\nsecond"
+    )
+    events = list(drain(conn))
+    assert events[0].target == b"/a"
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"first"
+    conn.start_next_cycle()
+    events = list(drain(conn))
+    assert events[0].target == b"/b"
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"second"
+
+
+def test_second_feed_arrives_before_first_is_drained() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhello")
+    conn.receive_data(b"world")
+    events = list(drain(conn))
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"helloworld"
+    assert isinstance(events[-1], zttp.EndOfMessage)
+
+
+def test_body_fed_in_pieces_with_draining_between() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 9\r\n\r\n")
+    assert isinstance(next(drain(conn)), zttp.Request)
+    body = b""
+    for piece in (b"abc", b"def", b"ghi"):
+        conn.receive_data(piece)
+        body += b"".join(e.data for e in drain(conn) if isinstance(e, zttp.Data))
+    assert body == b"abcdefghi"
+
+
+def test_garbage_after_complete_message_raises_on_next_cycle() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nokNOT HTTP\x00\r\n\r\n")
+    events = list(drain(conn))
+    assert isinstance(events[-1], zttp.EndOfMessage)
+    conn.start_next_cycle()
+    with pytest.raises(zttp.RemoteProtocolError):
+        drain_all(conn)
+
+
+def test_large_body_round_trips_unchanged() -> None:
+    body = bytes(range(256)) * 256  # 64KB, every byte value
+    raw = b"POST /up HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    events = parse_request(raw)
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == body
+    assert isinstance(events[-1], zttp.EndOfMessage)


### PR DESCRIPTION
The 14-workload benchmark suite (#67) exposed that zttp was ~0.5x httptools on large whole-buffer bodies: every body byte was copied twice - `receive_data` appended it into the reader's buffer, then the `Data` event copied it again into a fresh `PyBytes`. httptools copies once because it parses synchronously inside `feed_data` while the input is alive; zttp's pull API defers parsing past that borrow window.

This closes the gap without touching the API or the error model:

- `receive_data` now holds a reference to the fed bytes object instead of copying its body portion. When the reader is mid-way through a Content-Length body (buffer drained), the whole feed is stashed; when a complete head arrives in a feed of 1KB or more, only the head bytes enter the buffer and the rest is stashed. The 1KB floor keeps bodyless requests on the untouched old path - the head-split scan only pays for itself when a sizeable body follows.
- `next_event` materialises body `Data` events straight from the stashed buffer (the one copy) and tells the reader to account for the skipped bytes (`Reader.skipBodyLength`). Anything the stash cannot serve in place - chunked bodies, pipelined tails, a second feed arriving first - is flushed into the reader's buffer, i.e. falls back to exactly the old behaviour. All parsing still happens in `next_event`, so errors surface from the same call they always did.

Suite results (vs main, ReleaseSafe, httptools 0.8.0):

| workload | before | after |
| --- | ---: | ---: |
| 16KB upload POST | 0.52x httptools | **0.90x** |
| 16KB upload, MTU pieces | 1.23x httptools | **1.80x** |
| every other workload | unchanged within noise | unchanged within noise |

New reader APIs (`backlogEmpty`, `atMessageStart`, `bodyLengthRemaining`, `skipBodyLength`) have direct Zig tests; five new Python tests cover the stash paths (pipelined tail after a body, second feed before draining, piecewise bodies, garbage after a stashed message, a 64KB all-byte-values round trip). Full Zig + Python suites pass (166).

Independent of #69; the ratios above are measured against plain main.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.