### PR TITLE
Strip change-narration comments and correct THREAT_MODEL API names

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -111,8 +111,8 @@ amortized O(n). A peer cannot force an allocation larger than `max_buffer`.
 ### Terminal errors (anti-desync)
 
 A parse error **poisons the connection permanently**: every subsequent
-`next_event()` re-raises it, and `start_next_cycle()` / `reset()` cannot revive a
-failed connection. A desynchronized byte stream can never be re-parsed as if it
+`next_event()` re-raises it, and `start_next_cycle()` cannot revive a failed
+connection. A desynchronized byte stream can never be re-parsed as if it
 were valid.
 
 ### Outbound injection (response splitting)
@@ -134,9 +134,12 @@ them wrong can reintroduce a smuggling or DoS class that the core sidesteps.
 2. **Connection concurrency / request caps.** The host must cap concurrent
    connections and may cap requests-per-connection.
 3. **Bodyless responses (client role).** Responses to `HEAD` and all
-   `1xx` / `204` / `304` have no body regardless of headers. The application
-   **must** call `conn.expect_bodyless()` before parsing such a response, or a
-   keep-alive response stream will desynchronize. (This is h11's contract.)
+   `1xx` / `204` / `304` have no body regardless of headers. The connection
+   handles this automatically: it remembers the method from `send_request` and
+   auto-frames the matching response as bodyless. The integrator's only
+   responsibility is to send the request through the **same** `Connection` so the
+   method is known; parsing a response on a connection that never saw the request
+   will desynchronize a keep-alive stream.
 4. **`Upgrade` / `CONNECT` / `101`.** zttp has no tunnel awareness. After a
    protocol switch the integrator must stop feeding bytes to zttp as HTTP/1.1,
    must not call `start_next_cycle()` on a tunneled connection, and must strip
@@ -148,17 +151,18 @@ them wrong can reintroduce a smuggling or DoS class that the core sidesteps.
 6. **Discard poisoned connections.** When `next_event()` raises
    `RemoteProtocolError`, the connection is terminally failed; the host should
    send an error response (if appropriate) and close it.
-7. **Tune `Limits` for the deployment.** The defaults are conservative; adjust
-   them to the workload and threat profile.
+7. **Know the `Limits`.** The defaults (above) are conservative and are not
+   configurable from the Python API today; the host's own caps (timeouts,
+   concurrency) are the tunable defense.
 
 ## Residual risks
 
 These are not defects in the current parser; they are the places where the
 *system* can still go wrong:
 
-- **Misuse of the integration contract** (items 3-5 above) - a forgotten
-  `expect_bodyless()` or mishandled `CONNECT` can desynchronize a stream that the
-  core itself parses correctly.
+- **Misuse of the integration contract** (items 3-5 above) - parsing a response
+  on a connection that never sent the request, or a mishandled `CONNECT`, can
+  desynchronize a stream that the core itself parses correctly.
 - **Lenient mode.** The Zig core has `strict_crlf` / chunk-strictness toggles that
   default to strict and are **not** exposed through the Python API. If a future
   binding ever exposes them, the bare-LF/CR smuggling classes re-open. Keep

