### PR TITLE
Hoist duplicated ASCII, H2 field, and decimal helpers into shared leaves

### DIFF
--- a/src/core/ascii.zig
+++ b/src/core/ascii.zig
@@ -1,0 +1,60 @@
+//! Small ASCII helpers shared by the read and write paths: case-insensitive
+//! field-name comparison, OWS trimming, and overflow-safe decimal parsing. Kept
+//! as a leaf module (only `tables.zig` and `std`) so both directions fold case
+//! and frame lengths identically.
+
+const std = @import("std");
+const tables = @import("tables.zig");
+
+/// Case-insensitive ASCII compare, folding A-Z via the `to_lower` table. Used to
+/// match field-names and tokens, which HTTP treats case-insensitively.
+pub fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |x, y| if (tables.to_lower[x] != tables.to_lower[y]) return false;
+    return true;
+}
+
+/// Strip leading and trailing OWS (SP / HTAB) from a field-value (RFC 9110 5.6.3).
+pub fn trimOws(s: []const u8) []const u8 {
+    var start: usize = 0;
+    var end = s.len;
+    while (start < end and (s[start] == ' ' or s[start] == '\t')) start += 1;
+    while (end > start and (s[end - 1] == ' ' or s[end - 1] == '\t')) end -= 1;
+    return s[start..end];
+}
+
+/// Parse a base-10 unsigned integer, rejecting (returning null) an empty string,
+/// any non-digit byte, or a value that overflows `T`. The overflow-safe form used
+/// for Content-Length so a 30-nines length can never wrap to a small body size.
+pub fn parseDecimal(comptime T: type, s: []const u8) ?T {
+    if (s.len == 0) return null;
+    var n: T = 0;
+    for (s) |ch| {
+        if (ch < '0' or ch > '9') return null;
+        n = std.math.mul(T, n, 10) catch return null;
+        n = std.math.add(T, n, ch - '0') catch return null;
+    }
+    return n;
+}
+
+test "eqIgnoreCase folds case" {
+    try std.testing.expect(eqIgnoreCase("Connection", "connection"));
+    try std.testing.expect(eqIgnoreCase("HEAD", "head"));
+    try std.testing.expect(!eqIgnoreCase("close", "keep-alive"));
+    try std.testing.expect(!eqIgnoreCase("a", "ab"));
+}
+
+test "trimOws strips SP and HTAB" {
+    try std.testing.expectEqualStrings("x", trimOws(" \tx\t "));
+    try std.testing.expectEqualStrings("a b", trimOws("  a b  "));
+    try std.testing.expectEqualStrings("", trimOws(" \t \t"));
+    try std.testing.expectEqualStrings("y", trimOws("y"));
+}
+
+test "parseDecimal accepts digits and rejects bad/overflow" {
+    try std.testing.expectEqual(@as(?u64, 42), parseDecimal(u64, "42"));
+    try std.testing.expectEqual(@as(?u64, 0), parseDecimal(u64, "0"));
+    try std.testing.expectEqual(@as(?u64, null), parseDecimal(u64, ""));
+    try std.testing.expectEqual(@as(?u64, null), parseDecimal(u64, "12a"));
+    try std.testing.expectEqual(@as(?u64, null), parseDecimal(u64, "99999999999999999999999999999"));
+}

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -6,24 +6,12 @@
 //! caller.
 
 const std = @import("std");
-const tables = @import("../tables.zig");
+const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 
 const Header = events.Header;
-
-fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |x, y| if (tables.to_lower[x] != tables.to_lower[y]) return false;
-    return true;
-}
-
-fn trimOws(s: []const u8) []const u8 {
-    var start: usize = 0;
-    var end = s.len;
-    while (start < end and (s[start] == ' ' or s[start] == '\t')) start += 1;
-    while (end > start and (s[end - 1] == ' ' or s[end - 1] == '\t')) end -= 1;
-    return s[start..end];
-}
+const eqIgnoreCase = ascii.eqIgnoreCase;
+const trimOws = ascii.trimOws;
 
 /// True if any comma-separated token in `value` equals `token` (case-insensitive,
 /// surrounding whitespace ignored). Used for the `Connection` header's token list.

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -4,11 +4,12 @@
 //! conflicting values, we reject rather than guess.
 
 const std = @import("std");
