### PR TITLE
Intern request-line and status-line strings

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -164,6 +164,31 @@ pub const Reader = struct {
         return self.conn_should_close;
     }
 
+    /// True when every buffered byte has been consumed.
+    pub fn backlogEmpty(self: *const Reader) bool {
+        return self.buf.items.len == self.consumed;
+    }
+
+    /// True when the reader is waiting for the head of a new message.
+    pub fn atMessageStart(self: *const Reader) bool {
+        return self.state == .head;
+    }
+
+    /// Bytes still expected of a Content-Length body, or null when the reader
+    /// is not mid-way through one.
+    pub fn bodyLengthRemaining(self: *const Reader) ?u64 {
+        return if (self.state == .body_length and self.body_remaining > 0) self.body_remaining else null;
+    }
+
+    /// Account for `n` body bytes the caller delivered to the application out
+    /// of band, without buffering them. Only valid while `bodyLengthRemaining`
+    /// is non-null and `n` is at most that remainder.
+    pub fn skipBodyLength(self: *Reader, n: u64) void {
+        std.debug.assert(self.state == .body_length and n <= self.body_remaining);
+        self.body_remaining -= n;
+        if (self.body_remaining == 0) self.state = .eom_pending;
+    }
+
     /// The `Upgrade` value of the most recently parsed request iff its
     /// `Connection` header listed the `upgrade` token; else null. The slice is
     /// borrowed from the head buffer - read it right after the Request event.
