### PR TITLE
Enforce the Content-Length guard on every HTTP/2 end-of-stream path

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -453,13 +453,20 @@ pub const Connection = struct {
         s.creditRecvWindow(f.header.length);
         if (content.len > 0) self.push(.{ .data = .{ .data = content, .stream_id = f.header.stream_id } });
         s.recvApply(.data, end_stream);
-        if (end_stream) {
-            if (s.checkContentLength().action == .stream_error) {
-                self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(ErrorCode.protocol_error) } });
-                return;
-            }
-            self.push(.{ .end_of_message = .{ .stream_id = f.header.stream_id } });
+        if (end_stream) try self.endMessage(s, f.header.stream_id, &.{});
+    }
+
+    /// Finalize a stream at END_STREAM: enforce the Content-Length vs body-seen
+    /// guard (the h2->h1 smuggling defense) on EVERY end path - DATA, a bodyless
+    /// HEADERS, or trailers - then surface end_of_message. A mismatch is a stream
+    /// PROTOCOL_ERROR (RST_STREAM), so a request that lies about its body length
+    /// can never be downgraded to a smuggled HTTP/1.1 message.
+    fn endMessage(self: *Connection, s: *Stream, id: u32, trailers: []const events.Header) H2Error!void {
+        if (s.checkContentLength().action == .stream_error) {
+            try self.resetStream(s, id, .protocol_error);
+            return;
         }
+        self.push(.{ .end_of_message = .{ .trailers = trailers, .stream_id = id } });
     }
 
     fn handleRstStream(self: *Connection, f: frame_mod.Frame) H2Error!void {
@@ -593,7 +600,7 @@ pub const Connection = struct {
                 return;
             }
             s.recvApply(.headers, true);
-            self.push(.{ .end_of_message = .{ .trailers = headers, .stream_id = id } });
+            try self.endMessage(s, id, headers);
             return;
         }
 
@@ -626,7 +633,7 @@ pub const Connection = struct {
             self.push(.{ .response = resp.event });
             if (end_stream) {
                 s.recvApply(.headers, true); // open -> half_closed_remote
-                self.push(.{ .end_of_message = .{ .stream_id = id } });
+                try self.endMessage(s, id, &.{});
             }
             return;
         }
@@ -644,7 +651,7 @@ pub const Connection = struct {
         self.push(.{ .request = req.event });
         if (end_stream) {
             s.recvApply(.headers, true); // open -> half_closed_remote
-            self.push(.{ .end_of_message = .{ .stream_id = id } });
+            try self.endMessage(s, id, &.{});
         }
     }
 
@@ -1452,6 +1459,22 @@ test "conflicting duplicate content-length is malformed" {
     try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
     try handshook(&c, hdr.items);
     try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(try c.nextEvent()));