-const tables = @import("../tables.zig");
+const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
+const eqIgnoreCase = ascii.eqIgnoreCase;
 
 pub const Framing = union(enum) {
     /// No body. The message is complete once headers end.
@@ -20,14 +21,6 @@ pub const Framing = union(enum) {
     /// Body runs until the connection closes (responses only; RFC 9112 6.3).
     until_close,
 };
-
-fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |x, y| {
-        if (tables.to_lower[x] != tables.to_lower[y]) return false;
-    }
-    return true;
-}
 
 /// Accumulates Transfer-Encoding codings across (possibly multiple) field-lines,
 /// which RFC 9112 6.1 requires to be treated as a single ordered comma list. The
@@ -60,15 +53,8 @@ const TransferEncoding = struct {
 };
 
 fn parseContentLength(value: []const u8) ParseError!u64 {
-    const v = std.mem.trim(u8, value, " \t");
-    if (v.len == 0) return error.InvalidFraming;
-    var n: u64 = 0;
-    for (v) |ch| {
-        if (ch < '0' or ch > '9') return error.InvalidFraming;
-        n = std.math.mul(u64, n, 10) catch return error.InvalidFraming;
-        n = std.math.add(u64, n, ch - '0') catch return error.InvalidFraming;
-    }
-    return n;
+    const v = ascii.trimOws(value);
+    return ascii.parseDecimal(u64, v) orelse error.InvalidFraming;
 }
 
 /// A response carries no body regardless of its headers when it answers a HEAD,

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -6,11 +6,14 @@
 
 const std = @import("std");
 const tables = @import("../tables.zig");
+const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 const framing = @import("framing.zig");
 
 const Header = events.Header;
 const responseIsBodyless = framing.responseIsBodyless;
+const eqIgnoreCase = ascii.eqIgnoreCase;
+const trimOws = ascii.trimOws;
 
 pub const WriteError = error{
     /// A head was sent while a message was still in progress.
@@ -172,7 +175,7 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
             has_te = true;
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
-            for (v) |ch| if (ch < '0' or ch > '9') return error.InvalidField; // digits only
+            if (v.len > 0 and ascii.parseDecimal(u64, v) == null) return error.InvalidField; // digits, no overflow
             if (content_length) |prev| {
                 if (!eqIgnoreCase(prev, v)) return error.InvalidField; // conflicting duplicate
             }
@@ -180,14 +183,6 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
         }
     }
     if (has_te and content_length != null) return error.InvalidField; // TE + CL
-}
-
-fn trimOws(s: []const u8) []const u8 {
-    var start: usize = 0;
-    var end = s.len;
-    while (start < end and (s[start] == ' ' or s[start] == '\t')) start += 1;
-    while (end > start and (s[end - 1] == ' ' or s[end - 1] == '\t')) end -= 1;
-    return s[start..end];
 }
 
 const State = enum {
@@ -363,12 +358,6 @@ pub const Writer = struct {
     }
 };
 
-fn eqIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |x, y| if (tables.to_lower[x] != tables.to_lower[y]) return false;
-    return true;
-}
-
 const BodyFraming = struct { state: State, length: u64 = 0 };
 
 /// Pick the body state from the headers the caller supplied: chunked if
@@ -389,12 +378,11 @@ fn bodyStateFor(hdrs: []const Header) BodyFraming {
     return .{ .state = .body_none };
 }
 
-/// Parse a digits-only Content-Length. validateFraming already rejected
-/// non-digit and conflicting values, so this only sees valid input.
+/// Parse a Content-Length. validateFraming already rejected non-digit,
+/// overflowing, and conflicting values, so this only sees an empty value (an
+/// empty Content-Length frames no body) or a parseable one.
 fn parseLength(v: []const u8) u64 {
-    var n: u64 = 0;
-    for (v) |ch| n = n * 10 + (ch - '0');
-    return n;
+    return ascii.parseDecimal(u64, v) orelse 0;
 }
 
 const t = std.testing;

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -18,7 +18,8 @@ const stream_mod = @import("stream.zig");
 const decoder_mod = @import("hpack/decoder.zig");
 const writer_mod = @import("writer.zig");
 const events = @import("../events.zig");
-const tables = @import("../tables.zig");
+const ascii = @import("../ascii.zig");
+const fields = @import("fields.zig");
 
 const Event = events.H2Event;
 const FrameType = constants.FrameType;