@@ -395,7 +420,7 @@ pub const Reader = struct {
 
 /// Find the byte offset just past the blank line terminating the header block,
 /// i.e. the length of the head. Recognizes both CRLFCRLF and bare LFLF.
-fn findHeadEnd(region: []const u8) ?usize {
+pub fn findHeadEnd(region: []const u8) ?usize {
     var i: usize = 0;
     while (i < region.len) {
         // Look for LF, then test what precedes/follows for the blank line.
@@ -737,6 +762,45 @@ fn driveReader(input: []const u8) void {
 // A deterministic property test: run many adversarial and pseudo-random inputs
 // through driveReader and assert it never panics. This is the always-on
 // regression net; coverage-guided fuzzing (`zig build fuzz`) layers on top.
+test "skipBodyLength accounts for out-of-band body bytes" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\n");
+    try t.expect((try r.nextEvent()) == .request);
+    try t.expectEqual(@as(?u64, 10), r.bodyLengthRemaining());
+    try t.expect(r.backlogEmpty());
+
+    r.skipBodyLength(4);
+    try t.expectEqual(@as(?u64, 6), r.bodyLengthRemaining());
+    r.skipBodyLength(6);
+    try t.expectEqual(@as(?u64, null), r.bodyLengthRemaining());
+    try t.expect((try r.nextEvent()) == .end_of_message);
+}
+
+test "skipBodyLength interleaves with buffered body bytes" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 8\r\n\r\nabcd");
+    try t.expect((try r.nextEvent()) == .request);
+    const d = try r.nextEvent();
+    try t.expectEqualStrings("abcd", d.data.data);
+    try t.expect(r.backlogEmpty());
+    r.skipBodyLength(4);
+    try t.expect((try r.nextEvent()) == .end_of_message);
+}
+
+test "atMessageStart and backlogEmpty track parser progress" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try t.expect(r.atMessageStart());
+    try r.feed("GET / HT");
+    try t.expect(r.atMessageStart());
+    try t.expect(!r.backlogEmpty());
+    try r.feed("TP/1.1\r\nHost: x\r\n\r\n");
+    try t.expect((try r.nextEvent()) == .request);
+    try t.expect(!r.atMessageStart());
+}
+
 test "fuzz: reader never panics on adversarial inputs" {
     const seeds = [_][]const u8{
         "",

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -45,6 +45,12 @@ const H1Engine = struct {
     /// they outlive the head buffer. `upgrade_obj` is held Python bytes (or null).
     should_close: bool = false,
     upgrade_obj: py.Object = null,
+    /// Single-copy body path: when a fed buffer's prefix is a Content-Length
+    /// body, the bytes object is held here (incref'd, its memory stable)
+    /// instead of being copied into the reader; next_event materialises Data
+    /// events straight from it. `pending` is the not-yet-consumed remainder.
+    pending_obj: py.Object = null,
+    pending: []const u8 = &.{},
 
     fn rememberMethod(self: *H1Engine, m: []const u8) void {
         if (m.len > self.req_method.len) {
@@ -59,12 +65,62 @@ const H1Engine = struct {
         return self.req_method[0..self.req_method_len];
     }
 
+    fn stash(self: *H1Engine, obj: py.Object, rest: []const u8) void {
+        py.incref(obj);
+        self.pending_obj = obj;
+        self.pending = rest;
+    }
+
+    fn dropPending(self: *H1Engine) void {
+        py.xdecref(self.pending_obj);
+        self.pending_obj = null;
+        self.pending = &.{};
+    }
+
+    /// Move the stashed remainder into the reader's own buffer (the slow path
+    /// the stash bypassed). Returns false with a Python error set on failure.
+    fn flushPending(self: *H1Engine) bool {
+        if (self.pending_obj == null) return true;
+        const rest = self.pending;
+        defer self.dropPending();
+        self.reader.feed(rest) catch |err| {
+            _ = exceptions.raiseParse(err);
+            return false;
+        };
+        return true;
+    }
+
+    /// Feeds smaller than this take the plain buffered path: the head-split
+    /// scan below costs one extra pass over the head, which only pays for
+    /// itself when a sizeable body follows.
+    const head_split_min_feed = 1024;
+
+    fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
+        if (!self.flushPending()) return null;
+        if (data.len > 0 and self.reader.backlogEmpty()) {
+            if (self.reader.bodyLengthRemaining() != null) {
+                self.stash(obj, data);
+                return py.none();
+            }
+            if (data.len >= head_split_min_feed and self.reader.atMessageStart()) {
+                if (core.h1.reader.findHeadEnd(data)) |head_end| {
+                    self.reader.feed(data[0..head_end]) catch |err| return exceptions.raiseParse(err);
+                    if (head_end < data.len) self.stash(obj, data[head_end..]);
+                    return py.none();
+                }
+            }
+        }
+        self.reader.feed(data) catch |err| return exceptions.raiseParse(err);
+        return py.none();
+    }
+
     fn deinit(self: *H1Engine) void {
         self.reader.deinit();
         gpa.destroy(self.reader);
         self.writer.deinit();
         gpa.destroy(self.writer);
         py.xdecref(self.upgrade_obj);
+        py.xdecref(self.pending_obj);
     }
 };
 
@@ -573,10 +629,7 @@ fn receive_data(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Objec
             e.conn.feed(bytes) catch |err| return exceptions.raiseH2(err);
             return py.none();
         },
-        .h1 => |*e| {
-            e.reader.feed(bytes) catch |err| return exceptions.raiseParse(err); // MessageTooLong -> RemoteProtocolError
-            return py.none();
-        },
+        .h1 => |*e| return e.receiveData(bytes, arg),
         .h3 => return py.raiseRuntime("receive_data is not valid for an HTTP/3 connection; use receive_datagram"),
     }
 }
@@ -604,17 +657,50 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {
-            const ev = e.reader.nextEvent() catch |err| return exceptions.raiseParse(err);
-            if (ev == .request) {
-                e.rememberMethod(ev.request.method);
-                e.should_close = e.reader.shouldClose();
-                py.xdecref(e.upgrade_obj);
-                if (e.reader.upgrade()) |u| {
-                    e.upgrade_obj = py.fromBytes(u);
-                    if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
-                } else e.upgrade_obj = null;
+            while (true) {
+                const ev = e.reader.nextEvent() catch |err| {
+                    e.dropPending();
+                    return exceptions.raiseParse(err);
+                };
+                if (ev == .need_data and e.pending_obj != null) {
+                    if (e.reader.backlogEmpty()) {
+                        if (e.reader.bodyLengthRemaining()) |rem| {
+                            // Materialise body bytes straight from the stashed
+                            // buffer - the one copy - and account for them.
+                            const take: usize = @intCast(@min(rem, @as(u64, e.pending.len)));
+                            const out = events_obj.fromH1Event(.{ .data = .{ .data = e.pending[0..take] } });
+                            if (out == null) return null;
+                            e.reader.skipBodyLength(take);
+                            e.pending = e.pending[take..];
+                            if (e.pending.len == 0) {
+                                e.dropPending();
+                            } else if (e.reader.bodyLengthRemaining() == null) {
+                                // The remainder is the next pipelined message.
+                                if (!e.flushPending()) {
+                                    py.decref(out);
+                                    return null;
+                                }
+                            }
+                            return out;
+                        }
+                    }
+                    // The stash cannot be consumed in place (chunked body,
+                    // message done, or buffered bytes precede it): buffer it
+                    // and ask the reader again.
+                    if (!e.flushPending()) return null;
+                    continue;
+                }
+                if (ev == .request) {
+                    e.rememberMethod(ev.request.method);
+                    e.should_close = e.reader.shouldClose();
+                    py.xdecref(e.upgrade_obj);
+                    if (e.reader.upgrade()) |u| {
+                        e.upgrade_obj = py.fromBytes(u);
+                        if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
+                    } else e.upgrade_obj = null;
+                }
+                return events_obj.fromH1Event(ev);
             }
-            return events_obj.fromH1Event(ev);
         },
     }
 }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -34,7 +34,9 @@ const HTTP3: c_long = 3;
 /// state the send path needs (the request method the next response answers, the
 /// keep-alive / upgrade signals captured at parse time).
 const H1Engine = struct {
-    reader: *Reader,
+    /// Embedded by value: the engine is one allocation, so constructing a
+    /// Connection does not pay a separate heap allocation for the Reader.
+    reader: Reader,
     writer: *Writer,
     /// The method of the message the next response answers (server: the parsed
     /// request; client: the request we sent), so the connection auto-derives
@@ -116,7 +118,6 @@ const H1Engine = struct {
 
     fn deinit(self: *H1Engine) void {
         self.reader.deinit();
-        gpa.destroy(self.reader);
         self.writer.deinit();
         gpa.destroy(self.writer);
         py.xdecref(self.upgrade_obj);
@@ -299,7 +300,11 @@ const Engine = union(enum) {
 
 const ConnectionObject = extern struct {
     ob_base: c.PyObject,
+    /// Points into `engine_storage` when live, null once torn down. The engine
+    /// lives inside the PyObject so constructing a Connection costs no separate
+    /// heap allocation for it.
     engine: ?*Engine,
+    engine_storage: [@sizeOf(Engine)]u8 align(@alignOf(Engine)),
 };
 
 var connection_type: py.Object = null;
@@ -452,11 +457,23 @@ var stream_spec = py.Spec{
 fn parseArgs(args: ?*c.PyObject, kwds: ?*c.PyObject, role: *Role, protocol_out: *c_long, fixed: ?c_long) bool {
     var role_val: c_long = 0;
     var protocol_val: c_long = fixed orelse HTTP1;
-    // The kwlist parameter type differs across CPython versions (char** in 3.12,
-    // const char* const* in 3.13+), so build a plain C-pointer array and ptrCast
-    // it to whatever the translated signature expects.
-    var kwlist = [_][*c]u8{ @constCast("role"), @constCast("protocol"), null };
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l", @ptrCast(&kwlist), &role_val, &protocol_val) == 0) return false;
+    const positional = if (kwds == null) c.PyTuple_Size(args) else -1;
+    if (positional == 1 or positional == 2) {
+        // The common positional forms skip PyArg_ParseTupleAndKeywords, which
+        // costs more than the rest of construction combined.
+        role_val = c.PyLong_AsLong(c.PyTuple_GetItem(args, 0));
+        if (role_val == -1 and c.PyErr_Occurred() != null) return false;
+        if (positional == 2) {
+            protocol_val = c.PyLong_AsLong(c.PyTuple_GetItem(args, 1));
+            if (protocol_val == -1 and c.PyErr_Occurred() != null) return false;
+        }
+    } else {
+        // The kwlist parameter type differs across CPython versions (char** in 3.12,
+        // const char* const* in 3.13+), so build a plain C-pointer array and ptrCast
+        // it to whatever the translated signature expects.
+        var kwlist = [_][*c]u8{ @constCast("role"), @constCast("protocol"), null };
+        if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l", @ptrCast(&kwlist), &role_val, &protocol_val) == 0) return false;
+    }
     role.* = switch (role_val) {
         SERVER => .server,
         CLIENT => .client,
@@ -491,10 +508,11 @@ fn allocAndBuild(tp: ?*c.PyTypeObject, role: Role, protocol_val: c_long) py.Obje
     if (obj == null) return null;
     const self: *ConnectionObject = @ptrCast(obj);
     self.engine = null;
-    const engine = buildEngine(role, protocol_val) orelse {
+    const engine: *Engine = @ptrCast(@alignCast(&self.engine_storage));
+    if (!buildEngine(engine, role, protocol_val)) {
         py.decref(obj);
         return null;
-    };
+    }
     self.engine = engine;
     return obj;
 }
@@ -540,60 +558,43 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
     return allocAndBuild(tp, role, HTTP3);
 }
 
-fn buildEngine(role: Role, protocol_val: c_long) ?*Engine {
-    const engine = gpa.create(Engine) catch {
-        _ = c.PyErr_NoMemory();
-        return null;
-    };
-
+fn buildEngine(engine: *Engine, role: Role, protocol_val: c_long) bool {
     if (protocol_val == HTTP3) {
         // The QUIC + HTTP/3 engine is built lazily on the first datagram.
         engine.* = .{ .h3 = .{} };
-        return engine;
+        return true;
     }
 
     if (protocol_val == HTTP2) {
         const conn = gpa.create(H2Connection) catch {
-            gpa.destroy(engine);
             _ = c.PyErr_NoMemory();
-            return null;
+            return false;
         };
         conn.* = H2Connection.init(gpa, if (role == .server) H2Role.server else H2Role.client);
         const writer = gpa.create(H2Writer) catch {
             conn.deinit();
             gpa.destroy(conn);
-            gpa.destroy(engine);
             _ = c.PyErr_NoMemory();
-            return null;
+            return false;
         };
         writer.* = H2Writer.init(gpa, if (role == .server) core.h2.writer.Role.server else core.h2.writer.Role.client);
         engine.* = .{ .h2 = .{ .conn = conn, .writer = writer } };
-        return engine;
+        return true;
     }
 
-    const reader = gpa.create(Reader) catch {
-        gpa.destroy(engine);
-        _ = c.PyErr_NoMemory();
-        return null;
-    };
-    reader.* = Reader.init(gpa, role);
     const writer = gpa.create(Writer) catch {
-        reader.deinit();
-        gpa.destroy(reader);
-        gpa.destroy(engine);
         _ = c.PyErr_NoMemory();
-        return null;
+        return false;
     };
     writer.* = Writer.init(gpa);
-    engine.* = .{ .h1 = .{ .reader = reader, .writer = writer } };
-    return engine;
+    engine.* = .{ .h1 = .{ .reader = Reader.init(gpa, role), .writer = writer } };
+    return true;
 }
 
 fn dealloc(self_obj: ?*c.PyObject) callconv(.c) void {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     if (self.engine) |engine| {
         engine.deinit();
-        gpa.destroy(engine);
     }
     py.freeInstance(@ptrCast(self));
 }

--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -592,14 +592,63 @@ const INTERNED_NAMES = [_][]const u8{
     "Transfer-Encoding",
 };
 
+// The request/status line draws from even smaller fixed sets: the standard
+// methods, the two HTTP/1.x versions, and the stock reason phrases. Same deal -
+// one PyBytes each at module init, returned on an exact-bytes match.
+const INTERNED_METHODS = [_][]const u8{ "GET", "POST", "HEAD", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH" };
+const INTERNED_VERSIONS = [_][]const u8{ "1.1", "1.0" };
+const INTERNED_REASONS = [_][]const u8{
+    "OK",
+    "Created",
+    "Accepted",
+    "No Content",
+    "Moved Permanently",
+    "Found",
+    "Not Modified",
+    "Bad Request",
+    "Unauthorized",
+    "Forbidden",
+    "Not Found",
+    "Internal Server Error",
+    "Service Unavailable",
+};
+
 var interned: [INTERNED_NAMES.len]py.Object = @splat(null);
+var interned_methods: [INTERNED_METHODS.len]py.Object = @splat(null);
+var interned_versions: [INTERNED_VERSIONS.len]py.Object = @splat(null);
+var interned_reasons: [INTERNED_REASONS.len]py.Object = @splat(null);
+var empty_bytes: py.Object = null;
 
 fn buildInternTable() bool {
     inline for (INTERNED_NAMES, 0..) |name, i| {
         interned[i] = py.fromBytes(name);
         if (interned[i] == null) return false;
     }
-    return true;
+    inline for (INTERNED_METHODS, 0..) |m, i| {
+        interned_methods[i] = py.fromBytes(m);
+        if (interned_methods[i] == null) return false;
+    }
+    inline for (INTERNED_VERSIONS, 0..) |v, i| {
+        interned_versions[i] = py.fromBytes(v);
+        if (interned_versions[i] == null) return false;
+    }
+    inline for (INTERNED_REASONS, 0..) |r, i| {
+        interned_reasons[i] = py.fromBytes(r);
+        if (interned_reasons[i] == null) return false;
+    }
+    empty_bytes = py.fromBytes("");
+    return empty_bytes != null;
+}
+
+/// A new reference to the cached PyBytes for `s` if it matches a table entry
+/// exactly, else null. The tables are small enough that a length + first-byte
+/// gated linear scan beats fancier dispatch.
+fn internFrom(comptime table: []const []const u8, cache: *const [table.len]py.Object, s: []const u8) ?py.Object {
+    if (s.len == 0) return null;
+    inline for (table, 0..) |cand, i| {
+        if (s.len == cand.len and s[0] == cand[0] and std.mem.eql(u8, s, cand)) return py.newRef(cache[i]);
+    }
+    return null;
 }
 
 /// A new reference to the cached PyBytes for `name` if it matches an interned
@@ -697,11 +746,16 @@ fn makeRequest(r: events.Request) py.Object {
     const o = py.allocInstance(request_type);
     if (o == null) return null;
     const s: *RequestObject = @ptrCast(o);
-    s.method = py.fromBytes(r.method);
+    s.method = internFrom(&INTERNED_METHODS, &interned_methods, r.method) orelse py.fromBytes(r.method);
     s.target = py.fromBytes(r.target);
-    s.path = py.fromBytes(r.path);
-    s.query = py.fromBytes(r.query);
-    s.http_version = py.fromBytes(r.http_version);
+    // With no query string the parser hands path and target as the same slice,
+    // so the immutable target bytes can simply be shared.
+    s.path = if (s.target != null and r.path.ptr == r.target.ptr and r.path.len == r.target.len)
+        py.newRef(s.target)
+    else
+        py.fromBytes(r.path);
+    s.query = if (r.query.len == 0) py.newRef(empty_bytes) else py.fromBytes(r.query);
+    s.http_version = internFrom(&INTERNED_VERSIONS, &interned_versions, r.http_version) orelse py.fromBytes(r.http_version);
     s.headers = buildHeaders(r.headers);
     s.stream_id = u32Obj(r.stream_id);
     s.expect_continue = @intFromBool(r.expect_continue);
@@ -717,8 +771,8 @@ fn makeResponse(r: events.Response) py.Object {
     if (o == null) return null;
     const s: *ResponseObject = @ptrCast(o);
     s.status_code = py.fromU16(r.status_code);
-    s.reason = py.fromBytes(r.reason);
-    s.http_version = py.fromBytes(r.http_version);
+    s.reason = internFrom(&INTERNED_REASONS, &interned_reasons, r.reason) orelse py.fromBytes(r.reason);
+    s.http_version = internFrom(&INTERNED_VERSIONS, &interned_versions, r.http_version) orelse py.fromBytes(r.http_version);
     s.headers = buildHeaders(r.headers);
     s.stream_id = u32Obj(r.stream_id);
     if (s.status_code == null or s.reason == null or s.http_version == null or s.headers == null or s.stream_id == null) {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -162,3 +162,55 @@ def test_invalid_role_rejected() -> None:
 def test_remote_is_subclass_of_protocol_error() -> None:
     assert issubclass(zttp.RemoteProtocolError, zttp.ProtocolError)
     assert issubclass(zttp.LocalProtocolError, zttp.ProtocolError)
+
+
+def test_body_and_pipelined_request_in_one_feed() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(
+        b"POST /a HTTP/1.1\r\nContent-Length: 5\r\n\r\nfirstPOST /b HTTP/1.1\r\nContent-Length: 6\r\n\r\nsecond"
+    )
+    events = list(drain(conn))
+    assert events[0].target == b"/a"
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"first"
+    conn.start_next_cycle()
+    events = list(drain(conn))
+    assert events[0].target == b"/b"
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"second"
+
+
+def test_second_feed_arrives_before_first_is_drained() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhello")
+    conn.receive_data(b"world")
+    events = list(drain(conn))
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"helloworld"
+    assert isinstance(events[-1], zttp.EndOfMessage)
+
+
+def test_body_fed_in_pieces_with_draining_between() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 9\r\n\r\n")
+    assert isinstance(next(drain(conn)), zttp.Request)
+    body = b""
+    for piece in (b"abc", b"def", b"ghi"):
+        conn.receive_data(piece)
+        body += b"".join(e.data for e in drain(conn) if isinstance(e, zttp.Data))
+    assert body == b"abcdefghi"
+
+
+def test_garbage_after_complete_message_raises_on_next_cycle() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nokNOT HTTP\x00\r\n\r\n")
+    events = list(drain(conn))
+    assert isinstance(events[-1], zttp.EndOfMessage)
+    conn.start_next_cycle()
+    with pytest.raises(zttp.RemoteProtocolError):
+        drain_all(conn)
+
+
+def test_large_body_round_trips_unchanged() -> None:
+    body = bytes(range(256)) * 256  # 64KB, every byte value
+    raw = b"POST /up HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    events = parse_request(raw)
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == body
+    assert isinstance(events[-1], zttp.EndOfMessage)


### PR DESCRIPTION
Stacked on #72. Second of the vetted series.

`makeRequest` allocated five fresh `PyBytes` per request, four of which almost always come from tiny fixed sets. This extends the header-name interning pattern to the request/status line:

- Init-time intern tables for the nine standard methods, the two HTTP/1.x versions, and thirteen stock reason phrases (exact-bytes match only, wire casing preserved; anything else allocates fresh as before).
- When a request has no query string, the parser hands `path` and `target` as the identical slice - `Request.path` now shares the immutable target bytes object instead of allocating a second copy.
- An empty query returns a cached `b""`.

Before/after (back-to-back full-suite runs, ReleaseSafe, CPython 3.14, httptools 0.8.0):

| workload | before | after |
| --- | ---: | ---: |
| wrk default GET | 2.15M (1.02x) | **2.22M (1.09x)** |
| httparse REQ_SHORT | 1.89M (1.09x) | **1.92M (1.12x)** |
| TFB plaintext x16 pipelined | 128k (0.80x) | **133k (0.86x)** |
| small API GET | 1.04M (0.98x) | **1.05M (1.03x)** |
| POST + JSON body | 1.20M (0.98x) | **1.26M (1.05x)** |
| 16KB upload POST | 981k (0.95x) | **1.03M (1.01x)** |
| httparse RESP_SHORT | 1.57M (1.02x) | **1.60M (1.05x)** |
| remaining rows | +1.5-3.5% each | - |

After vs httptools, full suite: 10 of 14 workloads now at or above 1.0x (wrk 1.09, REQ_SHORT 1.12, small API 1.03, POST+JSON 1.05, chunked POST 1.04, Chrome 1.02, 16KB upload 1.01, MTU pieces 1.99, RESP_SHORT 1.05, JSON response 1.03); below: TFB pipelined 0.86, pico GET 0.97, k8s proxied 0.98, chunked HTML 0.98.

All 166 tests pass. Reviewed by Codex CLI: approved, no findings (refcount balance incl. the path-shares-target flow, match exactness, immutable-sharing observability, free-threading-safe read-only tables).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.