### PR TITLE
Emit GOAWAY on a connection-fatal HTTP/2 error

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -66,6 +66,19 @@ pub const H2Error = error{
     EnhanceYourCalm,
 };
 
+/// The RFC 9113 7 error code a connection-fatal H2Error maps to, for the GOAWAY
+/// the integrator sends before closing. MessageTooLong is a resource-limit
+/// breach, so it reports ENHANCE_YOUR_CALM like the other flood defenses.
+pub fn errorCode(e: H2Error) constants.ErrorCode {
+    return switch (e) {
+        error.ProtocolError => .protocol_error,
+        error.FrameSizeError => .frame_size_error,
+        error.CompressionError => .compression_error,
+        error.FlowControlError => .flow_control_error,
+        error.EnhanceYourCalm, error.MessageTooLong => .enhance_your_calm,
+    };
+}
+
 const Phase = enum {
     /// Server: waiting for the 24-byte client preface. Client: about to send its
     /// preface (no inbound preface to await).
@@ -141,6 +154,10 @@ pub const Connection = struct {
     upgrade_headers: std.ArrayList(events.Header) = .empty,
 
     failed_with: H2Error = error.ProtocolError,
+    /// Set to the GOAWAY error code on the FIRST transition to .failed, so the
+    /// integrator can serialize one GOAWAY before closing (RFC 9113 5.4.1).
+    /// Consumed by takeGoawayOwed; re-raising the latched error does not re-set it.
+    goaway_owed: ?constants.ErrorCode = null,
     eof_seen: bool = false,
 
     pub fn init(gpa: std.mem.Allocator, role: Role) Connection {
@@ -183,14 +200,25 @@ pub const Connection = struct {
     }
 
     /// Produce the next event, or `.need_data`. A connection error poisons the
-    /// engine: it is latched and re-raised on every later call (as H1 does).
+    /// engine: it is latched and re-raised on every later call (as H1 does). The
+    /// first failure records the GOAWAY code in goaway_owed (RFC 9113 5.4.1); the
+    /// integrator drains it via takeGoawayOwed and serializes one GOAWAY.
     pub fn nextEvent(self: *Connection) H2Error!Event {
         if (self.phase == .failed) return self.failed_with;
         return self.dispatch() catch |e| {
             self.phase = .failed;
             self.failed_with = e;
+            self.goaway_owed = errorCode(e);
             return e;
         };
+    }
+
+    /// The GOAWAY error code owed after a connection-fatal error, or null. Returns
+    /// it at most once so the integrator sends exactly one GOAWAY.
+    pub fn takeGoawayOwed(self: *Connection) ?constants.ErrorCode {
+        const owed = self.goaway_owed;
+        self.goaway_owed = null;
+        return owed;
     }
 
     fn dispatch(self: *Connection) H2Error!Event {
@@ -1326,6 +1354,31 @@ test "an even-numbered request stream id is a connection error" {
     try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 2, &GET_BLOCK);
     try handshook(&c, hdr.items);
     try testing.expectError(error.ProtocolError, c.nextEvent());
+}
+
+test "a connection-fatal error owes one GOAWAY with the mapped code" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 2, &GET_BLOCK);
+    try handshook(&c, hdr.items);
+    try testing.expectError(error.ProtocolError, c.nextEvent());
+    // The owed GOAWAY carries PROTOCOL_ERROR and is reported exactly once.
+    try testing.expectEqual(@as(?ErrorCode, .protocol_error), c.takeGoawayOwed());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+    // Re-raising the latched error does not re-arm a GOAWAY.
+    try testing.expectError(error.ProtocolError, c.nextEvent());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+}
+
+test "errorCode maps each H2Error to its RFC 9113 code" {
+    try testing.expectEqual(ErrorCode.protocol_error, errorCode(error.ProtocolError));
+    try testing.expectEqual(ErrorCode.frame_size_error, errorCode(error.FrameSizeError));
+    try testing.expectEqual(ErrorCode.compression_error, errorCode(error.CompressionError));
+    try testing.expectEqual(ErrorCode.flow_control_error, errorCode(error.FlowControlError));
+    try testing.expectEqual(ErrorCode.enhance_your_calm, errorCode(error.EnhanceYourCalm));
+    try testing.expectEqual(ErrorCode.enhance_your_calm, errorCode(error.MessageTooLong));
 }
 
 test "a field name with a space byte is malformed" {

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -186,17 +186,29 @@ pub const Connection = struct {
         self.upgrade_headers.deinit(self.gpa);
     }
 
-    /// Append received bytes (empty slice signals EOF). Bounded by max_buffer.
+    /// Append received bytes (empty slice signals EOF). Bounded by max_buffer; a
+    /// breach is connection-fatal and poisons the engine (arming a GOAWAY) just as
+    /// a parse error does, so the integrator sends one GOAWAY and stops.
     pub fn feed(self: *Connection, data: []const u8) H2Error!void {
+        if (self.phase == .failed) return self.failed_with;
         if (data.len == 0) {
             self.eof_seen = true;
             return;
         }
         if (self.limits.max_buffer != 0) {
             const unconsumed = self.buf.items.len - self.consumed;
-            if (unconsumed + data.len > self.limits.max_buffer) return error.MessageTooLong;
+            if (unconsumed + data.len > self.limits.max_buffer) return self.fail(error.MessageTooLong);
         }
-        self.buf.appendSlice(self.gpa, data) catch return error.MessageTooLong;
+        self.buf.appendSlice(self.gpa, data) catch return self.fail(error.MessageTooLong);
+    }
+
+    /// Poison the connection with `e` and arm the owed GOAWAY (RFC 9113 5.4.1).
+    /// The single transition into `.failed`, used by both feed and nextEvent.
+    fn fail(self: *Connection, e: H2Error) H2Error {
+        self.phase = .failed;
+        self.failed_with = e;
+        self.goaway_owed = errorCode(e);
+        return e;
     }
 
     /// Produce the next event, or `.need_data`. A connection error poisons the
@@ -205,12 +217,7 @@ pub const Connection = struct {
     /// integrator drains it via takeGoawayOwed and serializes one GOAWAY.
     pub fn nextEvent(self: *Connection) H2Error!Event {
         if (self.phase == .failed) return self.failed_with;
-        return self.dispatch() catch |e| {
-            self.phase = .failed;
-            self.failed_with = e;
-            self.goaway_owed = errorCode(e);
-            return e;
-        };
+        return self.dispatch() catch |e| self.fail(e);
     }
 
     /// The GOAWAY error code owed after a connection-fatal error, or null. Returns
@@ -1369,6 +1376,19 @@ test "a connection-fatal error owes one GOAWAY with the mapped code" {
     try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
     // Re-raising the latched error does not re-arm a GOAWAY.
     try testing.expectError(error.ProtocolError, c.nextEvent());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+}
+
+test "a fatal feed (max_buffer breach) poisons the connection and owes a GOAWAY" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_buffer = 8;
+    try testing.expectError(error.MessageTooLong, c.feed("123456789")); // 9 > 8
+    // The breach owes ENHANCE_YOUR_CALM and poisons the connection.
+    try testing.expectEqual(@as(?ErrorCode, .enhance_your_calm), c.takeGoawayOwed());
+    try testing.expectError(error.MessageTooLong, c.nextEvent()); // latched
+    // A later feed re-raises the latched error without re-arming a GOAWAY.
+    try testing.expectError(error.MessageTooLong, c.feed("more"));
     try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
 }
 

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1029,7 +1029,10 @@ fn receive_data(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Objec
     const engine = self.engine orelse return py.raiseRuntime("connection is closed");
     switch (engine.*) {
         .h2 => |*e| {
-            e.conn.feed(bytes) catch |err| return exceptions.raiseH2(err);
+            e.conn.feed(bytes) catch |err| {
+                e.emitGoawayIfOwed(); // a fatal feed (e.g. max_buffer flood) still owes a GOAWAY
+                return exceptions.raiseH2(err);
+            };
             return py.none();
         },
         .h1 => |*e| return e.receiveData(bytes, arg),

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -303,6 +303,19 @@ const H2Engine = struct {
         if (ev == .window_update or ev == .settings) try self.conn.flushSendable(self.writer);
     }
 
+    /// Serialize the GOAWAY owed after a connection-fatal error (RFC 9113 5.4.1),
+    /// so data_to_send carries it before the integrator closes. Best-effort: if
+    /// the writer itself OOMs there is nothing useful to do but close.
+    fn emitGoawayIfOwed(self: *H2Engine) void {
+        if (self.conn.takeGoawayOwed()) |code| {
+            if (!self.handshake_sent) {
+                self.writer.sendPreface(&.{}) catch return;
+                self.handshake_sent = true;
+            }
+            self.writer.sendGoaway(self.conn.lastPeerStreamId(), code, &.{}) catch {};
+        }
+    }
+
     fn deinit(self: *H2Engine) void {
         self.conn.deinit();
         gpa.destroy(self.conn);
@@ -1045,7 +1058,10 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
     switch (engine.*) {
         .h3 => |*e| return e.nextEvent(),
         .h2 => |*e| {
-            const ev = e.conn.nextEvent() catch |err| return exceptions.raiseH2(err);
+            const ev = e.conn.nextEvent() catch |err| {
+                e.emitGoawayIfOwed(); // queue one GOAWAY for the next data_to_send
+                return exceptions.raiseH2(err);
+            };
             e.autoRespond(ev) catch |err| return h2RaiseWrite(err);
             return events_obj.fromH2Event(ev);
         },

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -138,6 +138,29 @@ def test_bad_preface_raises() -> None:
         conn.next_event()
 
 
+def test_connection_fatal_error_emits_goaway() -> None:
+    # An even-numbered request stream id is a connection PROTOCOL_ERROR; the server
+    # must send a GOAWAY before closing (RFC 9113 5.4.1).
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 2, GET_BLOCK))
+    with pytest.raises(zttp.RemoteProtocolError):
+        list(drain_h2(conn))
+    goaways = [f for f in _frames(conn.data_to_send()) if f[0] == 0x07]
+    assert len(goaways) == 1
+    error_code = int.from_bytes(goaways[0][3][4:8], "big")
+    assert error_code == 0x01  # PROTOCOL_ERROR
+
+
+def test_goaway_is_emitted_only_once() -> None:
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 2, GET_BLOCK))
+    with pytest.raises(zttp.RemoteProtocolError):
+        list(drain_h2(conn))
+    conn.data_to_send()  # drains the GOAWAY
+    # Re-raising the latched error must not queue another GOAWAY.
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    assert [f for f in _frames(conn.data_to_send()) if f[0] == 0x07] == []
+
+
 def test_partial_feed_resumes() -> None:
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
     data = PREFACE + frame(0x04, 0, 0, b"") + frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK)


### PR DESCRIPTION
Fixes #48.

`nextEvent` latched `.failed` and re-raised the error but never sent a GOAWAY - the doc comment on `H2Error` even claimed "the GOAWAY it emits before poisoning", which didn't exist. A zttp server closed a connection-fatally-broken connection without telling the peer why (RFC 9113 5.4.1 requires a GOAWAY with the error code before closing).

### Fix
- **Core**: `errorCode(H2Error) -> ErrorCode` maps each fatal error to its RFC 9113 §7 code. `nextEvent` records the owed code in `goaway_owed` on the *first* transition to `.failed`; `takeGoawayOwed()` hands it back at most once.
- **Binding**: when `next_event` catches the fatal error, it serializes one GOAWAY (carrying `lastPeerStreamId`) into the writer buffer before raising, so the next `data_to_send()` carries it.

The GOAWAY rides *after* the server's own SETTINGS preface (§3.4 ordering, composing with the earlier preface-ordering fix) and is emitted **exactly once** even as the latched error re-raises on later calls. `MessageTooLong` (a buffer/limit breach) reports `ENHANCE_YOUR_CALM`, matching the other resource-limit defenses.

### Tests
Core: the owed code + once-only semantics, and the full `errorCode` mapping. Python: a fatal error (even-numbered stream id) emits one GOAWAY with `PROTOCOL_ERROR`, and re-raising does not queue a second. Verified the Python test fails without the emission.

`zig build test` + `zig build fuzz`, 200 pytest, mypy, ruff (check + format) all green.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
