### PR TITLE
Add the QUIC STREAM send path on the shared packet builder

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -270,17 +270,24 @@ pub const Connection = struct {
         const st = &self.spaces[@intFromEnum(space)];
         if (st.send_keys == null) return; // no 1-RTT keys yet: nothing can be sent
         // A conservative single-packet budget; one STREAM frame per packet for now.
-        const room = constants.MIN_INITIAL_DATAGRAM - 64;
+        const packet_room = constants.MIN_INITIAL_DATAGRAM - 64;
         var it = self.send_streams.iterator();
         while (it.next()) |entry| {
             const id = entry.key_ptr.*;
             const s = entry.value_ptr.*;
             while (s.pending()) {
-                const chunk = s.peek(room) orelse break;
+                // Cap the chunk by the connection-level send window (RFC 9000 4.1):
+                // the peer's MAX_DATA grant limits how much STREAM data may be sent.
+                // A chunk that carries only a FIN (no bytes) needs no credit.
+                const credit = self.conn_send_window.available();
+                const room = @min(packet_room, credit);
+                const chunk = s.peek(room) orelse break; // no bytes fit and no FIN owed
+                if (chunk.data.len == 0 and !chunk.fin) break; // out of window: keep the rest queued
                 var frames: std.ArrayListUnmanaged(u8) = .empty;
                 defer frames.deinit(self.gpa);
                 frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
                 try self.buildPacket(space, frames.items, true, now);
+                self.conn_send_window.onSent(chunk.data.len);
                 s.commit(chunk.data.len, chunk.fin);
             }
         }
@@ -964,6 +971,32 @@ test "flushSend is a no-op until the Application keys are installed" {
     testInstallAppKeys(&conn);
     try conn.flushSend(1000);
     try testing.expectEqual(@as(usize, 1), conn.datagramLengths().len);
+}
+
+test "flushSend never sends past the connection send window, and resumes on MAX_DATA" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x91, 0x92, 0x93, 0x94 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.conn_send_window.limit = 4; // the peer has granted only 4 bytes
+
+    try conn.sendStreamData(1, "abcdefghij", false); // 10 bytes queued
+    try conn.flushSend(1000);
+    // Only the 4 granted bytes left; the rest stays queued.
+    try testing.expectEqual(@as(u64, 4), conn.conn_send_window.sent);
+    try testing.expect(conn.hasPendingSend());
+
+    // A flush with no further credit sends nothing more.
+    conn.clearSend();
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+
+    // The peer raises MAX_DATA; the remaining bytes can now flow.
+    conn.conn_send_window.onMaxData(10);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(u64, 10), conn.conn_send_window.sent);
+    try testing.expect(!conn.hasPendingSend());
 }
 
 test "a large stream send is chunked across multiple packets" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -261,6 +261,10 @@ pub const Connection = struct {
     /// frame per packet. STREAM is legal only in the Application space (RFC 9000
     /// 12.4), so nothing flows until the handshake installs the 1-RTT send keys -
     /// the structural fix for shipping STREAM data in Initial packets.
+    ///
+    /// `commit` drops each chunk from the SendStream once it is framed, so a packet
+    /// lost in flight is NOT retransmitted: loss-recovery for STREAM data (tracking
+    /// sent-but-unacked ranges and requeueing on loss/PTO) is a deliberate follow-up.
     pub fn flushSend(self: *Connection, now: u64) Error!void {
         const space = Space.application;
         const st = &self.spaces[@intFromEnum(space)];

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -6,12 +6,11 @@
 //! the HTTP/3 layer. It is sans-IO: bytes and a monotonic `now` in, transport
 //! state and (eventually) datagrams out, no socket.
 //!
-//! Scope: the Initial packet-number space is wired end-to-end, which exercises the
-//! whole pipeline (header protection, AEAD, framing, ack/stream state) with the
-//! deterministic Initial keys. The Handshake and Application spaces install their
-//! keys through the same `installKeys` seam once the TLS 1.3 handshake driver
-//! lands; that negotiation is the follow-up, mirroring how HTTP/2 staged its write
-//! side.
+//! Scope: all three packet-number spaces are wired. The TLS 1.3 handshake runs
+//! over CRYPTO frames and installs the Handshake and Application keys through the
+//! `installKeys` seam; `buildPacket` is the one send primitive (CRYPTO, ACK, and
+//! STREAM all funnel through it), so STREAM data ships only in the Application
+//! space once 1-RTT keys exist - never in an Initial packet.
 
 const std = @import("std");
 const constants = @import("constants.zig");
@@ -80,6 +79,7 @@ pub const Connection = struct {
     conn_received_total: u64 = 0,
     conn_consumed_total: u64 = 0,
     streams: std.AutoHashMapUnmanaged(u64, *stream.RecvStream) = .empty,
+    send_streams: std.AutoHashMapUnmanaged(u64, *stream.SendStream) = .empty,
     /// Built datagrams waiting to be drained by `datagramsToSend` (one contiguous
     /// buffer; `out_lengths` records each datagram's byte length in order).
     out: std.ArrayListUnmanaged(u8) = .empty,
@@ -146,6 +146,12 @@ pub const Connection = struct {
             self.gpa.destroy(s.*);
         }
         self.streams.deinit(self.gpa);
+        var sit = self.send_streams.valueIterator();
+        while (sit.next()) |s| {
+            s.*.deinit();
+            self.gpa.destroy(s.*);
+        }
+        self.send_streams.deinit(self.gpa);
         self.out.deinit(self.gpa);
         self.out_lengths.deinit(self.gpa);
         for (&self.spaces) |*s| s.deinit(self.gpa);
@@ -218,6 +224,62 @@ pub const Connection = struct {
     pub fn clearSend(self: *Connection) void {
         self.out.clearRetainingCapacity();
         self.out_lengths.clearRetainingCapacity();
+    }
+
+    // ---- STREAM send -----------------------------------------------------------
+
+    fn sendStream(self: *Connection, id: u64) Error!*stream.SendStream {
+        if (self.send_streams.get(id)) |s| return s;
+        const s = try self.gpa.create(stream.SendStream);
+        s.* = stream.SendStream.init(self.gpa);
+        self.send_streams.put(self.gpa, id, s) catch {
+            s.deinit();
+            self.gpa.destroy(s);
+            return error.OutOfMemory;
+        };
+        return s;
+    }
+
+    /// Queue `data` (and/or a FIN) to be sent on stream `id`. `flushSend` packetizes
+    /// the queue once the Application keys exist. Writing after a FIN is rejected.
+    pub fn sendStreamData(self: *Connection, id: u64, data: []const u8, fin: bool) Error!void {
+        const s = try self.sendStream(id);
+        s.write(data, fin) catch |e| switch (e) {
+            error.FinalSizeError => return error.FinalSizeError,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+    }
+
+    /// Whether any stream has bytes (or a FIN) still to send.
+    pub fn hasPendingSend(self: *Connection) bool {
+        var it = self.send_streams.valueIterator();
+        while (it.next()) |s| if (s.*.pending()) return true;
+        return false;
+    }
+
+    /// Packetize queued stream data into Application (1-RTT) datagrams, one STREAM
+    /// frame per packet. STREAM is legal only in the Application space (RFC 9000
+    /// 12.4), so nothing flows until the handshake installs the 1-RTT send keys -
+    /// the structural fix for shipping STREAM data in Initial packets.
+    pub fn flushSend(self: *Connection, now: u64) Error!void {
+        const space = Space.application;
+        const st = &self.spaces[@intFromEnum(space)];
+        if (st.send_keys == null) return; // no 1-RTT keys yet: nothing can be sent
+        // A conservative single-packet budget; one STREAM frame per packet for now.
+        const room = constants.MIN_INITIAL_DATAGRAM - 64;
+        var it = self.send_streams.iterator();
+        while (it.next()) |entry| {
+            const id = entry.key_ptr.*;
+            const s = entry.value_ptr.*;
+            while (s.pending()) {
+                const chunk = s.peek(room) orelse break;
+                var frames: std.ArrayListUnmanaged(u8) = .empty;
+                defer frames.deinit(self.gpa);
+                frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
+                try self.buildPacket(space, frames.items, true, now);
+                s.commit(chunk.data.len, chunk.fin);
+            }
+        }
     }
 
     // ---- TLS handshake drive ---------------------------------------------------
@@ -853,4 +915,85 @@ test "a malformed ClientHello (no supported_versions) poisons the connection" {
     const dgram = try testBuildInitial(gpa, &dcid, .client, 0, frames.items);
     defer gpa.free(dgram);
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(dgram, 1000));
+}
+
+// ---- STREAM send tests -----------------------------------------------------
+
+test "queued stream data flushes into a 1-RTT datagram a peer reassembles" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48 };
+
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    // Nothing to flush until data is queued.
+    try testing.expect(!sender.hasPendingSend());
+    try sender.sendStreamData(1, "hello over quic", true); // server-initiated bidi id 1
+    try testing.expect(sender.hasPendingSend());
+
+    try sender.flushSend(1000);
+    try testing.expectEqual(@as(usize, 1), sender.datagramLengths().len);
+    try testing.expect(!sender.hasPendingSend()); // fully drained
+
+    // A peer with the matching Application keys decrypts and reassembles it.
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+    try peer.receiveDatagram(sender.datagramsToSend(), 2000);
+    try testing.expectEqualStrings("hello over quic", peer.streamData(1));
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "flushSend is a no-op until the Application keys are installed" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x51, 0x52, 0x53, 0x54 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    // No app keys yet (no handshake): queued data cannot leave - the #64 P1 fix.
+    try conn.sendStreamData(1, "held", false);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+    try testing.expect(conn.hasPendingSend()); // still queued
+
+    // Once 1-RTT keys exist, the same queue flushes.
+    testInstallAppKeys(&conn);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 1), conn.datagramLengths().len);
+}
+
+test "a large stream send is chunked across multiple packets" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x61, 0x62, 0x63, 0x64 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    const big = [_]u8{0x7a} ** 4000; // larger than one packet's room
+    try sender.sendStreamData(1, &big, true);
+    try sender.flushSend(1000);
+    try testing.expect(sender.datagramLengths().len > 1); // split into multiple packets
+
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+    // Each built packet is its own UDP datagram (a short header runs to the
+    // datagram end), so the peer is fed them one at a time, sliced by the lengths.
+    const buf = sender.datagramsToSend();
+    var off: usize = 0;
+    for (sender.datagramLengths()) |len| {
+        try peer.receiveDatagram(buf[off .. off + len], 2000);
+        off += len;
+    }
+    try testing.expectEqual(@as(usize, big.len), peer.streamData(1).len);
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "writing after a FIN is a final-size error" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x71, 0x72, 0x73, 0x74 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    try conn.sendStreamData(1, "done", true);
+    try testing.expectError(error.FinalSizeError, conn.sendStreamData(1, "more", false));
 }

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -180,6 +180,64 @@ pub const RecvStream = struct {
     }
 };
 
