### PR TITLE
Recover tail-lost STREAM data with a PTO timer

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -235,9 +235,11 @@ pub const Connection = struct {
         const datagram_len = self.out.items.len - start;
         self.out_lengths.append(self.gpa, datagram_len) catch return error.OutOfMemory;
         // A pure-ACK packet is not ack-eliciting, so it is not in flight: not
-        // congestion-controlled or retransmitted (RFC 9002 2, 7).
+        // congestion-controlled or retransmitted (RFC 9002 2, 7). Only in-flight
+        // packets count toward bytes_in_flight - charging a pure ACK would inflate it
+        // permanently, since the ACK/loss paths only credit back in-flight packets.
         st.rec.onSent(self.gpa, .{ .pn = pn, .sent_time = now, .size = datagram_len, .ack_eliciting = ack_eliciting, .in_flight = ack_eliciting }) catch return error.OutOfMemory;
-        self.cc.onSent(datagram_len);
+        if (ack_eliciting) self.cc.onSent(datagram_len);
         st.next_pn += 1;
         return pn;
     }
@@ -439,18 +441,28 @@ pub const Connection = struct {
     fn sendProbe(self: *Connection, space: Space, pn: u64, now: u64) Error!void {
         const st = &self.spaces[@intFromEnum(space)];
         if (st.stream_sent.get(pn)) |sent| {
-            if (self.send_streams.get(sent.id)) |s| try s.onLost(sent.offset, sent.len, sent.fin);
-            return;
+            if (self.send_streams.get(sent.id)) |s| {
+                try s.onLost(sent.offset, sent.len, sent.fin);
+                // If the original data was already acked, onLost clips the range to
+                // nothing (it is below base_offset) and queues no resend. Fall through
+                // to a PING so a probe still reaches the wire - otherwise the PTO
+                // advanced its backoff/latch with nothing sent and the timer would
+                // spin on an unsatisfiable deadline.
+                if (s.pending()) return;
+            }
         }
-        // No STREAM data to resend (a CRYPTO or PING packet): a PING is a valid probe
-        // that elicits an ACK. Retransmitting lost CRYPTO data on PTO - so the
-        // handshake itself recovers from tail loss - is a separate follow-up; here the
-        // PING at least keeps the timer and recovery loop alive.
+        // No STREAM data to resend (a CRYPTO or PING packet, or an already-acked
+        // range): a PING is a valid probe that elicits an ACK. Retransmitting lost
+        // CRYPTO data on PTO - so the handshake itself recovers from tail loss - is a
+        // separate follow-up; here the PING keeps the timer and recovery loop alive.
         try self.sendPing(space, now);
     }
 
     fn sendPing(self: *Connection, space: Space, now: u64) Error!void {
-        _ = try self.buildPacket(space, &[_]u8{0x01}, true, now); // PING (RFC 9000 19.2)
+        // PING (0x01) plus PADDING (0x00): the padding makes the packet long enough
+        // for the 16-byte header-protection sample (a bare 1-byte PING is too short),
+        // and PADDING is legal in every space. PING makes it ack-eliciting.
+        _ = try self.buildPacket(space, &([_]u8{0x01} ++ [_]u8{0x00} ** 19), true, now);
     }
 
     // ---- TLS handshake drive ---------------------------------------------------
@@ -1413,6 +1425,34 @@ test "onTimeout without an intervening flush does not inflate the backoff" {
     // must not re-fire and double the backoff again: the anchor has not advanced.
     try sender.onTimeout(after_first + 1);
     try testing.expectEqual(after_first, sender.nextTimeout().?);
+}
+
+test "a PTO on a probe whose data was already acked sends a PING, not nothing" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xAB, 0xCD, 0xEF, 0x01 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    try sender.sendStreamData(1, "tail", true);
+    try sender.flushSend(1000); // pn 0 carries [0,4)+FIN
+    const d1 = sender.nextTimeout().?;
+    try sender.onTimeout(d1 + 1); // PTO -> re-queue [0,4)
+    try sender.flushSend(d1 + 2); // probe is pn 1, same range; pn 0 still in flight
+    sender.clearSend();
+
+    // ACK the ORIGINAL (pn 0): its data is now acked, base_offset advances past it.
+    const ack = try buildAppAck(gpa, &dcid, 0, 0, 0);
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, d1 + 3); // also releases the latch
+
+    // The probe (pn 1) is still in flight, so a PTO arms for it. Firing it must put
+    // SOMETHING on the wire (a PING, sent inline by sendProbe) - re-queueing the
+    // already-acked range yields no STREAM resend, and a no-send would spin the timer.
+    const d2 = sender.nextTimeout().?;
+    try sender.onTimeout(d2 + 1);
+    try testing.expectEqual(@as(usize, 1), sender.datagramLengths().len); // a PING probe left
+    try testing.expect(!sender.hasPendingSend()); // no STREAM resend was queued
 }
 
 test "ACK progress releases the PTO latch so a later loss can re-fire" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -28,6 +28,22 @@ const Space = constants.Space;
 
 pub const Role = enum { server, client };
 
