### PR TITLE
Advertise the enforced SETTINGS in the H2 handshake

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -228,6 +228,20 @@ pub const Connection = struct {
         return owed;
     }
 
+    /// The (id, value) SETTINGS to advertise in our connection preface (RFC 9113
+    /// 6.5), built from `limits` so what we announce is exactly what we enforce.
+    /// MAX_CONCURRENT_STREAMS is the load-bearing one: the RFC default is unlimited,
+    /// so without it a peer opens more streams than we accept and gets spurious
+    /// REFUSED_STREAM resets. Fills `buf` and returns the populated prefix.
+    pub fn localSettingsParams(self: *const Connection, buf: *[4][2]u32) []const [2]u32 {
+        const ids = constants.SettingId;
+        buf[0] = .{ @intFromEnum(ids.max_concurrent_streams), self.limits.max_concurrent_streams };
+        buf[1] = .{ @intFromEnum(ids.max_header_list_size), self.limits.max_header_list_size };
+        buf[2] = .{ @intFromEnum(ids.header_table_size), self.limits.header_table_size };
+        buf[3] = .{ @intFromEnum(ids.max_frame_size), self.limits.max_frame_size };
+        return buf[0..4];
+    }
+
     fn dispatch(self: *Connection) H2Error!Event {
         if (self.pending_len > 0) return self.popPending();
 
@@ -1390,6 +1404,21 @@ test "a fatal feed (max_buffer breach) poisons the connection and owes a GOAWAY"
     // A later feed re-raises the latched error without re-arming a GOAWAY.
     try testing.expectError(error.MessageTooLong, c.feed("more"));
     try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+}
