### PR TITLE
Retransmit lost STREAM data on packet loss

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -270,17 +270,24 @@ pub const Connection = struct {
         const st = &self.spaces[@intFromEnum(space)];
         if (st.send_keys == null) return; // no 1-RTT keys yet: nothing can be sent
         // A conservative single-packet budget; one STREAM frame per packet for now.
-        const room = constants.MIN_INITIAL_DATAGRAM - 64;
+        const packet_room = constants.MIN_INITIAL_DATAGRAM - 64;
         var it = self.send_streams.iterator();
         while (it.next()) |entry| {
             const id = entry.key_ptr.*;
             const s = entry.value_ptr.*;
             while (s.pending()) {
-                const chunk = s.peek(room) orelse break;
+                // Cap the chunk by the connection-level send window (RFC 9000 4.1):
+                // the peer's MAX_DATA grant limits how much STREAM data may be sent.
+                // A chunk that carries only a FIN (no bytes) needs no credit.
+                const credit = self.conn_send_window.available();
+                const room = @min(packet_room, credit);
+                const chunk = s.peek(room) orelse break; // no bytes fit and no FIN owed
+                if (chunk.data.len == 0 and !chunk.fin) break; // out of window: keep the rest queued
                 var frames: std.ArrayListUnmanaged(u8) = .empty;
                 defer frames.deinit(self.gpa);
                 frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
                 try self.buildPacket(space, frames.items, true, now);
+                self.conn_send_window.onSent(chunk.data.len);
                 s.commit(chunk.data.len, chunk.fin);
             }
         }
@@ -964,6 +971,32 @@ test "flushSend is a no-op until the Application keys are installed" {
     testInstallAppKeys(&conn);
     try conn.flushSend(1000);
     try testing.expectEqual(@as(usize, 1), conn.datagramLengths().len);
+}
+
+test "flushSend never sends past the connection send window, and resumes on MAX_DATA" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x91, 0x92, 0x93, 0x94 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.conn_send_window.limit = 4; // the peer has granted only 4 bytes
+
+    try conn.sendStreamData(1, "abcdefghij", false); // 10 bytes queued
+    try conn.flushSend(1000);
+    // Only the 4 granted bytes left; the rest stays queued.
+    try testing.expectEqual(@as(u64, 4), conn.conn_send_window.sent);
+    try testing.expect(conn.hasPendingSend());
+
+    // A flush with no further credit sends nothing more.
+    conn.clearSend();
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+
+    // The peer raises MAX_DATA; the remaining bytes can now flow.
+    conn.conn_send_window.onMaxData(10);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(u64, 10), conn.conn_send_window.sent);
+    try testing.expect(!conn.hasPendingSend());
 }
 
 test "a large stream send is chunked across multiple packets" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -54,12 +54,21 @@ const SpaceState = struct {
     rec: recovery.Space = .{},
     crypto: crypto_stream.CryptoStream,
     ack_pending: bool = false,
+    /// The STREAM range each in-flight packet carried (pn -> {id,offset,len,fin}),
+    /// so a lost packet's data can be re-queued and an acked packet's data freed.
+    /// Only the Application space carries STREAM frames, but the field is uniform.
+    stream_sent: std.AutoHashMapUnmanaged(u64, StreamSent) = .empty,
 
     fn deinit(self: *SpaceState, gpa: std.mem.Allocator) void {
         self.rec.deinit(gpa);
         self.crypto.deinit();
+        self.stream_sent.deinit(gpa);
     }
 };