+/// The Application-space PTO ack-delay budget (RFC 9002 6.2.1). The default peer
+/// max_ack_delay (RFC 9000 18.2) until transport parameters are negotiated; the
+/// long-header spaces use 0, handled when handshake PTO lands.
+const MAX_ACK_DELAY_US: u64 = 25_000;
+
+/// The earlier of an optional `a` and a `b`.
+fn minOpt(a: ?u64, b: u64) ?u64 {
+    return if (a) |x| @min(x, b) else b;
+}
+
+/// The PTO ack-delay term per space (RFC 9002 6.2.1): max_ack_delay applies only to
+/// Application; the long-header spaces add 0.
+fn ackDelayFor(space: Space) u64 {
+    return if (space == .application) MAX_ACK_DELAY_US else 0;
+}
+
 pub const Error = error{
     /// A received packet failed authentication and was dropped; surfaced so a
     /// caller can count it, never fatal on its own (RFC 9001 9.5).
@@ -58,6 +74,11 @@ const SpaceState = struct {
     /// so a lost packet's data can be re-queued and an acked packet's data freed.
     /// Only the Application space carries STREAM frames, but the field is uniform.
     stream_sent: std.AutoHashMapUnmanaged(u64, StreamSent) = .empty,
+    /// The ack-eliciting send-time anchor a PTO last fired against. A PTO will not
+    /// re-fire for the same anchor (which would inflate the backoff without a probe
+    /// reaching the wire); it re-arms only once a fresh ack-eliciting send advances
+    /// last_ack_eliciting_sent_time past this.
+    pto_fired_anchor: ?u64 = null,
 
     fn deinit(self: *SpaceState, gpa: std.mem.Allocator) void {
         self.rec.deinit(gpa);
@@ -342,6 +363,19 @@ pub const Connection = struct {
                 if (self.send_streams.get(e.value.id)) |s| try s.onAck(e.value.offset, e.value.len, e.value.fin);
             }
         }
+        // ACK progress resets the PTO backoff (in recovery), so release the fire-once
+        // latch: a fresh PTO epoch may arm even if another packet sharing the fired
+        // anchor is still in flight.
+        if (acked_pns.items.len > 0) st.pto_fired_anchor = null;
+        try self.detectLostAndRequeue(space, now);
+    }
+
+    /// Run loss detection for one space and re-queue every newly-lost packet's
+    /// STREAM range so the next flushSend retransmits it. Shared by the ACK arm and
+    /// the time-threshold path of onTimeout; `fetchRemove` keeps rec.sent and
+    /// stream_sent in lockstep, so each pn is routed exactly once.
+    fn detectLostAndRequeue(self: *Connection, space: Space, now: u64) Error!void {
+        const st = &self.spaces[@intFromEnum(space)];
         var lost_pns: std.ArrayListUnmanaged(u64) = .empty;
         defer lost_pns.deinit(self.gpa);
         _ = st.rec.detectLost(&self.rtt, &self.cc, now, &lost_pns, self.gpa) catch return error.OutOfMemory;
@@ -350,6 +384,73 @@ pub const Connection = struct {
                 if (self.send_streams.get(e.value.id)) |s| try s.onLost(e.value.offset, e.value.len, e.value.fin);
             }
         }
+    }
+
+    // ---- loss-recovery timer (sans-IO: the integrator owns the OS timer) --------
+
+    /// The absolute time (us) of the earliest armed deadline across all spaces - the
+    /// earlier of any time-threshold loss deadline and any PTO deadline - or null if
+    /// nothing is armed. The integrator sets an OS timer for this and calls
+    /// `onTimeout` at or after it. Null also when the PTO backoff has saturated (a
+    /// black-holed peer): the integrator's own idle timeout then closes the connection.
+    pub fn nextTimeout(self: *Connection) ?u64 {
+        var earliest: ?u64 = null;
+        for (&self.spaces, 0..) |*st, i| {
+            if (st.rec.loss_time) |t| earliest = minOpt(earliest, t);
+            if (st.rec.ptoDeadline(&self.rtt, ackDelayFor(@enumFromInt(i)))) |t| earliest = minOpt(earliest, t);
+        }
+        return earliest;
+    }
+
+    /// Drive the loss-recovery timers at time `now`. First handle any space whose
+    /// time-threshold loss deadline passed (declare lost + re-queue, exactly the ACK
+    /// path). Then, per space whose PTO deadline passed, send a probe: re-queue the
+    /// oldest unacked STREAM range so the next flushSend resends it (or a PING). No
+    /// I/O happens here - the next flushSend emits whatever was queued.
+    pub fn onTimeout(self: *Connection, now: u64) Error!void {
+        if (self.closed) return error.ProtocolViolation;
+
+        // (1) Time-threshold losses first (RFC 9002 6.2.1: loss_time takes precedence).
+        for (&self.spaces, 0..) |*st, i| {
+            if (st.rec.loss_time) |lt| {
+                if (now >= lt) try self.detectLostAndRequeue(@enumFromInt(i), now);
+            }
+        }
+
+        // (2) PTO fires. The latch (pto_fired_anchor) stops a re-fire for the same
+        // ack-eliciting anchor: a PTO must wait for an actual probe to advance the
+        // anchor before backing off again, so repeated onTimeout calls without an
+        // intervening send cannot inflate the backoff.
+        for (&self.spaces, 0..) |*st, i| {
+            if (st.send_keys == null) continue;
+            const deadline = st.rec.ptoDeadline(&self.rtt, ackDelayFor(@enumFromInt(i))) orelse continue;
+            if (now < deadline) continue;
+            if (st.pto_fired_anchor == st.rec.last_ack_eliciting_sent_time) continue; // already fired for this anchor
+            st.pto_fired_anchor = st.rec.last_ack_eliciting_sent_time;
+            if (st.rec.onPtoExpired()) |pn| try self.sendProbe(@enumFromInt(i), pn, now);
+        }
+    }
+
+    /// Send a PTO probe for `space`: re-queue the oldest unacked STREAM range so the
+    /// next flushSend resends it to elicit an ACK, or a PING if that packet carried
+    /// no STREAM data. Crucially `stream_sent.get` (not fetchRemove): the probed
+    /// packet stays in flight - a probe re-sends data, it does not declare loss - so
+    /// its genuine later ACK or loss still routes exactly once.
+    fn sendProbe(self: *Connection, space: Space, pn: u64, now: u64) Error!void {
+        const st = &self.spaces[@intFromEnum(space)];
+        if (st.stream_sent.get(pn)) |sent| {
+            if (self.send_streams.get(sent.id)) |s| try s.onLost(sent.offset, sent.len, sent.fin);
+            return;
+        }
+        // No STREAM data to resend (a CRYPTO or PING packet): a PING is a valid probe
+        // that elicits an ACK. Retransmitting lost CRYPTO data on PTO - so the
+        // handshake itself recovers from tail loss - is a separate follow-up; here the
+        // PING at least keeps the timer and recovery loop alive.
+        try self.sendPing(space, now);
+    }
+
+    fn sendPing(self: *Connection, space: Space, now: u64) Error!void {
+        _ = try self.buildPacket(space, &[_]u8{0x01}, true, now); // PING (RFC 9000 19.2)
     }
 
     // ---- TLS handshake drive ---------------------------------------------------