@@ -622,7 +623,7 @@ pub const Connection = struct {
 
         for (headers) |h| {
             if (h.name.len == 0) return error.Malformed;
-            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
+            if (!fields.validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (eql(h.name, ":method")) {
@@ -643,11 +644,11 @@ pub const Connection = struct {
                 continue;
             }
             seen_regular = true;
-            if (!isValidFieldName(h.name)) return error.Malformed; // uppercase / non-token byte
-            if (isConnectionSpecific(h.name)) return error.Malformed;
+            if (!fields.isValidFieldName(h.name)) return error.Malformed; // uppercase / non-token byte
+            if (fields.isConnectionSpecific(h.name)) return error.Malformed;
             if (eql(h.name, "te") and !eql(h.value, "trailers")) return error.Malformed;
             if (eql(h.name, "content-length")) {
-                const cl = parseU64(h.value) orelse return error.Malformed;
+                const cl = ascii.parseDecimal(u64, h.value) orelse return error.Malformed;
                 // A repeated content-length is malformed unless it agrees (RFC 9110).
                 if (content_length) |prev| {
                     if (prev != cl) return error.Malformed;
@@ -720,11 +721,11 @@ pub const Connection = struct {
                 continue;
             }
             seen_regular = true;
-            if (!isValidFieldName(h.name)) return error.Malformed;
-            if (!validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
-            if (isConnectionSpecific(h.name)) return error.Malformed;
+            if (!fields.isValidFieldName(h.name)) return error.Malformed;
+            if (!fields.validValue(h.value)) return error.Malformed; // CR/LF/NUL/control in value
+            if (fields.isConnectionSpecific(h.name)) return error.Malformed;
             if (eql(h.name, "content-length")) {
-                const cl = parseU64(h.value) orelse return error.Malformed;
+                const cl = ascii.parseDecimal(u64, h.value) orelse return error.Malformed;
                 if (content_length) |prev| {
                     if (prev != cl) return error.Malformed;
                 } else content_length = cl;
@@ -990,65 +991,16 @@ fn eql(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, a, b);
 }
 
-/// A valid HTTP/2 field name: a non-empty RFC 9110 token (so no SP, NUL, ':',
-/// or other separators) with no uppercase ASCII (RFC 9113 8.2.1). `:` is
-/// excluded here, so this is only applied to regular (non-pseudo) names.
-fn isValidFieldName(name: []const u8) bool {
-    if (name.len == 0) return false;
-    for (name) |ch| {
-        if (ch >= 'A' and ch <= 'Z') return false;
-        if (!tables.is_tchar[ch]) return false;
-    }
-    return true;
-}
-
-/// A legal field value (RFC 9113 8.2.1): no CR/LF/NUL or other control and no
-/// DEL (obs-text 0x80-0xFF and inner SP/HTAB are allowed), and no leading or
-/// trailing whitespace. The same rule the H2 write path enforces, so a value the
-/// read side accepts the write side can re-serialize without splitting or being
-/// silently re-trimmed by a peer.
-fn validValue(value: []const u8) bool {
-    for (value) |ch| {
-        if (!tables.is_field_vchar[ch]) return false;
-    }
-    if (value.len > 0) {
-        const first = value[0];
-        const last = value[value.len - 1];
-        if (first == ' ' or first == '\t' or last == ' ' or last == '\t') return false;
-    }
-    return true;
-}
-
 /// Trailers (RFC 9113 8.1): no pseudo-header may appear, and every name must be
 /// a valid lowercase field name. Connection-specific fields are likewise barred.
 fn validTrailers(headers: []const events.Header) bool {
     for (headers) |h| {
         if (h.name.len == 0 or h.name[0] == ':') return false;
-        if (!isValidFieldName(h.name)) return false;
-        if (!validValue(h.value)) return false;
-        if (isConnectionSpecific(h.name)) return false;
+        if (!fields.isValidFieldName(h.name)) return false;
+        if (!fields.validValue(h.value)) return false;
+        if (fields.isConnectionSpecific(h.name)) return false;
     }
     return true;
-}
-
-/// The connection-specific fields forbidden in HTTP/2 (RFC 9113 8.2.2).
-fn isConnectionSpecific(name: []const u8) bool {
-    const forbidden = [_][]const u8{ "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade" };
-    for (forbidden) |f| {
-        if (eql(name, f)) return true;
-    }
-    return false;
-}
-
-fn parseU64(s: []const u8) ?u64 {
-    if (s.len == 0) return null;
-    var v: u64 = 0;
-    for (s) |ch| {
-        if (ch < '0' or ch > '9') return null;
-        v = std.math.mul(u64, v, 10) catch return null;
-        v = std.math.add(u64, v, ch - '0') catch return null;
-    }
-    return v;
 }
 
 const testing = std.testing;

--- a/src/core/h2/fields.zig
+++ b/src/core/h2/fields.zig
@@ -1,0 +1,67 @@
+//! RFC 9113 8.2 field validation shared by the H2 read and write paths, so both
+//! directions agree on which field names and connection-specific fields are
+//! legal. The value-body check intentionally lives in each path: the read side
+//! (`validValue`) follows RFC 9110 field-vchar and allows inner HTAB, while the
+//! write side is stricter and rejects it (see h2/writer.zig validateValue).
+
+const std = @import("std");
+const tables = @import("../tables.zig");
+
+/// A valid HTTP/2 field name: a non-empty RFC 9110 token (so no SP, NUL, ':',
+/// or other separators) with no uppercase ASCII (RFC 9113 8.2.1). `:` is
+/// excluded here, so this is only applied to regular (non-pseudo) names.
+pub fn isValidFieldName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name) |ch| {
+        if (ch >= 'A' and ch <= 'Z') return false;
+        if (!tables.is_tchar[ch]) return false;
+    }
+    return true;
+}
+
+/// A legal field value (RFC 9113 8.2.1): no CR/LF/NUL or other control and no
+/// DEL (obs-text 0x80-0xFF and inner SP/HTAB are allowed), and no leading or
+/// trailing whitespace. This is the read-side rule; the write side is stricter.
+pub fn validValue(value: []const u8) bool {
+    for (value) |ch| {
+        if (!tables.is_field_vchar[ch]) return false;
+    }
+    if (value.len > 0) {
+        const first = value[0];
+        const last = value[value.len - 1];
+        if (first == ' ' or first == '\t' or last == ' ' or last == '\t') return false;
+    }
+    return true;
+}
+
+/// The connection-specific fields forbidden in HTTP/2 (RFC 9113 8.2.2).
+pub fn isConnectionSpecific(name: []const u8) bool {
+    const forbidden = [_][]const u8{ "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade" };
+    for (forbidden) |f| {
+        if (std.mem.eql(u8, name, f)) return true;
+    }
+    return false;
+}
+
+test "isValidFieldName accepts lowercase token, rejects uppercase and empty" {
+    try std.testing.expect(isValidFieldName("content-type"));
+    try std.testing.expect(!isValidFieldName("Content-Type"));
+    try std.testing.expect(!isValidFieldName(""));
+    try std.testing.expect(!isValidFieldName("bad name"));
+}
+
+test "validValue rejects leading space, control, and DEL" {
+    try std.testing.expect(validValue("text/plain"));
+    try std.testing.expect(!validValue(" x"));
+    try std.testing.expect(!validValue("x "));
+    try std.testing.expect(!validValue("a\rb"));
+    try std.testing.expect(!validValue("a\x00b"));
+    try std.testing.expect(!validValue("a\x7Fb"));
+}
+
+test "isConnectionSpecific detects each forbidden name" {
+    for ([_][]const u8{ "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade" }) |name| {
+        try std.testing.expect(isConnectionSpecific(name));
+    }
+    try std.testing.expect(!isConnectionSpecific("content-type"));
+}

--- a/src/core/h2/root.zig
+++ b/src/core/h2/root.zig
@@ -11,6 +11,7 @@ pub const hpack_decoder = @import("hpack/decoder.zig");
 pub const hpack_encoder = @import("hpack/encoder.zig");
 pub const settings = @import("settings.zig");
 pub const stream = @import("stream.zig");
+pub const fields = @import("fields.zig");
 pub const connection = @import("connection.zig");
 pub const writer = @import("writer.zig");
 
@@ -23,6 +24,7 @@ test {
     _ = hpack_encoder;
     _ = settings;
     _ = stream;
+    _ = fields;
     _ = connection;
     _ = writer;
 }

--- a/src/core/h2/writer.zig
+++ b/src/core/h2/writer.zig
@@ -9,6 +9,7 @@ const std = @import("std");
 const constants = @import("constants.zig");
 const frame_mod = @import("frame.zig");
 const encoder = @import("hpack/encoder.zig");
+const fields = @import("fields.zig");
 
 const Header = @import("../events.zig").Header;
 const FrameType = constants.FrameType;
@@ -234,23 +235,18 @@ pub const Writer = struct {
 /// non-token / uppercase name, control bytes in the value, or a connection-
 /// specific field.
 fn validateField(h: Header) WriteError!void {
-    if (h.name.len == 0) return error.InvalidField;
-    for (h.name) |ch| {
-        if (ch >= 'A' and ch <= 'Z') return error.InvalidField;
-        if (!is_tchar(ch)) return error.InvalidField;
-    }
+    if (!fields.isValidFieldName(h.name)) return error.InvalidField;
     try validateValue(h.value);
-    const forbidden = [_][]const u8{ "connection", "keep-alive", "proxy-connection", "transfer-encoding", "upgrade" };
-    for (forbidden) |f| {
-        if (std.mem.eql(u8, h.name, f)) return error.LocalProtocol;
-    }
+    if (fields.isConnectionSpecific(h.name)) return error.LocalProtocol;
     // TE may only carry "trailers" in HTTP/2 (RFC 9113 8.2.2).
     if (std.mem.eql(u8, h.name, "te") and !std.mem.eql(u8, h.value, "trailers")) return error.LocalProtocol;
 }
 
 /// A field value must contain no control bytes (CR/LF/NUL/DEL) and no leading or
 /// trailing whitespace (RFC 9113 8.2.1), so it can never inject a frame boundary,
-/// corrupt the decoded request line, or be silently re-trimmed by a peer.
+/// corrupt the decoded request line, or be silently re-trimmed by a peer. Stricter
+/// than the read side's `fields.validValue`: the write path rejects even an inner
+/// HTAB (`ch < 0x20`), so we never emit a value a stricter peer might re-trim.
 fn validateValue(value: []const u8) WriteError!void {
     for (value) |ch| {
         if (ch < 0x20 or ch == 0x7F) return error.InvalidField;
@@ -260,10 +256,6 @@ fn validateValue(value: []const u8) WriteError!void {
         const last = value[value.len - 1];
         if (first == ' ' or first == '\t' or last == ' ' or last == '\t') return error.InvalidField;
     }
-}
-
-fn is_tchar(ch: u8) bool {
-    return @import("../tables.zig").is_tchar[ch];
 }
 
 fn formatStatus(status: u16, buf: *[3]u8) ?[]const u8 {

--- a/src/core/root.zig
+++ b/src/core/root.zig
@@ -1,6 +1,7 @@
 //! Pure-Zig core: the sans-IO HTTP parser, independent of CPython.
 
 pub const tables = @import("tables.zig");
+pub const ascii = @import("ascii.zig");
 pub const errors = @import("errors.zig");
 pub const events = @import("events.zig");
 pub const scanner = @import("scanner.zig");
@@ -11,6 +12,7 @@ pub const h3 = @import("h3/root.zig");
 
 test {
     _ = tables;
+    _ = ascii;
     _ = errors;
     _ = events;
     _ = scanner;

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -792,15 +792,7 @@ fn borrowHeaders(seq: py.Object) ?BorrowedHeaders {
 
 // HTTP/2 send helpers -------------------------------------------------------
 
-fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |x, y| {
-        const lx = if (x >= 'A' and x <= 'Z') x + 32 else x;
-        const ly = if (y >= 'A' and y <= 'Z') y + 32 else y;
-        if (lx != ly) return false;
-    }
-    return true;
-}
+const asciiEqlIgnoreCase = core.ascii.eqIgnoreCase;
 
 // Build the HTTP/2 regular-header list and pull out :authority. For a request the
 // adapter derives :authority from a `host` (or `:authority`) field and drops it


### PR DESCRIPTION
Removes duplicated helpers that the audit surfaced, with zero behavior change on the security-critical paths.

- `eqIgnoreCase` / `trimOws` were copied across four core modules and the Python binding; the overflow-safe decimal parser was open-coded three times with inconsistent overflow handling.
- The H2 field-name and connection-specific (RFC 9113 8.2.2) checks were reimplemented on both the read and write paths - a smuggling-differential risk.

Adds `src/core/ascii.zig` (`eqIgnoreCase`, `trimOws`, `parseDecimal`) and `src/core/h2/fields.zig` (`isValidFieldName`, `validValue`, `isConnectionSpecific`), and routes every site through them. The read and write paths now share the H2 field-name and forbidden-list predicates, so they cannot drift; the error mappings (`RemoteProtocolError` vs `LocalProtocolError`) stay per-path.

The value-body check is deliberately left separate: the read side allows inner HTAB (RFC 9110 field-vchar) while the write side rejects it. Merging would change what the writer accepts, so only the name and forbidden-list predicates are shared.

Also hardens the H1 writer's `Content-Length` path: `validateFraming` now rejects an overflowing length up front via `parseDecimal`, removing a silent `u64` wraparound the old digit-only loop allowed.

`zig build test`, `zig build fuzz`, and the full pytest suite pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