+
+/// The STREAM frame one sent packet carried, kept so loss recovery can map a lost
+/// or acked packet number back to the stream bytes it was responsible for.
+const StreamSent = struct { id: u64, offset: u64, len: u64, fin: bool };
 
 pub const Connection = struct {
     gpa: std.mem.Allocator,
@@ -171,10 +180,11 @@ pub const Connection = struct {
     /// Build one packet in `space` carrying `frames` (already-encoded frame bytes),
     /// seal and header-protect it, append it to the outbound queue, and record it
     /// for loss recovery / congestion control. The single send primitive: CRYPTO,
-    /// ACK, and (later) STREAM all funnel through here. `frames` MUST fit one
-    /// datagram. A long header (Initial/Handshake) carries our scid + a length
-    /// field; a short header (Application) runs to the datagram end.
-    fn buildPacket(self: *Connection, space: Space, frames: []const u8, ack_eliciting: bool, now: u64) Error!void {
+    /// ACK, and STREAM all funnel through here. Returns the packet number assigned,
+    /// so the STREAM caller can map it back to the range it carried. `frames` MUST
+    /// fit one datagram. A long header (Initial/Handshake) carries our scid + a
+    /// length field; a short header (Application) runs to the datagram end.
+    fn buildPacket(self: *Connection, space: Space, frames: []const u8, ack_eliciting: bool, now: u64) Error!u64 {
         assertFramesAllowedIn(space, frames); // no STREAM in Initial/Handshake, by construction
         const st = &self.spaces[@intFromEnum(space)];
         const keys = st.send_keys orelse return error.ProtocolViolation; // driver installs first
@@ -208,6 +218,7 @@ pub const Connection = struct {
         st.rec.onSent(self.gpa, .{ .pn = pn, .sent_time = now, .size = datagram_len, .ack_eliciting = ack_eliciting, .in_flight = ack_eliciting }) catch return error.OutOfMemory;
         self.cc.onSent(datagram_len);
         st.next_pn += 1;
+        return pn;
     }
 
     /// The built datagrams as one contiguous buffer; pair with `datagramLengths`.
@@ -242,6 +253,12 @@ pub const Connection = struct {
 
     /// Queue `data` (and/or a FIN) to be sent on stream `id`. `flushSend` packetizes
     /// the queue once the Application keys exist. Writing after a FIN is rejected.
+    ///
+    /// This is application queueing: it buffers everything written. Only `flushSend`
+    /// applies the connection send window, so the in-flight bytes on the wire are
+    /// bounded by the peer's MAX_DATA grant, but the queued-but-unsent buffer is
+    /// bounded only by what the application writes. A write-side backpressure cap is
+    /// a follow-up.
     pub fn sendStreamData(self: *Connection, id: u64, data: []const u8, fin: bool) Error!void {
         const s = try self.sendStream(id);
         s.write(data, fin) catch |e| switch (e) {
@@ -262,9 +279,10 @@ pub const Connection = struct {
     /// 12.4), so nothing flows until the handshake installs the 1-RTT send keys -
     /// the structural fix for shipping STREAM data in Initial packets.
     ///
-    /// `commit` drops each chunk from the SendStream once it is framed, so a packet
-    /// lost in flight is NOT retransmitted: loss-recovery for STREAM data (tracking
-    /// sent-but-unacked ranges and requeueing on loss/PTO) is a deliberate follow-up.
+    /// Each sent range is recorded per packet (stream_sent) and retained in the
+    /// SendStream until acked, so a lost packet is retransmitted (the ACK arm routes
+    /// lost pns back into SendStream.onLost). Loss is detected on ACK; a tail packet
+    /// with no later ACK to trigger detection needs the PTO timer, a follow-up.
     pub fn flushSend(self: *Connection, now: u64) Error!void {
         const space = Space.application;
         const st = &self.spaces[@intFromEnum(space)];
@@ -276,19 +294,57 @@ pub const Connection = struct {
             const id = entry.key_ptr.*;
             const s = entry.value_ptr.*;
             while (s.pending()) {
-                // Cap the chunk by the connection-level send window (RFC 9000 4.1):
-                // the peer's MAX_DATA grant limits how much STREAM data may be sent.
-                // A chunk that carries only a FIN (no bytes) needs no credit.
-                const credit = self.conn_send_window.available();
-                const room = @min(packet_room, credit);
-                const chunk = s.peek(room) orelse break; // no bytes fit and no FIN owed
-                if (chunk.data.len == 0 and !chunk.fin) break; // out of window: keep the rest queued
+                // Peek a full packet's worth; a retransmit (offset below the send
+                // cursor) re-sends already-presented bytes, a new chunk presents
+                // fresh offsets. Only new bytes consume connection send-window credit
+                // (RFC 9000 4.1); the window is a monotonic high-water mark, so a
+                // retransmit and a pure FIN need none.
+                var chunk = s.peek(packet_room) orelse break;
+                const is_new = chunk.offset >= s.sent;
+                if (is_new and chunk.data.len > 0) {
+                    const credit = self.conn_send_window.available();
+                    if (credit == 0) break; // out of window: keep new bytes queued
+                    if (chunk.data.len > credit) chunk = s.peek(@intCast(credit)).?; // shrink to fit
+                }
+                if (chunk.data.len == 0 and !chunk.fin) break;
                 var frames: std.ArrayListUnmanaged(u8) = .empty;
                 defer frames.deinit(self.gpa);
                 frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
-                try self.buildPacket(space, frames.items, true, now);
-                self.conn_send_window.onSent(chunk.data.len);
-                s.commit(chunk.data.len, chunk.fin);
+                // Reserve the record slot BEFORE sending, so the packet is never put
+                // on the wire without a retransmit route (an OOM here leaves nothing
+                // queued).
+                st.stream_sent.ensureUnusedCapacity(self.gpa, 1) catch return error.OutOfMemory;
+                const pn = try self.buildPacket(space, frames.items, true, now);
+                st.stream_sent.putAssumeCapacity(pn, .{ .id = id, .offset = chunk.offset, .len = chunk.data.len, .fin = chunk.fin });
+                if (is_new) self.conn_send_window.onSent(chunk.data.len); // monotonic: only new offsets
+                s.commit(chunk.offset, chunk.data.len, chunk.fin);
+            }
+        }
+    }
+
+    /// Process an incoming ACK for `space`: fold it into recovery, free the STREAM
+    /// bytes the acked packets carried, then run loss detection and re-queue the
+    /// bytes any newly-lost packet carried so the next flushSend retransmits them.
+    /// A pn lives in `rec.sent` and `stream_sent` in lockstep, so each is routed to
+    /// the SendStream exactly once (fetchRemove), defending double-free / resurrect.
+    fn onAckFrame(self: *Connection, space: Space, a: anytype, now: u64) Error!void {
+        const st = &self.spaces[@intFromEnum(space)];
+        var acked_pns: std.ArrayListUnmanaged(u64) = .empty;
+        defer acked_pns.deinit(self.gpa);
+        var it = frame.ackRanges(a.ranges);
+        _ = st.rec.onAck(&self.rtt, &self.cc, now, a.largest, a.delay, a.first_range, &it, &acked_pns, self.gpa) catch
+            return error.ProtocolViolation;
+        for (acked_pns.items) |pn| {
+            if (st.stream_sent.fetchRemove(pn)) |e| {
+                if (self.send_streams.get(e.value.id)) |s| try s.onAck(e.value.offset, e.value.len, e.value.fin);
+            }
+        }
+        var lost_pns: std.ArrayListUnmanaged(u64) = .empty;
+        defer lost_pns.deinit(self.gpa);
+        _ = st.rec.detectLost(&self.rtt, &self.cc, now, &lost_pns, self.gpa) catch return error.OutOfMemory;
+        for (lost_pns.items) |pn| {
+            if (st.stream_sent.fetchRemove(pn)) |e| {
+                if (self.send_streams.get(e.value.id)) |s| try s.onLost(e.value.offset, e.value.len, e.value.fin);
             }
         }
     }
@@ -346,7 +402,7 @@ pub const Connection = struct {
         var frames: std.ArrayListUnmanaged(u8) = .empty;
         defer frames.deinit(self.gpa);
         frame.encodeCrypto(&frames, self.gpa, 0, data) catch return error.OutOfMemory;
-        try self.buildPacket(space, frames.items, true, now);
+        _ = try self.buildPacket(space, frames.items, true, now); // CRYPTO carries no STREAM record
     }
 
     fn sendAck(self: *Connection, space: Space, now: u64) Error!void {
@@ -355,7 +411,7 @@ pub const Connection = struct {
         var frames: std.ArrayListUnmanaged(u8) = .empty;
         defer frames.deinit(self.gpa);
         frame.encodeAck(&frames, self.gpa, largest, 0, 0) catch return error.OutOfMemory; // one contiguous range
-        try self.buildPacket(space, frames.items, false, now); // an ACK is not ack-eliciting
+        _ = try self.buildPacket(space, frames.items, false, now); // ACK is not ack-eliciting
         st.ack_pending = false;
     }
 
@@ -471,11 +527,7 @@ pub const Connection = struct {
         switch (f) {
             .padding => {},
             .ping => st.ack_pending = true,
-            .ack => |a| {
-                var it = frame.ackRanges(a.ranges);
-                _ = st.rec.onAck(&self.rtt, &self.cc, now, a.largest, a.delay, a.first_range, &it) catch
-                    return error.ProtocolViolation;
-            },
+            .ack => |a| try self.onAckFrame(space, a, now),
             .crypto => |c| {
                 st.ack_pending = true;
                 try self.onCrypto(space, c.offset, c.data, now);
@@ -1033,4 +1085,118 @@ test "writing after a FIN is a final-size error" {
     defer conn.deinit();
     try conn.sendStreamData(1, "done", true);
     try testing.expectError(error.FinalSizeError, conn.sendStreamData(1, "more", false));
+}
+
+// ---- STREAM retransmission tests --------------------------------------------
+
+// An Application (1-RTT) datagram carrying one ACK frame, sealed with the test app
+// keys so a sender installed via testInstallAppKeys decrypts it.
+fn buildAppAck(gpa: std.mem.Allocator, dcid: []const u8, pn: u64, largest: u64, first_range: u64) ![]u8 {
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(gpa);
+    try frame.encodeAck(&frames, gpa, largest, 0, first_range);
+    return testBuildApp(gpa, dcid, pn, frames.items);
+}
+
+// Deliver every queued datagram in `sender`'s send buffer to `peer`, sliced by the
+// per-datagram lengths (each is its own UDP datagram). Optionally skip index `drop`.
+fn deliverAllExcept(sender: *Connection, peer: *Connection, drop: ?usize, now: u64) !void {
+    const buf = sender.datagramsToSend();
+    var off: usize = 0;
+    var idx: usize = 0;
+    for (sender.datagramLengths()) |len| {
+        if (drop == null or idx != drop.?) try peer.receiveDatagram(buf[off .. off + len], now);
+        off += len;
+        idx += 1;
+    }
+}
+
+test "a lost STREAM packet is retransmitted and the peer reassembles the whole stream" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+
+    // Enough data to span many packets so a dropped pn 0 lands past PACKET_THRESHOLD.
+    const payload = [_]u8{0x5c} ** 5000;
+    try sender.sendStreamData(1, &payload, true);
+    try sender.flushSend(1000);
+    const n = sender.datagramLengths().len;
+    try testing.expect(n >= 5);
+
+    // Deliver every packet EXCEPT the first (pn 0): it is "lost".
+    try deliverAllExcept(&sender, &peer, 0, 2000);
+    try testing.expect(peer.streamData(1).len < payload.len); // a hole remains
+
+    // ACK pns 1..n-1 back to the sender: largest = n-1, first_range covers down to 1.
+    sender.clearSend();
+    const ack = try buildAppAck(gpa, &dcid, 0, n - 1, n - 2);
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, 3000);
+
+    // pn 0 is now > PACKET_THRESHOLD behind n-1, so detectLost re-queued its range.
+    try testing.expect(sender.hasPendingSend());
+    try sender.flushSend(4000);
+    try testing.expect(sender.datagramLengths().len >= 1);
+
+    // Deliver the retransmission; the peer now holds the complete stream.
+    try deliverAllExcept(&sender, &peer, null, 5000);
+    try testing.expectEqual(@as(usize, payload.len), peer.streamData(1).len);
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "a retransmit does not consume new send-window credit" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    const payload = [_]u8{0x33} ** 5000;
+    try sender.sendStreamData(1, &payload, false);
+    try sender.flushSend(1000);
+    const sent_after_first = sender.conn_send_window.sent;
+    const n = sender.datagramLengths().len;
+
+    // Lose pn 0, ack the rest -> the range is re-queued and retransmitted.
+    sender.clearSend();
+    const ack = try buildAppAck(gpa, &dcid, 0, n - 1, n - 2);
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, 2000);
+    try sender.flushSend(3000);
+
+    // The retransmit re-sent already-presented offsets, so the monotonic window
+    // high-water mark did not advance (it only ever counts new bytes).
+    try testing.expectEqual(sent_after_first, sender.conn_send_window.sent);
+}
+
+test "a late ACK of an already-lost packet is a harmless no-op" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    const payload = [_]u8{0x44} ** 5000;
+    try sender.sendStreamData(1, &payload, true);
+    try sender.flushSend(1000);
+    const n = sender.datagramLengths().len;
+
+    // Declare pn 0 lost (ack the rest), retransmit it, then deliver a LATE ack that
+    // names pn 0 - it was already removed from recovery, so it routes nowhere.
+    sender.clearSend();
+    const ack1 = try buildAppAck(gpa, &dcid, 0, n - 1, n - 2);
+    defer gpa.free(ack1);
+    try sender.receiveDatagram(ack1, 2000);
+    try sender.flushSend(3000); // retransmits pn 0's range under a new pn
+    sender.clearSend();
+
+    const late = try buildAppAck(gpa, &dcid, 1, 0, 0); // ack pn 0 only, late
+    defer gpa.free(late);
+    try sender.receiveDatagram(late, 4000); // must not crash, double-free, or resurrect
+    try testing.expect(!sender.closed);
 }

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -261,6 +261,10 @@ pub const Connection = struct {
     /// frame per packet. STREAM is legal only in the Application space (RFC 9000
     /// 12.4), so nothing flows until the handshake installs the 1-RTT send keys -
     /// the structural fix for shipping STREAM data in Initial packets.
+    ///
+    /// `commit` drops each chunk from the SendStream once it is framed, so a packet
+    /// lost in flight is NOT retransmitted: loss-recovery for STREAM data (tracking
+    /// sent-but-unacked ranges and requeueing on loss/PTO) is a deliberate follow-up.
     pub fn flushSend(self: *Connection, now: u64) Error!void {
         const space = Space.application;
         const st = &self.spaces[@intFromEnum(space)];

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -6,12 +6,11 @@
 //! the HTTP/3 layer. It is sans-IO: bytes and a monotonic `now` in, transport
 //! state and (eventually) datagrams out, no socket.
 //!
-//! Scope: the Initial packet-number space is wired end-to-end, which exercises the
-//! whole pipeline (header protection, AEAD, framing, ack/stream state) with the
-//! deterministic Initial keys. The Handshake and Application spaces install their
-//! keys through the same `installKeys` seam once the TLS 1.3 handshake driver
-//! lands; that negotiation is the follow-up, mirroring how HTTP/2 staged its write
-//! side.
+//! Scope: all three packet-number spaces are wired. The TLS 1.3 handshake runs
+//! over CRYPTO frames and installs the Handshake and Application keys through the
+//! `installKeys` seam; `buildPacket` is the one send primitive (CRYPTO, ACK, and
+//! STREAM all funnel through it), so STREAM data ships only in the Application
+//! space once 1-RTT keys exist - never in an Initial packet.
 
 const std = @import("std");
 const constants = @import("constants.zig");
@@ -80,6 +79,7 @@ pub const Connection = struct {
     conn_received_total: u64 = 0,
     conn_consumed_total: u64 = 0,
     streams: std.AutoHashMapUnmanaged(u64, *stream.RecvStream) = .empty,
+    send_streams: std.AutoHashMapUnmanaged(u64, *stream.SendStream) = .empty,
     /// Built datagrams waiting to be drained by `datagramsToSend` (one contiguous
     /// buffer; `out_lengths` records each datagram's byte length in order).
     out: std.ArrayListUnmanaged(u8) = .empty,
@@ -146,6 +146,12 @@ pub const Connection = struct {
             self.gpa.destroy(s.*);
         }
         self.streams.deinit(self.gpa);
+        var sit = self.send_streams.valueIterator();
+        while (sit.next()) |s| {
+            s.*.deinit();
+            self.gpa.destroy(s.*);
+        }
+        self.send_streams.deinit(self.gpa);
         self.out.deinit(self.gpa);
         self.out_lengths.deinit(self.gpa);
         for (&self.spaces) |*s| s.deinit(self.gpa);
@@ -218,6 +224,62 @@ pub const Connection = struct {
     pub fn clearSend(self: *Connection) void {
         self.out.clearRetainingCapacity();
         self.out_lengths.clearRetainingCapacity();
+    }
+
+    // ---- STREAM send -----------------------------------------------------------
+
+    fn sendStream(self: *Connection, id: u64) Error!*stream.SendStream {
+        if (self.send_streams.get(id)) |s| return s;
+        const s = try self.gpa.create(stream.SendStream);
+        s.* = stream.SendStream.init(self.gpa);
+        self.send_streams.put(self.gpa, id, s) catch {
+            s.deinit();
+            self.gpa.destroy(s);
+            return error.OutOfMemory;
+        };
+        return s;
+    }
+
+    /// Queue `data` (and/or a FIN) to be sent on stream `id`. `flushSend` packetizes
+    /// the queue once the Application keys exist. Writing after a FIN is rejected.
+    pub fn sendStreamData(self: *Connection, id: u64, data: []const u8, fin: bool) Error!void {
+        const s = try self.sendStream(id);
+        s.write(data, fin) catch |e| switch (e) {
+            error.FinalSizeError => return error.FinalSizeError,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+    }
+
+    /// Whether any stream has bytes (or a FIN) still to send.
+    pub fn hasPendingSend(self: *Connection) bool {
+        var it = self.send_streams.valueIterator();
+        while (it.next()) |s| if (s.*.pending()) return true;
+        return false;
+    }
+
+    /// Packetize queued stream data into Application (1-RTT) datagrams, one STREAM
+    /// frame per packet. STREAM is legal only in the Application space (RFC 9000
+    /// 12.4), so nothing flows until the handshake installs the 1-RTT send keys -
+    /// the structural fix for shipping STREAM data in Initial packets.
+    pub fn flushSend(self: *Connection, now: u64) Error!void {
+        const space = Space.application;
+        const st = &self.spaces[@intFromEnum(space)];
+        if (st.send_keys == null) return; // no 1-RTT keys yet: nothing can be sent
+        // A conservative single-packet budget; one STREAM frame per packet for now.
+        const room = constants.MIN_INITIAL_DATAGRAM - 64;
+        var it = self.send_streams.iterator();
+        while (it.next()) |entry| {
+            const id = entry.key_ptr.*;
+            const s = entry.value_ptr.*;
+            while (s.pending()) {
+                const chunk = s.peek(room) orelse break;
+                var frames: std.ArrayListUnmanaged(u8) = .empty;
+                defer frames.deinit(self.gpa);
+                frame.encodeStream(&frames, self.gpa, id, chunk.offset, chunk.data, chunk.fin) catch return error.OutOfMemory;
+                try self.buildPacket(space, frames.items, true, now);
+                s.commit(chunk.data.len, chunk.fin);
+            }
+        }
     }
 
     // ---- TLS handshake drive ---------------------------------------------------
@@ -853,4 +915,85 @@ test "a malformed ClientHello (no supported_versions) poisons the connection" {
     const dgram = try testBuildInitial(gpa, &dcid, .client, 0, frames.items);
     defer gpa.free(dgram);
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(dgram, 1000));
+}
+
+// ---- STREAM send tests -----------------------------------------------------
+
+test "queued stream data flushes into a 1-RTT datagram a peer reassembles" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48 };
+
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    // Nothing to flush until data is queued.
+    try testing.expect(!sender.hasPendingSend());
+    try sender.sendStreamData(1, "hello over quic", true); // server-initiated bidi id 1
+    try testing.expect(sender.hasPendingSend());
+
+    try sender.flushSend(1000);
+    try testing.expectEqual(@as(usize, 1), sender.datagramLengths().len);
+    try testing.expect(!sender.hasPendingSend()); // fully drained
+
+    // A peer with the matching Application keys decrypts and reassembles it.
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+    try peer.receiveDatagram(sender.datagramsToSend(), 2000);
+    try testing.expectEqualStrings("hello over quic", peer.streamData(1));
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "flushSend is a no-op until the Application keys are installed" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x51, 0x52, 0x53, 0x54 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    // No app keys yet (no handshake): queued data cannot leave - the #64 P1 fix.
+    try conn.sendStreamData(1, "held", false);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);
+    try testing.expect(conn.hasPendingSend()); // still queued
+
+    // Once 1-RTT keys exist, the same queue flushes.
+    testInstallAppKeys(&conn);
+    try conn.flushSend(1000);
+    try testing.expectEqual(@as(usize, 1), conn.datagramLengths().len);
+}
+
+test "a large stream send is chunked across multiple packets" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x61, 0x62, 0x63, 0x64 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    const big = [_]u8{0x7a} ** 4000; // larger than one packet's room
+    try sender.sendStreamData(1, &big, true);
+    try sender.flushSend(1000);
+    try testing.expect(sender.datagramLengths().len > 1); // split into multiple packets
+
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+    // Each built packet is its own UDP datagram (a short header runs to the
+    // datagram end), so the peer is fed them one at a time, sliced by the lengths.
+    const buf = sender.datagramsToSend();
+    var off: usize = 0;
+    for (sender.datagramLengths()) |len| {
+        try peer.receiveDatagram(buf[off .. off + len], 2000);
+        off += len;
+    }
+    try testing.expectEqual(@as(usize, big.len), peer.streamData(1).len);
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "writing after a FIN is a final-size error" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x71, 0x72, 0x73, 0x74 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    try conn.sendStreamData(1, "done", true);
+    try testing.expectError(error.FinalSizeError, conn.sendStreamData(1, "more", false));
 }

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -332,8 +332,11 @@ pub const Connection = struct {
         var acked_pns: std.ArrayListUnmanaged(u64) = .empty;
         defer acked_pns.deinit(self.gpa);
         var it = frame.ackRanges(a.ranges);
+        // onAck's only failure is the acked_pns append, i.e. OutOfMemory - a
+        // malformed range just stops the walk, it never errors. So surface allocator
+        // pressure as OutOfMemory, not a peer protocol error.
         _ = st.rec.onAck(&self.rtt, &self.cc, now, a.largest, a.delay, a.first_range, &it, &acked_pns, self.gpa) catch
-            return error.ProtocolViolation;
+            return error.OutOfMemory;
         for (acked_pns.items) |pn| {
             if (st.stream_sent.fetchRemove(pn)) |e| {
                 if (self.send_streams.get(e.value.id)) |s| try s.onAck(e.value.offset, e.value.len, e.value.fin);

--- a/src/core/quic/recovery.zig
+++ b/src/core/quic/recovery.zig
@@ -85,6 +85,9 @@ pub const Space = struct {
     /// Apply an ACK (its largest, first-range, and the raw range bytes from the
     /// frame). Removes acked packets from the in-flight set, updates the RTT from
     /// the largest newly acked ack-eliciting packet, and returns what was acked.
+    /// Each removed packet's number is appended to `acked_pns`, so a frame-aware
+    /// caller (e.g. STREAM retransmission) can free the data it carried - recovery
+    /// itself stays oblivious to what a packet held.
     pub fn onAck(
         self: *Space,
         rtt: *RttEstimator,
@@ -94,6 +97,8 @@ pub const Space = struct {
         ack_delay: u64,
         first_range: u64,
         ranges: anytype, // an iterator yielding {gap,len}
+        acked_pns: *std.ArrayListUnmanaged(u64),
+        gpa: std.mem.Allocator,
     ) !AckOutcome {
         var acked = AckSet{};
         acked.add(largest - first_range, largest);
@@ -114,6 +119,9 @@ pub const Space = struct {
         while (i < self.sent.items.len) {
             const p = self.sent.items[i];
             if (acked.contains(p.pn)) {
+                // Record the pn first: a failed append must not leave congestion
+                // state mutated while the packet stays in the in-flight set.
+                try acked_pns.append(gpa, p.pn);
                 outcome.newly_acked += 1;
                 if (p.in_flight) {
                     outcome.acked_bytes += p.size;
@@ -141,8 +149,16 @@ pub const Space = struct {
     /// Detect lost packets (RFC 9002 6.1): a packet is lost if a later packet was
     /// acked and it is either more than PACKET_THRESHOLD behind the largest acked
     /// or older than the time threshold. Lost packets are removed and their bytes
-    /// reported to congestion control. Returns how many were lost.
-    pub fn detectLost(self: *Space, rtt: *const RttEstimator, cc: *congestion.Controller, now: u64) u64 {
+    /// reported to congestion control; each removed pn is appended to `lost_pns` so
+    /// a frame-aware caller can re-queue the data it carried. Returns how many were lost.
+    pub fn detectLost(
+        self: *Space,
+        rtt: *const RttEstimator,
+        cc: *congestion.Controller,
+        now: u64,
+        lost_pns: *std.ArrayListUnmanaged(u64),
+        gpa: std.mem.Allocator,
+    ) !u64 {
         const largest = self.largest_acked orelse return 0;
         const threshold = @max(rtt.latest, rtt.smoothed) * TIME_THRESHOLD_NUM / TIME_THRESHOLD_DEN;
         self.loss_time = null;
@@ -157,6 +173,7 @@ pub const Space = struct {
             const by_packet = largest >= p.pn + PACKET_THRESHOLD;
             const by_time = now >= p.sent_time + threshold;
             if (by_packet or by_time) {
+                try lost_pns.append(gpa, p.pn); // record before mutating cc / removing
                 if (p.in_flight) cc.onLost(p.pn, p.size);
                 lost += 1;
                 _ = self.sent.swapRemove(i);
@@ -227,7 +244,9 @@ test "ack removes the in-flight packet and updates RTT" {
     cc.onSent(1200);
     try space.onSent(gpa, .{ .pn = 0, .sent_time = 1000, .size = 1200, .ack_eliciting = true, .in_flight = true });
     var ranges = EmptyRanges{};
-    const out = try space.onAck(&rtt, &cc, 51_000, 0, 0, 0, &ranges);
+    var sink: std.ArrayListUnmanaged(u64) = .empty;
+    defer sink.deinit(gpa);
+    const out = try space.onAck(&rtt, &cc, 51_000, 0, 0, 0, &ranges, &sink, gpa);
     try std.testing.expectEqual(@as(u64, 1), out.newly_acked);
     try std.testing.expectEqual(@as(u64, 1200), out.acked_bytes);
     try std.testing.expectEqual(@as(u64, 0), cc.bytes_in_flight);
@@ -252,7 +271,9 @@ test "ack with multiple ranges" {
         }
     };
     var r = Ranges{};
-    const out = try space.onAck(&rtt, &cc, 2000, 5, 0, 1, &r);
+    var sink: std.ArrayListUnmanaged(u64) = .empty;
+    defer sink.deinit(gpa);
+    const out = try space.onAck(&rtt, &cc, 2000, 5, 0, 1, &r, &sink, gpa);
     try std.testing.expectEqual(@as(u64, 4), out.newly_acked); // 4,5,1,2
     try std.testing.expectEqual(@as(u64, 5), out.largest_newly_acked.?);
     try std.testing.expectEqual(@as(usize, 2), space.sent.items.len); // 0 and 3 remain
@@ -269,8 +290,12 @@ test "packet threshold declares an old packet lost" {
     try space.onSent(gpa, .{ .pn = 0, .sent_time = 1000, .size = 1200, .ack_eliciting = true, .in_flight = true });
     try space.onSent(gpa, .{ .pn = 4, .sent_time = 1000, .size = 1200, .ack_eliciting = true, .in_flight = true });
     var ranges = EmptyRanges{};
-    _ = try space.onAck(&rtt, &cc, 2000, 4, 0, 0, &ranges);
-    const lost = space.detectLost(&rtt, &cc, 2000);
+    var sink: std.ArrayListUnmanaged(u64) = .empty;
+    defer sink.deinit(gpa);
+    _ = try space.onAck(&rtt, &cc, 2000, 4, 0, 0, &ranges, &sink, gpa);
+    var lost_pns: std.ArrayListUnmanaged(u64) = .empty;
+    defer lost_pns.deinit(gpa);
+    const lost = try space.detectLost(&rtt, &cc, 2000, &lost_pns, gpa);
     try std.testing.expectEqual(@as(u64, 1), lost);
     try std.testing.expectEqual(@as(usize, 0), space.sent.items.len);
 }

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -180,6 +180,64 @@ pub const RecvStream = struct {
     }
 };
 
+/// The send side of one stream: a queue of outbound bytes the connection drains
+/// into STREAM frames. It tracks the offset of the next unsent byte and whether a
+/// FIN is owed, mirroring RecvStream but for the write direction.
+pub const SendStream = struct {
+    gpa: std.mem.Allocator,
+    /// Bytes queued but not yet framed (drained from the front as they are sent).
+    unsent: std.ArrayListUnmanaged(u8) = .empty,
+    /// The offset of the first byte still in `unsent` - what a STREAM frame for the
+    /// next chunk carries.
+    send_offset: u64 = 0,
+    /// The application has finished writing; a FIN is owed on the last frame.
+    fin: bool = false,
+    /// The FIN has been emitted on a frame, so the stream is fully sent.
+    fin_sent: bool = false,
+
+    pub fn init(gpa: std.mem.Allocator) SendStream {
+        return .{ .gpa = gpa };
+    }
+
+    pub fn deinit(self: *SendStream) void {
+        self.unsent.deinit(self.gpa);
+    }
+
+    /// Queue `data` to be sent and/or mark the stream finished. Writing after the
+    /// stream has been finished (FIN owed or sent) would push bytes past the
+    /// declared final size (RFC 9000 4.5), so it is rejected.
+    pub fn write(self: *SendStream, data: []const u8, fin: bool) Error!void {
+        if (self.fin and (data.len != 0 or !fin)) return error.FinalSizeError;
+        self.unsent.appendSlice(self.gpa, data) catch return error.OutOfMemory;
+        if (fin) self.fin = true;
+    }
+
+    /// Whether anything still needs to leave: buffered bytes, or an owed FIN.
+    pub fn pending(self: *const SendStream) bool {
+        return self.unsent.items.len > 0 or (self.fin and !self.fin_sent);
+    }
+
+    /// The next chunk to frame, capped at `max` bytes. Returns the offset, the
+    /// chunk (a slice into `unsent`, valid until the next `commit`), and whether
+    /// this chunk carries the FIN. Call `commit` once the chunk is framed.
+    pub const Chunk = struct { offset: u64, data: []const u8, fin: bool };
+    pub fn peek(self: *const SendStream, max: usize) ?Chunk {
+        const n = @min(max, self.unsent.items.len);
+        const carries_fin = self.fin and !self.fin_sent and n == self.unsent.items.len;
+        if (n == 0 and !carries_fin) return null;
+        return .{ .offset = self.send_offset, .data = self.unsent.items[0..n], .fin = carries_fin };
+    }
+
+    /// Drop the `n` bytes a framed chunk consumed and, if it carried the FIN, mark
+    /// the FIN sent. `n` must be the length of the chunk returned by `peek`.
+    pub fn commit(self: *SendStream, n: usize, sent_fin: bool) void {
+        std.mem.copyForwards(u8, self.unsent.items[0 .. self.unsent.items.len - n], self.unsent.items[n..]);
+        self.unsent.shrinkRetainingCapacity(self.unsent.items.len - n);
+        self.send_offset += n;
+        if (sent_fin) self.fin_sent = true;
+    }
+};
+
 test "stream-id typing reads the low two bits" {
     try std.testing.expectEqual(StreamType.client_bidi, StreamType.of(0));
     try std.testing.expectEqual(StreamType.server_bidi, StreamType.of(1));
@@ -246,4 +304,53 @@ test "a conflicting FIN offset is rejected" {
     defer s.deinit();
     _ = try s.push(0, "abcde", true); // final size 5
     try std.testing.expectError(error.FinalSizeError, s.push(0, "abc", true)); // fin at 3
+}
+
+test "SendStream drains queued bytes in offset-ordered chunks" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("hello world", false);
+    try std.testing.expect(s.pending());
+
+    const c1 = s.peek(5).?; // capped at 5
+    try std.testing.expectEqual(@as(u64, 0), c1.offset);
+    try std.testing.expectEqualStrings("hello", c1.data);
+    try std.testing.expect(!c1.fin);
+    s.commit(c1.data.len, false);
+
+    const c2 = s.peek(100).?;
+    try std.testing.expectEqual(@as(u64, 5), c2.offset);
+    try std.testing.expectEqualStrings(" world", c2.data);
+    s.commit(c2.data.len, false);
+    try std.testing.expect(!s.pending());
+}
+
+test "SendStream carries the FIN on the final chunk and forbids later writes" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("data", true); // bytes + FIN
+    const c = s.peek(100).?;
+    try std.testing.expect(c.fin);
+    s.commit(c.data.len, true);
+    try std.testing.expect(!s.pending()); // FIN sent, nothing left
+
+    // Writing after FIN would exceed the final size.
+    try std.testing.expectError(error.FinalSizeError, s.write("x", false));
+    // An empty, idempotent FIN write is allowed.
+    try s.write("", true);
+}
+
+test "SendStream owes a FIN even with no bytes" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("", true); // pure FIN
+    try std.testing.expect(s.pending());
+    const c = s.peek(100).?;
+    try std.testing.expectEqual(@as(usize, 0), c.data.len);
+    try std.testing.expect(c.fin);
+    s.commit(0, true);
+    try std.testing.expect(!s.pending());
 }

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -180,61 +180,216 @@ pub const RecvStream = struct {
     }
 };
 
-/// The send side of one stream: a queue of outbound bytes the connection drains
-/// into STREAM frames. It tracks the offset of the next unsent byte and whether a
-/// FIN is owed, mirroring RecvStream but for the write direction.
+/// The send side of one stream: a retain buffer of all unacked bytes the
+/// connection drains into STREAM frames, plus the bookkeeping to retransmit a
+/// range whose packet was lost. One contiguous `buf` holds [base_offset, end);
+/// the `sent` cursor splits already-framed bytes (left) from never-framed bytes
+/// (right). Lost ranges are re-framed before new bytes (RFC 9002 13.3); acked
+/// bytes are freed off the front. Mirrors RecvStream, but for the write direction.
 pub const SendStream = struct {
     gpa: std.mem.Allocator,
-    /// Bytes queued but not yet framed (drained from the front as they are sent).
-    unsent: std.ArrayListUnmanaged(u8) = .empty,
-    /// The offset of the first byte still in `unsent` - what a STREAM frame for the
-    /// next chunk carries.
-    send_offset: u64 = 0,
-    /// The application has finished writing; a FIN is owed on the last frame.
-    fin: bool = false,
-    /// The FIN has been emitted on a frame, so the stream is fully sent.
-    fin_sent: bool = false,
+    /// Every written, not-yet-acked byte: [base_offset, base_offset + buf.len).
+    buf: std.ArrayListUnmanaged(u8) = .empty,
+    /// Offset of buf.items[0]; everything below is acked and freed.
+    base_offset: u64 = 0,
+    /// Bytes in [base_offset, sent) have ridden a frame; [sent, end) are new. The
+    /// cursor only moves forward (commit); a loss records a `lost` range instead.
+    sent: u64 = 0,
+    fin: bool = false, // the application finished writing; a FIN is owed at end()
+    fin_sent: bool = false, // the FIN has ridden a frame
+    fin_acked: bool = false, // the FIN has been acknowledged
+    fin_lost: bool = false, // the FIN's packet was lost; it must ride again
+    /// Byte spans below `sent` whose carrying packet was lost: re-framed first.
+    /// Sorted by offset, non-overlapping.
+    lost: std.ArrayListUnmanaged(Range) = .empty,
+    /// Acked spans above `base_offset` not yet contiguous with it (out-of-order
+    /// acks): held until the filling ack lets `base_offset` slide through them.
+    /// Sorted, non-overlapping - the send-side mirror of RecvStream.pending.
+    acked_gaps: std.ArrayListUnmanaged(Range) = .empty,
+
+    const Range = struct { offset: u64, len: u64 };
 
     pub fn init(gpa: std.mem.Allocator) SendStream {
         return .{ .gpa = gpa };
     }
 
     pub fn deinit(self: *SendStream) void {
-        self.unsent.deinit(self.gpa);
+        self.buf.deinit(self.gpa);
+        self.lost.deinit(self.gpa);
+        self.acked_gaps.deinit(self.gpa);
     }
 
-    /// Queue `data` to be sent and/or mark the stream finished. Writing after the
-    /// stream has been finished (FIN owed or sent) would push bytes past the
-    /// declared final size (RFC 9000 4.5), so it is rejected.
+    pub fn end(self: *const SendStream) u64 {
+        return self.base_offset + self.buf.items.len;
+    }
+
+    /// Queue `data` and/or mark the stream finished. Writing after the stream is
+    /// finished would exceed the final size (RFC 9000 4.5), so it is rejected.
     pub fn write(self: *SendStream, data: []const u8, fin: bool) Error!void {
         if (self.fin and (data.len != 0 or !fin)) return error.FinalSizeError;
-        self.unsent.appendSlice(self.gpa, data) catch return error.OutOfMemory;
+        self.buf.appendSlice(self.gpa, data) catch return error.OutOfMemory;
         if (fin) self.fin = true;
     }
 
-    /// Whether anything still needs to leave: buffered bytes, or an owed FIN.
+    /// Whether anything still needs to leave: a lost range, an owed FIN, or new
+    /// bytes past the cursor.
     pub fn pending(self: *const SendStream) bool {
-        return self.unsent.items.len > 0 or (self.fin and !self.fin_sent);
+        if (self.lost.items.len > 0 or self.fin_lost) return true;
+        if (self.sent < self.end()) return true;
+        return self.finOwedAtEnd();
     }
 
-    /// The next chunk to frame, capped at `max` bytes. Returns the offset, the
-    /// chunk (a slice into `unsent`, valid until the next `commit`), and whether
-    /// this chunk carries the FIN. Call `commit` once the chunk is framed.
+    /// The next chunk to frame, capped at `max` bytes: a lost range first, then a
+    /// lost FIN with no lost bytes, then new bytes. The data slice borrows from
+    /// `buf` - valid until the next mutation, same as today's contract.
     pub const Chunk = struct { offset: u64, data: []const u8, fin: bool };
     pub fn peek(self: *const SendStream, max: usize) ?Chunk {
-        const n = @min(max, self.unsent.items.len);
-        const carries_fin = self.fin and !self.fin_sent and n == self.unsent.items.len;
+        if (max == 0) {
+            if (self.finOwedAtEnd() and self.sent == self.end()) {
+                return .{ .offset = self.end(), .data = &.{}, .fin = true };
+            }
+            return null;
+        }
+        // 1. Lost ranges first (resend lost data before new, RFC 9002 13.3).
+        if (self.lost.items.len > 0) {
+            const r = self.lost.items[0];
+            const n: usize = @intCast(@min(@as(u64, max), r.len));
+            const lo: usize = @intCast(r.offset - self.base_offset);
+            const carries_fin = self.fin_lost and n == r.len and r.offset + r.len == self.end();
+            return .{ .offset = r.offset, .data = self.buf.items[lo .. lo + n], .fin = carries_fin };
+        }
+        // 2. A lost FIN with no lost bytes left (a FIN-only retransmit).
+        if (self.fin_lost and self.sent == self.end()) {
+            return .{ .offset = self.end(), .data = &.{}, .fin = true };
+        }
+        // 3. New bytes after the cursor.
+        const avail = self.end() - self.sent;
+        const n: usize = @intCast(@min(@as(u64, max), avail));
+        const carries_fin = self.finOwedAtEnd() and @as(u64, n) == avail;
         if (n == 0 and !carries_fin) return null;
-        return .{ .offset = self.send_offset, .data = self.unsent.items[0..n], .fin = carries_fin };
+        const lo: usize = @intCast(self.sent - self.base_offset);
+        return .{ .offset = self.sent, .data = self.buf.items[lo .. lo + n], .fin = carries_fin };
     }
 
-    /// Drop the `n` bytes a framed chunk consumed and, if it carried the FIN, mark
-    /// the FIN sent. `n` must be the length of the chunk returned by `peek`.
-    pub fn commit(self: *SendStream, n: usize, sent_fin: bool) void {
-        std.mem.copyForwards(u8, self.unsent.items[0 .. self.unsent.items.len - n], self.unsent.items[n..]);
-        self.unsent.shrinkRetainingCapacity(self.unsent.items.len - n);
-        self.send_offset += n;
-        if (sent_fin) self.fin_sent = true;
+    fn finOwedAtEnd(self: *const SendStream) bool {
+        return self.fin and !self.fin_acked and (!self.fin_sent or self.fin_lost);
+    }
+
+    /// Record that the chunk `peek` returned at `offset` (length `n`) has been
+    /// framed. A lost-range chunk shrinks the front of `lost`; a new chunk advances
+    /// the cursor. The offset disambiguates which path `peek` took.
+    pub fn commit(self: *SendStream, offset: u64, n: usize, sent_fin: bool) void {
+        if (self.lost.items.len > 0 and offset == self.lost.items[0].offset) {
+            var r = &self.lost.items[0];
+            r.offset += n;
+            r.len -= n;
+            if (r.len == 0) _ = self.lost.orderedRemove(0);
+            if (sent_fin) self.fin_lost = false;
+            return;
+        }
+        // A pure-FIN retransmit (no bytes, FIN owed) or new bytes after the cursor.
+        self.sent += n;
+        if (sent_fin) {
+            self.fin_sent = true;
+            self.fin_lost = false;
+        }
+    }
+
+    /// A packet carrying [offset, offset+len) and possibly the FIN was lost. Record
+    /// the still-unacked sub-range for retransmission. Idempotent and clipped to the
+    /// unacked window, so an already-acked prefix is never re-queued.
+    pub fn onLost(self: *SendStream, offset: u64, len: u64, fin: bool) Error!void {
+        const lo = @max(offset, self.base_offset);
+        const hi = offset + len;
+        if (hi > lo) try self.insertLost(lo, hi - lo);
+        if (fin and !self.fin_acked) self.fin_lost = true;
+    }
+
+    /// A packet carrying [offset, offset+len) and possibly the FIN was acked. Drop
+    /// the span from any pending retransmit and free the now-contiguous prefix.
+    pub fn onAck(self: *SendStream, offset: u64, len: u64, fin: bool) Error!void {
+        const hi = offset + len;
+        if (fin) {
+            self.fin_acked = true;
+            self.fin_lost = false;
+        }
+        try self.dropLost(offset, hi);
+        if (hi <= self.base_offset) return; // wholly below the frontier; already freed
+        if (offset <= self.base_offset) {
+            self.slideBase(hi);
+        } else {
+            try self.insertAckedGap(offset, hi); // out of order: hold until the gap fills
+        }
+    }
+
+    /// Slide `base_offset` up to `new_base`, freeing the prefix, then absorb any
+    /// held acked gaps now made contiguous. `sent` never falls below `base_offset`.
+    fn slideBase(self: *SendStream, new_base_in: u64) void {
+        var new_base = new_base_in;
+        var i: usize = 0;
+        while (i < self.acked_gaps.items.len) {
+            const g = self.acked_gaps.items[i];
+            if (g.offset <= new_base) {
+                new_base = @max(new_base, g.offset + g.len);
+                _ = self.acked_gaps.orderedRemove(i);
+                i = 0; // a merge can unlock an earlier-skipped gap; rescan
+            } else i += 1;
+        }
+        const drop: usize = @intCast(new_base - self.base_offset);
+        const keep = self.buf.items.len - drop;
+        std.mem.copyForwards(u8, self.buf.items[0..keep], self.buf.items[drop..]);
+        self.buf.shrinkRetainingCapacity(keep);
+        self.base_offset = new_base;
+        if (self.sent < self.base_offset) self.sent = self.base_offset;
+    }
+
+    fn insertLost(self: *SendStream, offset: u64, len: u64) Error!void {
+        try self.insertRange(&self.lost, offset, len);
+    }
+
+    fn insertAckedGap(self: *SendStream, offset: u64, hi: u64) Error!void {
+        try self.insertRange(&self.acked_gaps, offset, hi - offset);
+    }
+
+    /// Insert [offset, offset+len) into a sorted, non-overlapping range list,
+    /// coalescing with any touching neighbour. An allocation failure propagates: a
+    /// dropped retransmit or acked-gap record would silently strand bytes, so it is
+    /// surfaced to the caller rather than swallowed.
+    fn insertRange(self: *SendStream, list: *std.ArrayListUnmanaged(Range), offset: u64, len: u64) Error!void {
+        var lo = offset;
+        var hi = offset + len;
+        var i: usize = 0;
+        while (i < list.items.len) {
+            const r = list.items[i];
+            if (r.offset + r.len < lo) {
+                i += 1; // entirely before; keep
+            } else if (r.offset > hi) {
+                break; // entirely after; insert here
+            } else {
+                lo = @min(lo, r.offset);
+                hi = @max(hi, r.offset + r.len);
+                _ = list.orderedRemove(i); // merged in; re-examine this index
+            }
+        }
+        list.insert(self.gpa, i, .{ .offset = lo, .len = hi - lo }) catch return error.OutOfMemory;
+    }
+
+    /// Remove [lo, hi) from the pending retransmit list (it has been acked), keeping
+    /// the remaining fragments. Intersection-based, so a span already absent is a
+    /// no-op.
+    fn dropLost(self: *SendStream, lo: u64, hi: u64) Error!void {
+        var i: usize = 0;
+        while (i < self.lost.items.len) {
+            const r = self.lost.items[i];
+            const rhi = r.offset + r.len;
+            if (rhi <= lo or r.offset >= hi) {
+                i += 1; // disjoint
+                continue;
+            }
+            _ = self.lost.orderedRemove(i);
+            if (r.offset < lo) try self.insertLost(r.offset, lo - r.offset); // left remainder
+            if (rhi > hi) try self.insertLost(hi, rhi - hi); // right remainder
+        }
     }
 };
 
@@ -317,12 +472,12 @@ test "SendStream drains queued bytes in offset-ordered chunks" {
     try std.testing.expectEqual(@as(u64, 0), c1.offset);
     try std.testing.expectEqualStrings("hello", c1.data);
     try std.testing.expect(!c1.fin);
-    s.commit(c1.data.len, false);
+    s.commit(c1.offset, c1.data.len, false);
 
     const c2 = s.peek(100).?;
     try std.testing.expectEqual(@as(u64, 5), c2.offset);
     try std.testing.expectEqualStrings(" world", c2.data);
-    s.commit(c2.data.len, false);
+    s.commit(c2.offset, c2.data.len, false);
     try std.testing.expect(!s.pending());
 }
 
@@ -333,7 +488,7 @@ test "SendStream carries the FIN on the final chunk and forbids later writes" {
     try s.write("data", true); // bytes + FIN
     const c = s.peek(100).?;
     try std.testing.expect(c.fin);
-    s.commit(c.data.len, true);
+    s.commit(c.offset, c.data.len, true);
     try std.testing.expect(!s.pending()); // FIN sent, nothing left
 
     // Writing after FIN would exceed the final size.
@@ -351,6 +506,77 @@ test "SendStream owes a FIN even with no bytes" {
     const c = s.peek(100).?;
     try std.testing.expectEqual(@as(usize, 0), c.data.len);
     try std.testing.expect(c.fin);
-    s.commit(0, true);
+    s.commit(c.offset, 0, true);
     try std.testing.expect(!s.pending());
+}
+
+test "SendStream retains sent bytes until acked, then frees the prefix" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("abcdefghij", false);
+    const c = s.peek(100).?;
+    s.commit(c.offset, c.data.len, false);
+    try std.testing.expect(!s.pending()); // all sent
+    try std.testing.expectEqual(@as(usize, 10), s.buf.items.len); // but retained
+
+    try s.onAck(0, 4, false); // first 4 bytes acked
+    try std.testing.expectEqual(@as(u64, 4), s.base_offset);
+    try std.testing.expectEqual(@as(usize, 6), s.buf.items.len); // prefix freed
+    try s.onAck(4, 6, false);
+    try std.testing.expectEqual(@as(usize, 0), s.buf.items.len); // fully freed
+}
+
+test "SendStream re-frames a lost range before new bytes" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("AAAA", false);
+    const a = s.peek(100).?; // [0,4)
+    s.commit(a.offset, a.data.len, false);
+    try s.write("BBBB", false);
+    const b = s.peek(100).?; // [4,8)
+    s.commit(b.offset, b.data.len, false);
+
+    try s.onLost(0, 4, false); // the first packet was lost
+    try std.testing.expect(s.pending());
+    const r = s.peek(100).?; // retransmit comes first
+    try std.testing.expectEqual(@as(u64, 0), r.offset);
+    try std.testing.expectEqualStrings("AAAA", r.data);
+    s.commit(r.offset, r.data.len, false);
+    try std.testing.expect(!s.pending()); // [4,8) was already sent; nothing new
+}
+
+test "SendStream frees out-of-order acks once the gap fills" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("0123456789", false);
+    const c = s.peek(100).?;
+    s.commit(c.offset, c.data.len, false);
+
+    try s.onAck(5, 5, false); // ack the LATER half first (out of order)
+    try std.testing.expectEqual(@as(u64, 0), s.base_offset); // cannot free yet
+    try std.testing.expectEqual(@as(usize, 10), s.buf.items.len);
+    try s.onAck(0, 5, false); // the filling ack lets base slide through the held gap
+    try std.testing.expectEqual(@as(u64, 10), s.base_offset);
+    try std.testing.expectEqual(@as(usize, 0), s.buf.items.len);
+}
+
+test "SendStream re-sends a lost FIN exactly once" {
+    const gpa = std.testing.allocator;
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write("hi", true);
+    const c = s.peek(100).?; // "hi" + FIN
+    try std.testing.expect(c.fin);
+    s.commit(c.offset, c.data.len, true);
+
+    try s.onLost(0, 2, true); // the FIN-carrying packet was lost
+    try std.testing.expect(s.pending());
+    const r = s.peek(100).?;
+    try std.testing.expect(r.fin); // the FIN rides the resend
+    try std.testing.expectEqualStrings("hi", r.data);
+    s.commit(r.offset, r.data.len, true);
+    try std.testing.expect(!s.pending()); // FIN owed exactly once
 }


### PR DESCRIPTION
The QUIC send path dropped STREAM data when a packet was lost; this adds retransmission, the documented follow-up from the send-path PR.

- `stream.zig` - `SendStream` becomes a retain buffer. Instead of discarding bytes at `commit`, it keeps all unacked bytes in one contiguous buffer anchored at `base_offset`, with a `sent` cursor splitting already-framed bytes from new ones. `peek` re-frames lost ranges before new bytes (RFC 9002 13.3); `onAck` slides `base_offset` forward (freeing the acked prefix and pulling through any out-of-order acked gaps held in `acked_gaps`); `onLost` records the still-unacked sub-range; a lost FIN re-rides exactly once via `fin_lost`.
- `recovery.zig` - `onAck`/`detectLost` now append each removed packet number to a caller-supplied list, staying frame-agnostic (no STREAM knowledge in recovery).
- `connection.zig` - a per-packet `pn -> {stream, offset, len, fin}` map. On an incoming ACK the connection frees the acked ranges, runs loss detection, and re-queues each lost packet's range so the next `flushSend` resends it. A pn lives in recovery and the map in lockstep (`fetchRemove`), so each is routed exactly once - a late ack of an already-lost packet is a no-op.

Flow control stays correct: the send window is a monotonic high-water mark, so a retransmit re-sends already-presented offsets without consuming fresh credit, and there is no credit-return.

Designed and adversarially hardened via a multi-agent pass (three retain-buffer models, judged, then attacked along double-send/resurrect, partial-ack/FIN, and memory/ordering), then reviewed by Codex. The hardening pass caught two would-be P1s before they were written - decrementing the flow-control window on ACK, and an unimplemented out-of-order-ack merge - both avoided here. Codex's review confirmed the six correctness properties hold and flagged three allocation-failure consistency edges, all fixed: the per-packet record is reserved before the packet is sent, range-list inserts propagate OOM rather than silently stranding a retransmit, and recovery records a pn before mutating congestion state.

The decisive test drops a packet, feeds back an ACK that declares it lost, and confirms the peer reassembles the whole 5000-byte stream; others cover the no-new-credit-on-retransmit invariant, the late-ack no-op, retransmit-before-new ordering, the FIN-on-lost-packet case, and out-of-order-ack freeing.

Detect-on-ACK only; PTO-driven tail-loss recovery (a single lost tail packet with no later ACK) and write-side backpressure are documented follow-ups.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