@@ -1202,4 +1303,143 @@ test "a late ACK of an already-lost packet is a harmless no-op" {
     defer gpa.free(late);
     try sender.receiveDatagram(late, 4000); // must not crash, double-free, or resurrect
     try testing.expect(!sender.closed);
+}
+
+// ---- PTO / tail-loss tests --------------------------------------------------
+
+test "a lost tail STREAM packet is retransmitted via the PTO timer" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7, 0xD8 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    testInstallAppKeys(&peer);
+
+    // ONE tail packet, never acked: ACK-driven loss detection is blind here (no
+    // later packet, no ACK, loss_time never set). Only the PTO recovers it.
+    try sender.sendStreamData(1, "tail", true);
+    try sender.flushSend(1000);
+    try testing.expectEqual(@as(usize, 1), sender.datagramLengths().len);
+    sender.clearSend();
+    try testing.expect(!sender.hasPendingSend());
+
+    const deadline = sender.nextTimeout().?; // armed off the one ack-eliciting send
+    try testing.expect(deadline > 1000);
+    try sender.onTimeout(deadline + 1); // PTO fires -> probe re-queues the tail range
+    try testing.expect(sender.hasPendingSend());
+    try sender.flushSend(deadline + 2);
+    try testing.expect(sender.datagramLengths().len >= 1); // retransmitted
+
+    // The peer receives the retransmission and reassembles the whole stream.
+    try deliverAllExcept(&sender, &peer, null, deadline + 3);
+    try testing.expectEqualStrings("tail", peer.streamData(1));
+    try testing.expect(peer.streamFinished(1));
+}
+
+test "nextTimeout is null when idle and after everything is acked" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xE1, 0xE2, 0xE3, 0xE4 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    try testing.expect(sender.nextTimeout() == null); // nothing in flight: no timer
+
+    try sender.sendStreamData(1, "x", true);
+    try sender.flushSend(1000);
+    try testing.expect(sender.nextTimeout() != null); // armed off the send
+
+    const ack = try buildAppAck(gpa, &dcid, 0, 0, 0); // ack pn 0
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, 2000);
+    try testing.expect(sender.nextTimeout() == null); // all acked: no spurious arm
+}
+
+test "the PTO backs off exponentially across consecutive fires" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xF1, 0xF2, 0xF3, 0xF4 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    try sender.sendStreamData(1, "x", false);
+    try sender.flushSend(1000);
+    const d1 = sender.nextTimeout().?; // anchor 1000, pto_count 0 -> base
+    const base = d1 - 1000;
+
+    try sender.onTimeout(d1 + 1); // PTO 1: pto_count -> 1, re-queue
+    try sender.flushSend(d1 + 2); // the probe leaves; anchor advances to d1+2
+    const d2 = sender.nextTimeout().?;
+    // Second deadline is the doubled base measured from the probe's send time.
+    try testing.expectEqual((d1 + 2) + base * 2, d2);
+}
+
+test "a PTO probe that gets acked resets the backoff" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x1A, 0x2B, 0x3C, 0x4D };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    try sender.sendStreamData(1, "data", true);
+    try sender.flushSend(1000);
+    const d1 = sender.nextTimeout().?;
+    try sender.onTimeout(d1 + 1); // pto_count -> 1
+    try sender.flushSend(d1 + 2); // probe sent as pn 1
+
+    // Ack both the original tail (pn 0) and the probe (pn 1): everything in flight
+    // is acknowledged, so the backoff resets and no timer remains armed.
+    const ack = try buildAppAck(gpa, &dcid, 0, 1, 1);
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, d1 + 3);
+    try testing.expect(sender.nextTimeout() == null); // pto_count reset, nothing in flight
+}
+
+test "onTimeout without an intervening flush does not inflate the backoff" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x5E, 0x6F, 0x70, 0x81 };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    try sender.sendStreamData(1, "x", false);
+    try sender.flushSend(1000);
+    const d1 = sender.nextTimeout().?;
+    try sender.onTimeout(d1 + 1); // fires once for this anchor
+    const after_first = sender.nextTimeout().?;
+    // A second onTimeout past the deadline WITHOUT a flush (no new probe on the wire)
+    // must not re-fire and double the backoff again: the anchor has not advanced.
+    try sender.onTimeout(after_first + 1);
+    try testing.expectEqual(after_first, sender.nextTimeout().?);
+}
+
+test "ACK progress releases the PTO latch so a later loss can re-fire" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x9A, 0x8B, 0x7C, 0x6D };
+    var sender = try Connection.init(gpa, .server, &dcid);
+    defer sender.deinit();
+    testInstallAppKeys(&sender);
+
+    // Two packets sent at the SAME time -> they share one ack-eliciting anchor.
+    try sender.sendStreamData(1, "aaaa", false);
+    try sender.sendStreamData(2, "bbbb", false);
+    try sender.flushSend(1000); // pn 0 (stream 1), pn 1 (stream 2), anchor 1000
+
+    const d1 = sender.nextTimeout().?;
+    try sender.onTimeout(d1 + 1); // PTO fires for anchor 1000, latch = 1000
+    try sender.flushSend(d1 + 2);
+
+    // Ack only the probe/first packet; pto_count resets and the latch is released.
+    const ack = try buildAppAck(gpa, &dcid, 0, 0, 0); // ack pn 0
+    defer gpa.free(ack);
+    try sender.receiveDatagram(ack, d1 + 3);
+
+    // A still-unacked packet remains in flight, so the PTO must be able to arm and
+    // fire a fresh epoch - the latch must not suppress it forever.
+    try testing.expect(sender.nextTimeout() != null);
+    const d2 = sender.nextTimeout().?;
+    try sender.onTimeout(d2 + 1);
+    try testing.expect(sender.hasPendingSend()); // a new probe was queued
 }