+/// The send side of one stream: a queue of outbound bytes the connection drains
+/// into STREAM frames. It tracks the offset of the next unsent byte and whether a
+/// FIN is owed, mirroring RecvStream but for the write direction.
+pub const SendStream = struct {
+    gpa: std.mem.Allocator,
+    /// Bytes queued but not yet framed (drained from the front as they are sent).
+    unsent: std.ArrayListUnmanaged(u8) = .empty,
+    /// The offset of the first byte still in `unsent` - what a STREAM frame for the
+    /// next chunk carries.
+    send_offset: u64 = 0,
+    /// The application has finished writing; a FIN is owed on the last frame.
+    fin: bool = false,
+    /// The FIN has been emitted on a frame, so the stream is fully sent.
+    fin_sent: bool = false,
+
+    pub fn init(gpa: std.mem.Allocator) SendStream {
+        return .{ .gpa = gpa };
+    }
+
+    pub fn deinit(self: *SendStream) void {
+        self.unsent.deinit(self.gpa);
+    }
+
+    /// Queue `data` to be sent and/or mark the stream finished. Writing after the
+    /// stream has been finished (FIN owed or sent) would push bytes past the
+    /// declared final size (RFC 9000 4.5), so it is rejected.
+    pub fn write(self: *SendStream, data: []const u8, fin: bool) Error!void {
+        if (self.fin and (data.len != 0 or !fin)) return error.FinalSizeError;
+        self.unsent.appendSlice(self.gpa, data) catch return error.OutOfMemory;
+        if (fin) self.fin = true;
+    }
+
+    /// Whether anything still needs to leave: buffered bytes, or an owed FIN.
+    pub fn pending(self: *const SendStream) bool {
+        return self.unsent.items.len > 0 or (self.fin and !self.fin_sent);
+    }
+
+    /// The next chunk to frame, capped at `max` bytes. Returns the offset, the
+    /// chunk (a slice into `unsent`, valid until the next `commit`), and whether
+    /// this chunk carries the FIN. Call `commit` once the chunk is framed.
+    pub const Chunk = struct { offset: u64, data: []const u8, fin: bool };
+    pub fn peek(self: *const SendStream, max: usize) ?Chunk {
+        const n = @min(max, self.unsent.items.len);
+        const carries_fin = self.fin and !self.fin_sent and n == self.unsent.items.len;
+        if (n == 0 and !carries_fin) return null;
+        return .{ .offset = self.send_offset, .data = self.unsent.items[0..n], .fin = carries_fin };
+    }
+
+    /// Drop the `n` bytes a framed chunk consumed and, if it carried the FIN, mark
+    /// the FIN sent. `n` must be the length of the chunk returned by `peek`.
+    pub fn commit(self: *SendStream, n: usize, sent_fin: bool) void {
+        std.mem.copyForwards(u8, self.unsent.items[0 .. self.unsent.items.len - n], self.unsent.items[n..]);
+        self.unsent.shrinkRetainingCapacity(self.unsent.items.len - n);
+        self.send_offset += n;
+        if (sent_fin) self.fin_sent = true;
+    }
+};
+
 test "stream-id typing reads the low two bits" {
     try std.testing.expectEqual(StreamType.client_bidi, StreamType.of(0));
     try std.testing.expectEqual(StreamType.server_bidi, StreamType.of(1));
@@ -246,4 +304,53 @@ test "a conflicting FIN offset is rejected" {
     defer s.deinit();
     _ = try s.push(0, "abcde", true); // final size 5
     try std.testing.expectError(error.FinalSizeError, s.push(0, "abc", true)); // fin at 3
+}
+
+test "SendStream drains queued bytes in offset-ordered chunks" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("hello world", false);
+    try std.testing.expect(s.pending());
+
+    const c1 = s.peek(5).?; // capped at 5
+    try std.testing.expectEqual(@as(u64, 0), c1.offset);
+    try std.testing.expectEqualStrings("hello", c1.data);
+    try std.testing.expect(!c1.fin);
+    s.commit(c1.data.len, false);
+
+    const c2 = s.peek(100).?;
+    try std.testing.expectEqual(@as(u64, 5), c2.offset);
+    try std.testing.expectEqualStrings(" world", c2.data);
+    s.commit(c2.data.len, false);
+    try std.testing.expect(!s.pending());
+}
+
+test "SendStream carries the FIN on the final chunk and forbids later writes" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("data", true); // bytes + FIN
+    const c = s.peek(100).?;
+    try std.testing.expect(c.fin);
+    s.commit(c.data.len, true);
+    try std.testing.expect(!s.pending()); // FIN sent, nothing left
+
+    // Writing after FIN would exceed the final size.
+    try std.testing.expectError(error.FinalSizeError, s.write("x", false));
+    // An empty, idempotent FIN write is allowed.
+    try s.write("", true);
+}
+
+test "SendStream owes a FIN even with no bytes" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("", true); // pure FIN
+    try std.testing.expect(s.pending());
+    const c = s.peek(100).?;
+    try std.testing.expectEqual(@as(usize, 0), c.data.len);
+    try std.testing.expect(c.fin);
+    s.commit(0, true);
+    try std.testing.expect(!s.pending());
 }


### PR DESCRIPTION
The QUIC STREAM send path, rebuilt on the shared `buildPacket` core that landed with the connection seam (#73). This supersedes #64, which hardcoded the Initial space and had to be held on that P1 - the new path ships STREAM data only in the Application space, so the P1 is gone by construction.

- `stream.zig` gains `SendStream`, the write-side mirror of `RecvStream`: it buffers unsent bytes, tracks the next offset and an owed FIN, and yields offset-ordered `Chunk`s (`write`/`pending`/`peek`/`commit`). A write after FIN is a `FinalSizeError`.
- `connection.zig` gains `sendStreamData`/`hasPendingSend`/`flushSend`. `flushSend` drains each stream through `buildPacket` in the Application space, one STREAM frame per packet, and is gated on the Application send keys: nothing leaves until the handshake installs them.

Because everything funnels through `buildPacket`, STREAM-in-Initial is unrepresentable on both halves: the send side asserts frame legality per space, and the recv side gates it (RFC 9000 12.4). A round-trip test queues data on one connection, flushes it, and reassembles the identical bytes on a peer; the rest cover the keys-gate no-op (data stays queued until 1-RTT keys exist), multi-packet chunking of a large send, and the write-after-FIN rejection.

Closes #64.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