--- a/src/core/h1/chunked.zig
+++ b/src/core/h1/chunked.zig
@@ -110,7 +110,6 @@ fn parseChunkSize(line: []const u8) ParseError!u64 {
     var digits: usize = 0;
     for (line) |ch| {
         if (ch == ';') {
-            // Chunk extensions follow; ignore the remainder of the line.
             if (digits == 0) return error.InvalidChunk;
             return n;
         }
@@ -130,7 +129,7 @@ fn consumeCrlf(sc: *Scanner, strict: bool) ParseError!bool {
     const r = sc.remaining();
     if (r.len == 0) return false;
     if (r[0] == '\n') {
-        if (strict) return error.InvalidChunk; // bare LF rejected
+        if (strict) return error.InvalidChunk;
         _ = sc.take(1);
         return true;
     }

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -100,7 +100,7 @@ pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Frami
     for (headers) |h| {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
             has_te = true;
-            te.add(h.value); // fold every TE field-line into one ordered list
+            te.add(h.value);
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const n = try parseContentLength(h.value);
             if (content_length) |prev| {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -186,7 +186,6 @@ pub const Connection = struct {
     }
 
     fn dispatch(self: *Connection) H2Error!Event {
-        // Drain any buffered events from the previous frame first.
         if (self.pending_len > 0) return self.popPending();
 
         if (self.consumed >= COMPACT_THRESHOLD and self.consumed * 2 >= self.buf.items.len) self.compact();
@@ -506,7 +505,7 @@ pub const Connection = struct {
         const is_trailer = self.fb_is_trailer;
         const refused = self.fb_refused;
         const ignored = self.fb_ignored;
-        self.fb_stream = null; // block closed
+        self.fb_stream = null;
 
         // Always decode (even when refused/malformed) to keep the dynamic table
         // in sync; a decode failure is connection-fatal COMPRESSION_ERROR.

--- a/src/core/h2/hpack/decoder.zig
+++ b/src/core/h2/hpack/decoder.zig
@@ -423,8 +423,8 @@ test "oversized entry empties the table but still emits the header" {
 }
 
 test "an indexed dynamic header survives a later insert that evicts it" {
-    // Codex caught this: a header that resolves through the dynamic table must not
-    // dangle when a subsequent insert in the SAME block evicts/compacts the store.
+    // A header that resolves through the dynamic table must not dangle when a
+    // subsequent insert in the SAME block evicts/compacts the store.
     // With the offset-into-out_store design, the emitted bytes are copied before
     // any table mutation, so they stay valid.
     var d = Decoder.init(testing.allocator, 70, 1 << 20); // room for ~2 small entries

--- a/src/core/h2/stream.zig
+++ b/src/core/h2/stream.zig
@@ -55,7 +55,7 @@ pub const Stream = struct {
     /// (it answers a HEAD, or its status is 204/304), so the content-length vs
     /// data-seen check is skipped (RFC 9110 8.6).
     expects_bodyless: bool = false,
-    headers_done: bool = false, // the request/response HEADERS block completed
+    headers_done: bool = false,
     end_stream_seen: bool = false,
     /// Outbound DATA the send window could not yet admit, parked here and drained
     /// as WINDOW_UPDATE credits arrive. `send_end_pending` records that END_STREAM

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -257,8 +257,8 @@ pub const Connection = struct {
     /// This is application queueing: it buffers everything written. Only `flushSend`
     /// applies the connection send window, so the in-flight bytes on the wire are
     /// bounded by the peer's MAX_DATA grant, but the queued-but-unsent buffer is
-    /// bounded only by what the application writes. A write-side backpressure cap is
-    /// a follow-up.
+    /// bounded only by what the application writes; there is no write-side
+    /// backpressure cap.
     pub fn sendStreamData(self: *Connection, id: u64, data: []const u8, fin: bool) Error!void {
         const s = try self.sendStream(id);
         s.write(data, fin) catch |e| switch (e) {
@@ -281,13 +281,13 @@ pub const Connection = struct {
     ///
     /// Each sent range is recorded per packet (stream_sent) and retained in the
     /// SendStream until acked, so a lost packet is retransmitted (the ACK arm routes
-    /// lost pns back into SendStream.onLost). Loss is detected on ACK; a tail packet
-    /// with no later ACK to trigger detection needs the PTO timer, a follow-up.
+    /// lost pns back into SendStream.onLost). Loss is detected on ACK only; a tail
+    /// packet with no later ACK to trigger detection is not yet covered by a PTO timer.
     pub fn flushSend(self: *Connection, now: u64) Error!void {
         const space = Space.application;
         const st = &self.spaces[@intFromEnum(space)];
         if (st.send_keys == null) return; // no 1-RTT keys yet: nothing can be sent
-        // A conservative single-packet budget; one STREAM frame per packet for now.
+        // A conservative single-packet budget: one STREAM frame per packet.
         const packet_room = constants.MIN_INITIAL_DATAGRAM - 64;
         var it = self.send_streams.iterator();
         while (it.next()) |entry| {
@@ -364,7 +364,7 @@ pub const Connection = struct {
     }
 
     fn driveTls(self: *Connection, space: Space, now: u64) Error!void {
-        const server = if (self.tls) |*s| s else return; // client handshake send is a later stage
+        const server = if (self.tls) |*s| s else return; // only the server drives the handshake here
         const st = &self.spaces[@intFromEnum(space)];
         while (true) {
             const buf = st.crypto.readable();
@@ -387,7 +387,7 @@ pub const Connection = struct {
                     try self.sendCryptoFlight(flight_buf.items, outcome.server_hello_len, now);
                     continue;
                 },
-                .finished => st.crypto.advance(msg.len), // client Finished verify is a later stage
+                .finished => st.crypto.advance(msg.len), // the server does not verify a client Finished
                 else => return error.ProtocolViolation, // unexpected message at the server
             }
         }
@@ -522,8 +522,7 @@ pub const Connection = struct {
         // RFC 9000 12.4: only PADDING, PING, ACK, CRYPTO, and CONNECTION_CLOSE are
         // permitted in the Initial and Handshake spaces. STREAM and the other
         // 1-RTT frames in those spaces are a PROTOCOL_VIOLATION - the recv mirror of
-        // keeping STREAM out of Initial on the send side. This gate matters now that
-        // Stage 4 installs Handshake/Application recv keys, widening what decrypts.
+        // keeping STREAM out of Initial on the send side.
         if (!frameAllowedIn(space, f)) return error.ProtocolViolation;
 
         const st = &self.spaces[@intFromEnum(space)];
@@ -563,7 +562,7 @@ pub const Connection = struct {
 
     /// The send-side mirror of the recv gate: assert every frame we are about to
     /// seal is legal in `space` (so STREAM can never reach an Initial/Handshake
-    /// packet, the #64 P1, even through the shared buildPacket primitive). A debug
+    /// packet, even through the shared buildPacket primitive). A debug
     /// check - it decodes the payload, so it compiles out in release builds, where
     /// the single STREAM caller is already pinned to the Application space.
     fn assertFramesAllowedIn(space: Space, frames: []const u8) void {
@@ -1016,7 +1015,7 @@ test "flushSend is a no-op until the Application keys are installed" {
     const dcid = [_]u8{ 0x51, 0x52, 0x53, 0x54 };
     var conn = try Connection.init(gpa, .server, &dcid);
     defer conn.deinit();
-    // No app keys yet (no handshake): queued data cannot leave - the #64 P1 fix.
+    // No app keys yet (no handshake): queued data cannot leave.
     try conn.sendStreamData(1, "held", false);
     try conn.flushSend(1000);
     try testing.expectEqual(@as(usize, 0), conn.datagramsToSend().len);

--- a/src/core/quic/tls/finished.zig
+++ b/src/core/quic/tls/finished.zig
@@ -7,7 +7,7 @@
 const std = @import("std");
 const schedule = @import("schedule.zig");
 
-pub const LEN = schedule.SECRET_LEN; // 32
+pub const LEN = schedule.SECRET_LEN;
 
 /// The server's Finished verify_data over the transcript through CertificateVerify
 /// (RFC 8446 4.4.4), keyed by the server handshake traffic secret.

--- a/src/core/quic/tls/keyshare.zig
+++ b/src/core/quic/tls/keyshare.zig
@@ -8,8 +8,8 @@ const std = @import("std");
 
 const X25519 = std.crypto.dh.X25519;
 
-pub const PUBLIC_LEN = X25519.public_length; // 32
-pub const SHARED_LEN = X25519.shared_length; // 32
+pub const PUBLIC_LEN = X25519.public_length;
+pub const SHARED_LEN = X25519.shared_length;
 
 pub const KeyShare = struct {
     public_key: [PUBLIC_LEN]u8,

--- a/src/core/quic/tls/transcript.zig
+++ b/src/core/quic/tls/transcript.zig
@@ -8,7 +8,7 @@
 const std = @import("std");
 
 const Sha256 = std.crypto.hash.sha2.Sha256;
-pub const LEN = Sha256.digest_length; // 32
+pub const LEN = Sha256.digest_length;
 
 pub const Transcript = struct {
     hasher: Sha256 = Sha256.init(.{}),

--- a/src/core/tables.zig
+++ b/src/core/tables.zig
@@ -2,6 +2,10 @@
 //! (RFC 9110 Appendix B). A byte's class is a single array lookup - no branches
 //! in the hot scan loops.
 
+const HTAB = 0x09;
+const SP = 0x20;
+const DEL = 0x7F;
+
 /// tchar (RFC 9110 5.6.2): the set of characters allowed in a `token`, which is
 /// what field-names, methods and transfer-coding names are built from.
 ///   token = 1*tchar
@@ -25,10 +29,10 @@ pub const is_tchar: [256]bool = blk: {
 pub const is_field_vchar: [256]bool = blk: {
     var t = [_]bool{false} ** 256;
     var ch: usize = 0x21;
-    while (ch <= 0xFF) : (ch += 1) t[ch] = true; // VCHAR + obs-text (0x80-0xFF)
-    t[0x09] = true; // HTAB
-    t[0x20] = true; // SP
-    t[0x7F] = false; // DEL is not field-vchar
+    while (ch <= 0xFF) : (ch += 1) t[ch] = true; // obs-text runs to 0xFF
+    t[HTAB] = true;
+    t[SP] = true;
+    t[DEL] = false;
     break :blk t;
 };
 
@@ -49,7 +53,7 @@ pub const is_target_char: [256]bool = blk: {
     var t = [_]bool{false} ** 256;
     var ch: usize = 0x21;
     while (ch <= 0xFF) : (ch += 1) t[ch] = true;
-    t[0x7F] = false; // DEL
+    t[DEL] = false;
     t['"'] = false;
     break :blk t;
 };

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -769,7 +769,7 @@ fn borrowHeaders(seq: py.Object) ?BorrowedHeaders {
         }
         const name = c.PySequence_GetItem(item, 0);
         const value = c.PySequence_GetItem(item, 1);
-        py.decref(item); // the pair tuple itself is not needed past this point
+        py.decref(item);
         refs[i * 2] = name; // held (may be null; xdecref-safe) so the buffer survives
         refs[i * 2 + 1] = value;
         if (name == null or value == null) {
@@ -812,7 +812,7 @@ fn h2SplitAuthority(headers: []events.Header, out: *[]events.Header) []const u8 
     for (headers) |h| {
         if (asciiEqlIgnoreCase(h.name, "host") or asciiEqlIgnoreCase(h.name, ":authority")) {
             if (authority.len == 0) authority = h.value;
-            continue; // dropped from the regular list
+            continue;
         }
         headers[n] = h;
         n += 1;


### PR DESCRIPTION
Audit follow-up: removes inline comments that violate the project's "code should speak for itself" standard, and corrects `THREAT_MODEL.md` where it documented APIs that do not exist.

## Comments

Removes change/issue/reviewer narration (`#64 P1`, `Stage 4`, `Codex caught this`, `a follow-up` / `a later stage` / `for now`), replaces magic-byte label comments in `tables.zig` with named `HTAB`/`SP`/`DEL` constants, and drops a handful of inline comments that restate the adjacent line. Load-bearing RFC/invariant/why comments are kept untouched.

## THREAT_MODEL.md

The doc named APIs that do not exist:
- `conn.expect_bodyless()` -> bodyless framing is automatic (the connection remembers the request method); rewritten to match the real contract.
- A connection `reset()` -> removed (only `Stream.reset()` exists, which sends RST_STREAM).
- "Tune `Limits`" -> corrected; `Limits` is not configurable from Python on `main` (see #83).

`zig build test` and the full pytest suite pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