+
+test "localSettingsParams advertises the enforced limits" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    c.limits.max_concurrent_streams = 64;
+    var buf: [4][2]u32 = undefined;
+    const params = c.localSettingsParams(&buf);
+    var by_id = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer by_id.deinit();
+    for (params) |p| try by_id.put(p[0], p[1]);
+    try testing.expectEqual(@as(?u32, 64), by_id.get(@intFromEnum(constants.SettingId.max_concurrent_streams)));
+    try testing.expectEqual(@as(?u32, c.limits.max_header_list_size), by_id.get(@intFromEnum(constants.SettingId.max_header_list_size)));
+    try testing.expectEqual(@as(?u32, c.limits.header_table_size), by_id.get(@intFromEnum(constants.SettingId.header_table_size)));
+    try testing.expectEqual(@as(?u32, c.limits.max_frame_size), by_id.get(@intFromEnum(constants.SettingId.max_frame_size)));
 }
 
 test "errorCode maps each H2Error to its RFC 9113 code" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -151,9 +151,17 @@ const H2Engine = struct {
     writer: *H2Writer,
     handshake_sent: bool = false,
 
+    /// Serialize our connection preface, advertising the SETTINGS we enforce so a
+    /// peer respects our limits (e.g. max_concurrent_streams) rather than the RFC
+    /// defaults. Shared by every site that may emit the preface first.
+    fn sendOurPreface(self: *H2Engine) core.h2.writer.WriteError!void {
+        var buf: [4][2]u32 = undefined;
+        try self.writer.sendPreface(self.conn.localSettingsParams(&buf));
+    }
+
     fn ensureHandshake(self: *H2Engine) bool {
         if (self.handshake_sent) return true;
-        self.writer.sendPreface(&.{}) catch {
+        self.sendOurPreface() catch {
             _ = c.PyErr_NoMemory();
             return false;
         };
@@ -286,7 +294,7 @@ const H2Engine = struct {
         // Our own preface must be the first frame WE send (RFC 9113 3.4), so emit
         // it before any ACK/WINDOW_UPDATE this event would otherwise queue first.
         if (!self.handshake_sent) {
-            try self.writer.sendPreface(&.{});
+            try self.sendOurPreface();
             self.handshake_sent = true;
         }
         switch (ev) {
@@ -309,7 +317,7 @@ const H2Engine = struct {
     fn emitGoawayIfOwed(self: *H2Engine) void {
         if (self.conn.takeGoawayOwed()) |code| {
             if (!self.handshake_sent) {
-                self.writer.sendPreface(&.{}) catch return;
+                self.sendOurPreface() catch return;
                 self.handshake_sent = true;
             }
             self.writer.sendGoaway(self.conn.lastPeerStreamId(), code, &.{}) catch {};

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -51,6 +51,39 @@ def _settings_flags(buf: bytes) -> list[int]:
     return [flags for ftype, flags, _, _ in _frames(buf) if ftype == 0x04]
 
 
+def _own_settings(buf: bytes) -> dict[int, int]:
+    # The first non-ACK SETTINGS frame is the server's own preface; decode it.
+    for ftype, flags, _, payload in _frames(buf):
+        if ftype == 0x04 and not flags & 0x01:
+            return {
+                int.from_bytes(payload[j : j + 2], "big"): int.from_bytes(payload[j + 2 : j + 6], "big")
+                for j in range(0, len(payload), 6)
+            }
+    return {}
+
+
+def test_handshake_advertises_real_settings() -> None:
+    # The server must advertise its enforced limits, not an empty SETTINGS, or a
+    # peer uses RFC defaults and gets spurious REFUSED_STREAM resets (RFC 9113 6.5).
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK))
+    list(drain_h2(conn))
+    settings = _own_settings(conn.data_to_send())
+    assert settings[0x03] == 128  # MAX_CONCURRENT_STREAMS (the default cap)
+    assert settings[0x06] == 64 * 1024  # MAX_HEADER_LIST_SIZE
+    assert settings[0x01] == 4096  # HEADER_TABLE_SIZE
+    assert settings[0x05] == 16384  # MAX_FRAME_SIZE
+
+
+def test_advertised_settings_round_trip_to_a_peer() -> None:
+    # A client parses the server's advertised SETTINGS as a Settings event.
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    server.initiate_connection()
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    client.receive_data(server.data_to_send())
+    settings = next(e for e in drain_h2(client) if isinstance(e, zttp.Settings))
+    assert (0x03, 128) in settings.params  # MAX_CONCURRENT_STREAMS
+
+
 def test_server_settings_precede_the_settings_ack() -> None:
     # The server's own SETTINGS must be the first frame it sends (RFC 9113 3.4),
     # even when the client's SETTINGS is ACKed first while draining events.

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -53,13 +53,11 @@ def _settings_flags(buf: bytes) -> list[int]:
 
 def _own_settings(buf: bytes) -> dict[int, int]:
     # The first non-ACK SETTINGS frame is the server's own preface; decode it.
-    for ftype, flags, _, payload in _frames(buf):
-        if ftype == 0x04 and not flags & 0x01:
-            return {
-                int.from_bytes(payload[j : j + 2], "big"): int.from_bytes(payload[j + 2 : j + 6], "big")
-                for j in range(0, len(payload), 6)
-            }
-    return {}
+    payload = next(p for ftype, flags, _, p in _frames(buf) if ftype == 0x04 and not flags & 0x01)
+    return {
+        int.from_bytes(payload[j : j + 2], "big"): int.from_bytes(payload[j + 2 : j + 6], "big")
+        for j in range(0, len(payload), 6)
+    }
 
 
 def test_handshake_advertises_real_settings() -> None:


### PR DESCRIPTION
Fixes #47.

`ensureHandshake` sent `sendPreface(&.{})` - an empty SETTINGS frame. So our enforced limits were invisible to the peer, which fell back to RFC defaults. The damaging case: `MAX_CONCURRENT_STREAMS` defaults to *unlimited*, so a peer opened more streams than our cap of 128 accepts and got spurious `REFUSED_STREAM` resets.

### Fix
`localSettingsParams` (core) builds the SETTINGS params from `conn.limits` - `MAX_CONCURRENT_STREAMS`, `MAX_HEADER_LIST_SIZE`, `HEADER_TABLE_SIZE`, `MAX_FRAME_SIZE` - so we **advertise exactly what we enforce**. A shared `sendOurPreface` helper routes all three preface sites (first send, draining events, before a GOAWAY) through it, keeping the advertised values consistent.

The advertised==enforced invariant is the load-bearing property: the parser enforces `limits.max_frame_size`/`max_concurrent_streams` on the same values it advertises, so the server never lies about what it accepts (verified by a test that a frame exceeding the advertised `MAX_FRAME_SIZE` is rejected).

### Tests
Core: `localSettingsParams` reflects the limits. Python: the handshake advertises all four real settings, and a client parses them as a `Settings` event with `(MAX_CONCURRENT_STREAMS, 128)`.

`zig build test` + `zig build fuzz`, 203 pytest, mypy, ruff (check + format) all green.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