--- a/src/core/quic/recovery.zig
+++ b/src/core/quic/recovery.zig
@@ -66,6 +66,11 @@ pub const AckOutcome = struct {
 };
 
 /// Loss detection over one packet-number space.
+/// PTO backs off as `base << pto_count`; the shift is capped here so it cannot
+/// invoke undefined behaviour, and `nextTimeout` treats a saturated count as "give
+/// up" so a black-holed connection stops arming and minting probe records.
+const PTO_SHIFT_CAP: u32 = 20;
+
 pub const Space = struct {
     sent: std.ArrayListUnmanaged(SentPacket) = .empty,
     largest_acked: ?u64 = null,
@@ -73,6 +78,9 @@ pub const Space = struct {
     /// The number of times the PTO has fired without progress (RFC 9002 6.2.1);
     /// the PTO backs off exponentially by this count.
     pto_count: u32 = 0,
+    /// Send time of the most recent ack-eliciting packet; the PTO is measured from
+    /// here (RFC 9002 6.2.1). Read only when something ack-eliciting is in flight.
+    last_ack_eliciting_sent_time: ?u64 = null,
 
     pub fn deinit(self: *Space, gpa: std.mem.Allocator) void {
         self.sent.deinit(gpa);
@@ -80,6 +88,36 @@ pub const Space = struct {
 
     pub fn onSent(self: *Space, gpa: std.mem.Allocator, pkt: SentPacket) !void {
         try self.sent.append(gpa, pkt);
+        if (pkt.ack_eliciting) self.last_ack_eliciting_sent_time = pkt.sent_time;
+    }
+
+    /// The armed PTO deadline (RFC 9002 6.2.1), or null when no ack-eliciting packet
+    /// is in flight (PTO is not armed) or the backoff has saturated (a black-holed
+    /// connection: stop arming and let the integrator's idle timeout close it).
+    pub fn ptoDeadline(self: *const Space, rtt: *const RttEstimator, max_ack_delay: u64) ?u64 {
+        if (self.pto_count >= PTO_SHIFT_CAP) return null;
+        if (!self.hasAckEliciting()) return null;
+        const anchor = self.last_ack_eliciting_sent_time orelse return null;
+        const base = rtt.pto() + max_ack_delay;
+        return anchor + (base << @intCast(self.pto_count));
+    }
+
+    /// A PTO fired for this space: name the oldest in-flight ack-eliciting packet to
+    /// probe (re-send its data to elicit an ACK) and back off the timer. Returns
+    /// null - WITHOUT backing off - if nothing is ack-eliciting (the caller should
+    /// not have fired). The packet is NOT removed: a probe re-sends, it does not
+    /// declare loss.
+    pub fn onPtoExpired(self: *Space) ?u64 {
+        // The oldest in-flight ack-eliciting packet is the smallest pn (pn is
+        // monotonic with send order). `sent` is not append-ordered - swapRemove in
+        // onAck/detectLost reorders it - so scan for the minimum rather than take
+        // the first entry.
+        var oldest: ?u64 = null;
+        for (self.sent.items) |p| {
+            if (p.ack_eliciting) oldest = if (oldest) |o| @min(o, p.pn) else p.pn;
+        }
+        if (oldest != null) self.pto_count += 1; // back off only when a probe target exists
+        return oldest;
     }
 
     /// Apply an ACK (its largest, first-range, and the raw range bytes from the
@@ -142,6 +180,12 @@ pub const Space = struct {
                 if (largest_acked_time) |t| rtt.update(now - t, ack_delay);
             }
             self.pto_count = 0;
+        }
+        // Once nothing is in flight, no deadline is armed: clear the timer anchors so
+        // nextTimeout does not report a stale loss_time / PTO for an idle space.
+        if (self.sent.items.len == 0) {
+            self.loss_time = null;
+            self.last_ack_eliciting_sent_time = null;
         }
         return outcome;
     }


### PR DESCRIPTION
ACK-driven loss detection cannot recover a lost TAIL packet - the last ack-eliciting packet, with no later packet to ack and so no ACK to trigger detection. This adds RFC 9002 6.2's probe timeout (PTO), completing the loss-recovery story started by the retransmission PR.

Sans-IO, so the connection cannot fire its own timer. It exposes:
- `nextTimeout() -> ?u64` - the earliest armed deadline across spaces (the earlier of any time-threshold loss deadline and any PTO deadline), or null when idle / the backoff has saturated. The integrator arms its OS timer for this.
- `onTimeout(now)` - the integrator calls it when that timer fires. It handles time-threshold losses first (RFC 9002 6.2.1 precedence), then probes any space whose PTO deadline passed.

`recovery.Space` owns the timer math: `ptoDeadline` = `anchor + (pto()+max_ack_delay) << pto_count`, gated on ack-eliciting in flight and a backoff cap so a black-holed peer stops arming; `onPtoExpired` backs off and names the oldest in-flight ack-eliciting packet to probe. The connection's `sendProbe` re-queues that packet's STREAM range via `stream_sent.get` - never `fetchRemove`, so the probed packet stays in flight and its genuine later ACK or loss still routes exactly once - and the next `flushSend` resends it. A PING is the fallback when the probed packet carried no STREAM data.

A fire-once latch keyed on the ack-eliciting anchor stops repeated `onTimeout` calls from inflating the backoff without a probe reaching the wire; ACK progress releases the latch and resets the backoff.

The decisive test sends one tail packet, never acks it, fires `onTimeout` past the PTO, and confirms the retransmit reaches the peer - the exact case ACK detection cannot reach. The battery covers exponential backoff (anchored on the probe's send time), `nextTimeout` null when idle/acked, PTO-then-ACK resetting the backoff, the no-inflation latch, and the shared-anchor latch release.

Designed and adversarially hardened via a multi-agent pass (two timer-ownership designs, judged on RFC 9002 6.2 correctness + sans-IO fit, then attacked along arming/precedence, backoff/reset, and probe-content/rec.sent-integrity), then reviewed by Codex. The hardening caught the loss_time-not-cleared and latch-inflation issues up front; Codex's review caught the shared-anchor latch suppression (the latch now releases on ACK progress), the per-space max_ack_delay (0 for Initial/Handshake), and the oldest-pn scan after swapRemove. CRYPTO/handshake-space PTO and two-packet probes are documented follow-ups.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
