### PR TITLE
Expose the DoS Limits to the Python constructor

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -138,9 +138,17 @@ pub const Connection = struct {
     eof_seen: bool = false,
 
     pub fn init(gpa: std.mem.Allocator, role: Role) Connection {
+        return initWithLimits(gpa, role, .{});
+    }
+
+    /// Construct with explicit DoS limits. The HPACK decoder is sized from
+    /// `limits` here (before it is built), so an overridden header_table_size /
+    /// max_header_list_size takes effect; a post-init field set could not.
+    pub fn initWithLimits(gpa: std.mem.Allocator, role: Role, limits: Limits) Connection {
         var c = Connection{
             .gpa = gpa,
             .role = role,
+            .limits = limits,
             .hpack = undefined,
         };
         c.hpack = decoder_mod.Decoder.init(gpa, c.limits.header_table_size, c.limits.max_header_list_size);

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -10,6 +10,7 @@ const core = @import("core");
 const Reader = core.h1.reader.Reader;
 const Role = core.h1.reader.Role;
 const Writer = core.h1.writer.Writer;
+const H1Limits = core.h1.reader.Limits;
 const events = core.events;
 const events_obj = @import("events_obj.zig");
 const exceptions = @import("exceptions.zig");
@@ -17,6 +18,7 @@ const exceptions = @import("exceptions.zig");
 const H2Connection = core.h2.connection.Connection;
 const H2Role = core.h2.connection.Role;
 const H2Writer = core.h2.writer.Writer;
+const H2Limits = core.h2.connection.Limits;
 
 const QuicConnection = core.quic.connection.Connection;
 const QuicRole = core.quic.connection.Role;
@@ -471,13 +473,117 @@ var stream_spec = py.Spec{
     .slots = &stream_slots,
 };
 
-// Parse (role, protocol) from the constructor args. `default_protocol` is what a
-// missing `protocol` arg means - HTTP1 for the base Connection, but a subtype
-// fixes it (and the arg is rejected if it disagrees, so H2Connection(role, HTTP1)
-// can't lie). Returns false with a Python error set on bad input.
-fn parseArgs(args: ?*c.PyObject, kwds: ?*c.PyObject, role: *Role, protocol_out: *c_long, fixed: ?c_long) bool {
+// The DoS limits parsed from the constructor's `limits=` dict. One dict spans
+// both protocols' Limits structs: each takes the keys it knows, the other ignores
+// them, so a caller can pass one dict regardless of the protocol it builds.
+// `present` is false when no limits dict was given (the no-override fast path).
+const ParsedLimits = struct {
+    h1: H1Limits = .{},
+    h2: H2Limits = .{},
+    present: bool = false,
+};
+
+// The union of every key either Limits struct understands. A key outside this set
+// is a typo and raises ValueError. `max_buffer` appears in both structs and is set
+// in both; the rest are protocol-specific and ignored by the other protocol.
+const known_limit_keys = [_][]const u8{
+    // H1
+    "max_line",        "max_headers",     "max_header_bytes",    "max_trailers",
+    "max_trailer_bytes", "strict_crlf",
+    // shared
+    "max_buffer",
+    // H2
+    "max_concurrent_streams", "max_header_list_size", "header_table_size", "max_frame_size",
+    "max_field_block_bytes",  "max_continuation_frames", "max_streams", "max_stream_resets",
+};
+
+fn isKnownLimitKey(key: []const u8) bool {
+    for (known_limit_keys) |k| {
+        if (std.mem.eql(u8, k, key)) return true;
+    }
+    return false;
+}
+
+// Read an unsigned integer limit from `dict[name]` into `out` (only if present).
+// Returns false with a Python error set on a negative/overflowing/non-integer
+// value; a missing key keeps `out` untouched (the struct default).
+fn readU(comptime T: type, dict: ?*c.PyObject, name: [*c]const u8, out: *T) bool {
+    const val = c.PyDict_GetItemString(dict, name); // borrowed, null if absent
+    if (val == null) return true;
+    const n = c.PyLong_AsUnsignedLongLong(val);
+    if (n == @as(c_ulonglong, @bitCast(@as(c_longlong, -1))) and py.errOccurred()) return false;
+    if (n > std.math.maxInt(T)) {
+        _ = py.raiseValue("limits value out of range");
+        return false;
+    }
+    out.* = @intCast(n);
+    return true;
+}
+
+// Parse the `limits` dict into both Limits structs. Returns null (with a Python
+// error already set) on any bad key or value so the caller aborts construction.
+fn parseLimits(dict: ?*c.PyObject) ?ParsedLimits {
+    if (c.PyDict_Check(dict) == 0) {
+        _ = py.raiseType("limits must be a dict");
+        return null;
+    }
+    var parsed = ParsedLimits{ .present = true };
+
+    var pos: c.Py_ssize_t = 0;
+    var key: ?*c.PyObject = null;
+    var value: ?*c.PyObject = null;
+    while (c.PyDict_Next(dict, &pos, &key, &value) != 0) {
+        const ks = py.asUtf8(key) orelse {
+            _ = py.raiseType("limits keys must be strings");
+            return null;
+        };
+        if (!isKnownLimitKey(ks)) {
+            _ = py.raise(c.PyExc_ValueError, "unknown limits key");
+            return null;
+        }
+    }
+
+    // H1
+    if (!readU(usize, dict, "max_line", &parsed.h1.max_line)) return null;
+    if (!readU(usize, dict, "max_headers", &parsed.h1.max_headers)) return null;
+    if (!readU(usize, dict, "max_header_bytes", &parsed.h1.max_header_bytes)) return null;
+    if (!readU(usize, dict, "max_trailers", &parsed.h1.max_trailers)) return null;
+    if (!readU(usize, dict, "max_trailer_bytes", &parsed.h1.max_trailer_bytes)) return null;
+    {
+        const val = c.PyDict_GetItemString(dict, "strict_crlf");
+        if (val != null) {
+            const b = c.PyObject_IsTrue(val);
+            if (b < 0) return null;
+            parsed.h1.strict_crlf = b == 1;
+        }
+    }
+
+    // shared: set in both structs
+    if (!readU(usize, dict, "max_buffer", &parsed.h1.max_buffer)) return null;
+    parsed.h2.max_buffer = parsed.h1.max_buffer;
+
+    // H2
+    if (!readU(u32, dict, "max_concurrent_streams", &parsed.h2.max_concurrent_streams)) return null;
+    if (!readU(u32, dict, "max_header_list_size", &parsed.h2.max_header_list_size)) return null;
+    if (!readU(u32, dict, "header_table_size", &parsed.h2.header_table_size)) return null;
+    if (!readU(u32, dict, "max_frame_size", &parsed.h2.max_frame_size)) return null;
+    if (!readU(usize, dict, "max_field_block_bytes", &parsed.h2.max_field_block_bytes)) return null;
+    if (!readU(u32, dict, "max_continuation_frames", &parsed.h2.max_continuation_frames)) return null;
+    if (!readU(u64, dict, "max_streams", &parsed.h2.max_streams)) return null;
+    if (!readU(u64, dict, "max_stream_resets", &parsed.h2.max_stream_resets)) return null;
+
+    return parsed;
+}
+
+// Parse (role, protocol, limits) from the constructor args. `default_protocol` is
+// what a missing `protocol` arg means - HTTP1 for the base Connection, but a
+// subtype fixes it (and the arg is rejected if it disagrees, so
+// H2Connection(role, HTTP1) can't lie). `limits` is keyword-only. Returns false
+// with a Python error set on bad input.
+fn parseArgs(args: ?*c.PyObject, kwds: ?*c.PyObject, role: *Role, protocol_out: *c_long, limits_out: *ParsedLimits, fixed: ?c_long) bool {
     var role_val: c_long = 0;
     var protocol_val: c_long = fixed orelse HTTP1;
+    var limits_obj: ?*c.PyObject = null;
     const positional = if (kwds == null) c.PyTuple_Size(args) else -1;
     if (positional == 1 or positional == 2) {
         // The common positional forms skip PyArg_ParseTupleAndKeywords, which
@@ -491,9 +597,13 @@ fn parseArgs(args: ?*c.PyObject, kwds: ?*c.PyObject, role: *Role, protocol_out: 
     } else {
         // The kwlist parameter type differs across CPython versions (char** in 3.12,
         // const char* const* in 3.13+), so build a plain C-pointer array and ptrCast
-        // it to whatever the translated signature expects.
-        var kwlist = [_][*c]u8{ @constCast("role"), @constCast("protocol"), null };
-        if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l", @ptrCast(&kwlist), &role_val, &protocol_val) == 0) return false;
+        // it to whatever the translated signature expects. `$` makes `limits`
+        // keyword-only so it never disturbs the (role, protocol) positional forms.
+        var kwlist = [_][*c]u8{ @constCast("role"), @constCast("protocol"), @constCast("limits"), null };
+        if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l$O", @ptrCast(&kwlist), &role_val, &protocol_val, &limits_obj) == 0) return false;
+    }
+    if (limits_obj != null and !py.isNone(limits_obj)) {
+        limits_out.* = parseLimits(limits_obj) orelse return false;
     }
     role.* = switch (role_val) {
         SERVER => .server,
@@ -523,14 +633,14 @@ fn parseArgs(args: ?*c.PyObject, kwds: ?*c.PyObject, role: *Role, protocol_out: 
 
 // Allocate an instance of `tp` and build the engine for `protocol_val`. Shared by
 // the concrete subtypes' tp_new.
-fn allocAndBuild(tp: ?*c.PyTypeObject, role: Role, protocol_val: c_long) py.Object {
+fn allocAndBuild(tp: ?*c.PyTypeObject, role: Role, protocol_val: c_long, limits: ParsedLimits) py.Object {
     const alloc = tp.?.tp_alloc.?;
     const obj = alloc(tp, 0);
     if (obj == null) return null;
     const self: *ConnectionObject = @ptrCast(obj);
     self.engine = null;
     const engine: *Engine = @ptrCast(@alignCast(&self.engine_storage));
-    if (!buildEngine(engine, role, protocol_val)) {
+    if (!buildEngine(engine, role, protocol_val, limits)) {
         py.decref(obj);
         return null;
     }
@@ -546,42 +656,51 @@ fn allocAndBuild(tp: ?*c.PyTypeObject, role: Role, protocol_val: c_long) py.Obje
 fn new_base(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
     var role: Role = .server;
     var protocol_val: c_long = HTTP1;
-    if (!parseArgs(args, kwds, &role, &protocol_val, null)) return null;
+    var limits = ParsedLimits{};
+    if (!parseArgs(args, kwds, &role, &protocol_val, &limits, null)) return null;
     if (@intFromPtr(tp) == @intFromPtr(connection_type)) {
         const sub: ?*c.PyTypeObject = @ptrCast(switch (protocol_val) {
             HTTP2 => h2_connection_type,
             HTTP3 => h3_connection_type,
             else => h1_connection_type,
         });
-        return allocAndBuild(sub, role, protocol_val);
+        return allocAndBuild(sub, role, protocol_val, limits);
     }
-    return allocAndBuild(tp, role, protocol_val);
+    return allocAndBuild(tp, role, protocol_val, limits);
 }
 
 fn new_h1(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
     var role: Role = .server;
     var protocol_val: c_long = HTTP1;
-    if (!parseArgs(args, kwds, &role, &protocol_val, HTTP1)) return null;
-    return allocAndBuild(tp, role, HTTP1);
+    var limits = ParsedLimits{};
+    if (!parseArgs(args, kwds, &role, &protocol_val, &limits, HTTP1)) return null;
+    return allocAndBuild(tp, role, HTTP1, limits);
 }
 
 fn new_h2(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
     var role: Role = .server;
     var protocol_val: c_long = HTTP2;
-    if (!parseArgs(args, kwds, &role, &protocol_val, HTTP2)) return null;
-    return allocAndBuild(tp, role, HTTP2);
+    var limits = ParsedLimits{};
+    if (!parseArgs(args, kwds, &role, &protocol_val, &limits, HTTP2)) return null;
+    return allocAndBuild(tp, role, HTTP2, limits);
 }
 
 fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
     var role: Role = .server;
     var protocol_val: c_long = HTTP3;
-    if (!parseArgs(args, kwds, &role, &protocol_val, HTTP3)) return null;
-    return allocAndBuild(tp, role, HTTP3);
+    var limits = ParsedLimits{};
+    if (!parseArgs(args, kwds, &role, &protocol_val, &limits, HTTP3)) return null;
+    return allocAndBuild(tp, role, HTTP3, limits);
 }
 
-fn buildEngine(engine: *Engine, role: Role, protocol_val: c_long) bool {
+fn buildEngine(engine: *Engine, role: Role, protocol_val: c_long, limits: ParsedLimits) bool {
     if (protocol_val == HTTP3) {
-        // The QUIC + HTTP/3 engine is built lazily on the first datagram.
+        // The QUIC + HTTP/3 engine is built lazily and owns its own limits path,
+        // so an override here has nowhere to land - refuse it rather than lie.
+        if (limits.present) {
+            _ = py.raiseValue("limits are not configurable for HTTP/3 yet");
+            return false;
+        }
         engine.* = .{ .h3 = .{} };
         return true;
     }
@@ -591,7 +710,11 @@ fn buildEngine(engine: *Engine, role: Role, protocol_val: c_long) bool {
             _ = c.PyErr_NoMemory();
             return false;
         };
-        conn.* = H2Connection.init(gpa, if (role == .server) H2Role.server else H2Role.client);
+        const h2_role = if (role == .server) H2Role.server else H2Role.client;
+        conn.* = if (limits.present)
+            H2Connection.initWithLimits(gpa, h2_role, limits.h2)
+        else
+            H2Connection.init(gpa, h2_role);
         const writer = gpa.create(H2Writer) catch {
             conn.deinit();
             gpa.destroy(conn);
@@ -603,7 +726,9 @@ fn buildEngine(engine: *Engine, role: Role, protocol_val: c_long) bool {
         return true;
     }
 
-    engine.* = .{ .h1 = .{ .reader = Reader.init(gpa, role) } };
+    var reader = Reader.init(gpa, role);
+    if (limits.present) reader.limits = limits.h1;
+    engine.* = .{ .h1 = .{ .reader = reader } };
     return true;
 }
 

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -116,6 +116,16 @@ pub fn fromBytes(s: []const u8) Object {
     return c.PyBytes_FromStringAndSize(s.ptr, @intCast(s.len));
 }
 
+/// Borrow the UTF-8 bytes behind a Python `str`. Returns null (with a Python
+/// error set) if `o` is not a str. The buffer is owned by the str and valid for
+/// its lifetime.
+pub fn asUtf8(o: Object) ?[]const u8 {
+    var len: ssize = undefined;
+    const ptr = c.PyUnicode_AsUTF8AndSize(o, &len);
+    if (ptr == null) return null;
+    return ptr[0..@intCast(len)];
+}
+
 /// Borrow the buffer behind a Python `bytes`/`bytearray`/buffer-protocol object.
 /// Returns null and sets a TypeError if `o` is not bytes-like.
 pub fn asBytes(o: Object) ?[]const u8 {

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import pytest
+
+import zttp
+from tests.conftest import drain_all
+
+PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+GET_BLOCK = bytes([0x82, 0x86, 0x84, 0x41, 0x0F]) + b"www.example.com"
+
+
+def h2_frame(ftype: int, flags: int, stream_id: int, payload: bytes) -> bytes:
+    header = len(payload).to_bytes(3, "big") + bytes([ftype, flags]) + stream_id.to_bytes(4, "big")
+    return header + payload
+
+
+def test_limits_is_public() -> None:
+    assert "Limits" in zttp.__all__
+    limits: zttp.Limits = {"max_headers": 1}
+    assert limits["max_headers"] == 1
+
+
+def test_max_headers_override_reaches_core() -> None:
+    conn = zttp.Connection(zttp.SERVER, zttp.HTTP1, limits={"max_headers": 1})
+    conn.receive_data(b"GET / HTTP/1.1\r\nA: 1\r\nB: 2\r\n\r\n")
+    with pytest.raises(zttp.RemoteProtocolError):
+        drain_all(conn)
+
+
+def test_max_buffer_override_caps_input() -> None:
+    conn = zttp.Connection(zttp.SERVER, limits={"max_buffer": 16})
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+
+
+def test_strict_crlf_override_allows_bare_lf() -> None:
+    conn = zttp.Connection(zttp.SERVER, limits={"strict_crlf": False})
+    conn.receive_data(b"GET / HTTP/1.1\nHost: x\n\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+
+
+def test_default_limits_parse_normally() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"GET / HTTP/1.1\r\nA: 1\r\nB: 2\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+
+
+def test_unknown_key_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        zttp.Connection(zttp.SERVER, limits={"nonsense": 1})
+
+
+def test_negative_value_raises() -> None:
+    with pytest.raises((ValueError, OverflowError)):
+        zttp.Connection(zttp.SERVER, limits={"max_headers": -1})
+
+
+def test_non_dict_limits_raises_type_error() -> None:
+    with pytest.raises(TypeError):
+        zttp.Connection(zttp.SERVER, limits=5)  # type: ignore[arg-type]
+
+
+def test_h2_only_key_ignored_on_h1_connection() -> None:
+    # An H2-only key on an H1 connection is ignored, not an error, so one dict
+    # works regardless of protocol.
+    conn = zttp.Connection(zttp.SERVER, zttp.HTTP1, limits={"max_concurrent_streams": 1})
+    conn.receive_data(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+
+
+def test_h2_max_concurrent_streams_override_refuses_extra_stream() -> None:
+    conn = zttp.Connection(zttp.SERVER, zttp.HTTP2, limits={"max_concurrent_streams": 1})
+    conn.receive_data(
+        PREFACE
+        + h2_frame(0x04, 0, 0, b"")
+        + h2_frame(0x01, 0x04, 1, GET_BLOCK)
+        + h2_frame(0x01, 0x04, 3, GET_BLOCK)
+    )
+    resets = []
+    while True:
+        ev = conn.next_event()
+        if ev is zttp.NEED_DATA:
+            break
+        if isinstance(ev, zttp.RstStream):
+            resets.append(ev)
+    assert [(r.stream_id, r.error_code) for r in resets] == [(3, 7)]
+
+
+def test_h2_normal_exchange_with_limits_dict() -> None:
+    conn = zttp.Connection(zttp.SERVER, zttp.HTTP2, limits={"max_header_list_size": 32 * 1024})
+    conn.receive_data(PREFACE + h2_frame(0x04, 0, 0, b"") + h2_frame(0x01, 0x05, 1, GET_BLOCK))
+    events = []
+    while True:
+        ev = conn.next_event()
+        if ev is zttp.NEED_DATA:
+            break
+        events.append(ev)
+    assert any(isinstance(e, zttp.Request) for e in events)
+
+
+def test_h3_limits_rejected() -> None:
+    with pytest.raises(ValueError):
+        zttp.Connection(zttp.SERVER, zttp.HTTP3, limits={"max_buffer": 1024})

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -71,10 +71,7 @@ def test_h2_only_key_ignored_on_h1_connection() -> None:
 def test_h2_max_concurrent_streams_override_refuses_extra_stream() -> None:
     conn = zttp.Connection(zttp.SERVER, zttp.HTTP2, limits={"max_concurrent_streams": 1})
     conn.receive_data(
-        PREFACE
-        + h2_frame(0x04, 0, 0, b"")
-        + h2_frame(0x01, 0x04, 1, GET_BLOCK)
-        + h2_frame(0x01, 0x04, 3, GET_BLOCK)
+        PREFACE + h2_frame(0x04, 0, 0, b"") + h2_frame(0x01, 0x04, 1, GET_BLOCK) + h2_frame(0x01, 0x04, 3, GET_BLOCK)
     )
     resets = []
     while True:

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TypedDict
+
 from zttp._zttp import (
     CLIENT,
     CONNECTION_CLOSED,
@@ -28,6 +30,33 @@ from zttp._zttp import (
     Stream,
     WindowUpdate,
 )
+
+
+class Limits(TypedDict, total=False):
+    """Overrides for a Connection's DoS bounds, passed as `limits=`.
+
+    One dict spans both protocols: keys not relevant to the constructed protocol
+    are ignored, so the same dict works regardless of protocol. An unknown key
+    raises ValueError. Omitted keys keep the secure default. `max_buffer` applies
+    to both protocols.
+    """
+
+    max_line: int
+    max_headers: int
+    max_header_bytes: int
+    max_trailers: int
+    max_trailer_bytes: int
+    strict_crlf: bool
+    max_buffer: int
+    max_concurrent_streams: int
+    max_header_list_size: int
+    header_table_size: int
+    max_frame_size: int
+    max_field_block_bytes: int
+    max_continuation_frames: int
+    max_streams: int
+    max_stream_resets: int
+
 
 Event = (
     Request
@@ -60,6 +89,7 @@ __all__ = [
     "H1Connection",
     "H2Connection",
     "H3Connection",
+    "Limits",
     "LocalProtocolError",
     "NeedData",
     "Ping",

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -4,12 +4,42 @@ from __future__ import annotations
 
 from typing import Final, Literal, overload
 
+from typing_extensions import TypedDict
+
 SERVER: Final[int]
 CLIENT: Final[int]
 # Literal-typed so Connection(role, HTTP2) selects the H2Connection __new__ overload.
 HTTP1: Final = 1
 HTTP2: Final = 2
 HTTP3: Final = 3
+
+class Limits(TypedDict, total=False):
+    """Overrides for the DoS bounds, passed to a Connection as `limits=`.
+
+    One dict spans both protocols: keys not relevant to the constructed protocol
+    are ignored, so the same dict works regardless of protocol. An unknown key
+    raises ValueError. Omitted keys keep the secure default. `max_buffer` applies
+    to both protocols.
+    """
+
+    # HTTP/1.1
+    max_line: int
+    max_headers: int
+    max_header_bytes: int
+    max_trailers: int
+    max_trailer_bytes: int
+    strict_crlf: bool
+    # Both protocols
+    max_buffer: int
+    # HTTP/2
+    max_concurrent_streams: int
+    max_header_list_size: int
+    header_table_size: int
+    max_frame_size: int
+    max_field_block_bytes: int
+    max_continuation_frames: int
+    max_streams: int
+    max_stream_resets: int
 
 class Request:
     method: bytes
@@ -92,16 +122,17 @@ class Connection:
     # send surface differs, so each is its own type rather than methods that raise
     # at runtime.
     @overload
-    def __new__(cls, role: int, protocol: Literal[3]) -> H3Connection: ...
+    def __new__(cls, role: int, protocol: Literal[3], *, limits: Limits | None = ...) -> H3Connection: ...
     @overload
-    def __new__(cls, role: int, protocol: Literal[2]) -> H2Connection: ...
+    def __new__(cls, role: int, protocol: Literal[2], *, limits: Limits | None = ...) -> H2Connection: ...
     @overload
-    def __new__(cls, role: int, protocol: Literal[1] = ...) -> H1Connection: ...
+    def __new__(cls, role: int, protocol: Literal[1] = ..., *, limits: Limits | None = ...) -> H1Connection: ...
     def receive_data(self, data: bytes) -> None: ...
     def next_event(self) -> Event: ...
     def data_to_send(self) -> bytes: ...
 
 class H1Connection(Connection):
+    def __new__(cls, role: int, protocol: Literal[1] = ..., *, limits: Limits | None = ...) -> H1Connection: ...
     def start_next_cycle(self) -> None: ...
     def send_request(
         self, method: bytes, target: bytes, version: bytes, headers: list[tuple[bytes, bytes]]
@@ -114,6 +145,7 @@ class H1Connection(Connection):
     def upgrade(self) -> bytes | None: ...
 
 class H2Connection(Connection):
+    def __new__(cls, role: int, protocol: Literal[2] = ..., *, limits: Limits | None = ...) -> H2Connection: ...
     def send_request(
         self, method: bytes, target: bytes, version: bytes, headers: list[tuple[bytes, bytes]]
     ) -> Stream: ...
@@ -121,4 +153,5 @@ class H2Connection(Connection):
 
 class H3Connection(Connection):
     # Server read path only: fed by UDP datagrams rather than a byte stream.
+    def __new__(cls, role: int, protocol: Literal[3] = ..., *, limits: Limits | None = ...) -> H3Connection: ...
     def receive_datagram(self, datagram: bytes, /) -> None: ...


### PR DESCRIPTION
The per-connection DoS bounds (`max_headers`, `max_buffer`, the H2 stream/frame caps, `strict_crlf`, ...) were enforced in the core but fixed at their defaults from Python. This accepts a `limits=` dict on the `Connection` constructor so a deployment can tighten or loosen them.

```python
conn = zttp.Connection(zttp.SERVER, zttp.HTTP1, limits={"max_buffer": 16 * 1024 * 1024, "max_headers": 200})
```

One `Limits` `TypedDict` spans both protocols: each protocol reads the keys it understands and ignores the rest, so a single dict works regardless of the protocol built. Unknown keys raise `ValueError`; negative or non-integer values raise. HTTP/3 refuses a `limits` dict for now (the QUIC/H3 engine owns its own limits path). The H2 path constructs via `initWithLimits` so an overridden `header_table_size` sizes the HPACK decoder correctly.

New tests prove an override actually reaches the core (e.g. `max_headers=1` rejects a 2-header request; `max_concurrent_streams=1` drives an RST_STREAM on the second H2 stream). `zig build test`, pytest (178), mypy, and ruff all pass at 100% coverage.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