+}
+
+test "a bodyless request that declares content-length is reset (smuggling guard)" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+    // :method GET, :scheme http, :path /, content-length: 5 - with END_STREAM on the
+    // HEADERS frame and no DATA. data_seen 0 != 5 must reset, even off the DATA path.
+    const block = [_]u8{ 0x82, 0x86, 0x84, 0x00, 0x0e } ++ "content-length".* ++ [_]u8{ 0x01, '5' };
+    var hdr: std.ArrayList(u8) = .empty;
+    defer hdr.deinit(testing.allocator);
+    try frameBytes(&hdr, .headers, Flags.end_headers | Flags.end_stream, 1, &block);
+    try handshook(&c, hdr.items);
+    try testing.expectEqual(std.meta.Tag(Event).request, std.meta.activeTag(try c.nextEvent()));
+    const ev = try c.nextEvent();
+    try testing.expectEqual(std.meta.Tag(Event).rst_stream, std.meta.activeTag(ev));
+    try testing.expectEqual(@as(u32, @intFromEnum(ErrorCode.protocol_error)), ev.rst_stream.error_code);
 }
 
 test "a malformed request closes the stream so later DATA does not reopen it" {

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -642,6 +642,52 @@ def test_h2_head_response_with_content_length_is_not_a_stream_error() -> None:
     assert events == snapshot(["Settings", "Settings", "Response", "EndOfMessage"])
 
 
+def _lit(name: bytes, value: bytes) -> bytes:
+    # An HPACK literal header field, never indexed, with a literal name.
+    return bytes([0x00, len(name)]) + name + bytes([len(value)]) + value
+
+
+def _request_block(*extra: tuple[bytes, bytes], method: bytes = b"GET") -> bytes:
+    block = _lit(b":method", method) + _lit(b":path", b"/") + _lit(b":scheme", b"http") + _lit(b":authority", b"x")
+    for name, value in extra:
+        block += _lit(name, value)
+    return block
+
+
+def test_h2_bodyless_request_with_content_length_is_reset() -> None:
+    # A request declaring content-length but sending no DATA is an h2->h1 smuggling
+    # vector (the downgraded h1 request advertises a body that never arrives). It
+    # must be reset even though END_STREAM rode on the HEADERS frame, not DATA.
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, _request_block((b"content-length", b"5"))))
+    events = [type(e).__name__ for e in drain_h2(conn)]
+    assert "RstStream" in events
+    assert "EndOfMessage" not in events
+
+
+def test_h2_content_length_mismatch_via_trailers_is_reset() -> None:
+    # content-length: 5 but only 3 body bytes, with END_STREAM riding on a trailer
+    # block - the mismatch must still be caught (not only on the DATA end path).
+    conn = server_with(
+        frame(0x01, END_HEADERS, 1, _request_block((b"content-length", b"5"), method=b"POST")),
+        frame(0x00, 0, 1, b"abc"),  # 3 bytes, no END_STREAM
+        frame(0x01, END_HEADERS | END_STREAM, 1, _lit(b"x-trailer", b"v")),
+    )
+    events = [type(e).__name__ for e in drain_h2(conn)]
+    assert "RstStream" in events
+    assert "EndOfMessage" not in events
+
+
+def test_h2_matching_content_length_is_accepted() -> None:
+    # The guard must not reject a request whose body matches its content-length.
+    conn = server_with(
+        frame(0x01, END_HEADERS, 1, _request_block((b"content-length", b"3"), method=b"POST")),
+        frame(0x00, END_STREAM, 1, b"abc"),
+    )
+    events = [type(e).__name__ for e in drain_h2(conn)]
+    assert "RstStream" not in events
+    assert "EndOfMessage" in events
+
+
 def test_initiate_connection_emits_the_preface_before_any_send() -> None:
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
     conn.initiate_connection()


### PR DESCRIPTION
## Security fix: HTTP/2 → HTTP/1.1 request-smuggling

The h2→h1 smuggling guard (declared `Content-Length` vs DATA bytes actually seen) only ran when `END_STREAM` rode on a **DATA** frame. A request that ended on its **HEADERS** frame or on a **trailer** block bypassed the check entirely.

### Bypass (verified)
- A request: single HEADERS frame with `content-length: 5` + `END_STREAM`, **zero DATA frames**. `data_seen=0 ≠ content_length=5`, never checked → surfaced as a complete request.
- Downgraded to HTTP/1.1, this is a classic CL-based request-smuggling primitive: the back-end waits for a 5-byte body that never arrives, desyncing front-end/back-end on message boundaries.
- A second variant ends the stream on a trailer block after a short body (`content-length: 5`, 3 bytes sent).

### Fix
Route every end-of-stream path (DATA, bodyless HEADERS, trailers) through a single `endMessage` helper that runs `checkContentLength` before emitting `end_of_message`, resetting the stream with `PROTOCOL_ERROR` on a mismatch. Bodyless responses (HEAD / 204 / 304) still skip the check via `expects_bodyless`, so a matching body or a legitimately bodyless message is unaffected (verified: no false positives on `CL=3`+3 bytes, bodyless `GET`, `CL=0`).

### Tests
Python regressions for both bypasses + the matching-CL accept case; a core Zig test for the bodyless-mismatch path. `zig build test` + `zig build fuzz`, 208 pytest, 100% coverage, mypy, ruff all green.

This was found while refreshing `THREAT_MODEL.md` for HTTP/2 (#54) - an adversarial audit of the documented defenses surfaced it as a real gap rather than just a doc lag.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
