### PR TITLE
Refresh THREAT_MODEL.md for HTTP/2 and HTTP/3

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -5,7 +5,7 @@ it deliberately leaves to the integrator, and the residual risks. It reflects tw
 security audits (a code-level review and a CVE-driven review that worked backward
 from real HTTP-parser CVEs across Node, Go, Python, Rust, and C servers).
 
-zttp is an HTTP/1.1 **parser and serializer**, not a server. It does no I/O. That
+zttp is an HTTP **parser and serializer**, not a server. It does no I/O. That
 shapes everything below: zttp owns the *protocol*, the integrator owns the *I/O,
 the connection lifecycle, and the policy*.
 
@@ -15,14 +15,18 @@ In scope:
 
 - HTTP/1.1 request and response message framing (request/status line, headers,
   Content-Length and chunked bodies, trailers).
+- HTTP/2 (RFC 9113): frame codec, HPACK, stream multiplexing and state, flow
+  control, and the connection lifecycle, plus h2c upgrade (RFC 7540 3.2).
+- HTTP/3 (RFC 9114) over a QUIC transport (RFC 9000/9001/9002): the server read
+  path, QPACK, and the control/SETTINGS exchange.
 - The read side (`receive_data` / `next_event`) and the write side
   (`send_*` / `data_to_send`).
 
 Out of scope (by design - see [Integrator responsibilities](#integrator-responsibilities)):
 
-- Sockets, TLS, timeouts, and connection concurrency.
-- HTTP/2 and HTTP/3 (roadmap).
-- WebSocket / `Upgrade` / `CONNECT` tunnel semantics.
+- Sockets, TLS *termination* (HTTP/1.1 and HTTP/2 run over the integrator's
+  TLS), timeouts, and connection concurrency.
+- WebSocket / `Upgrade` (other than h2c) / `CONNECT` tunnel semantics.
 - URL, query-string, cookie, multipart, and form parsing.
 - Authentication, authorization, and application logic.
 
@@ -54,10 +58,12 @@ The security goal: **no attacker-controlled byte stream can cause memory unsafet
 crash the host process, desynchronize message framing, or force unbounded
 resource use** - within zttp's scope.
 
-## What zttp defends against
+## What zttp defends against (HTTP/1.1)
 
 Each item below is enforced in the parser core and covered by tests. Citations
-are to `src/core/`.
+are to `src/core/h1/`. The HTTP/2 and HTTP/3 defenses follow in their own
+sections; the memory-safety guarantees (Zig `ReleaseSafe`, no input-driven
+recursion, owned-copy event payloads) apply across all three.
 
 ### Request smuggling (the primary threat)
 
@@ -76,8 +82,10 @@ are to `src/core/`.
 - **obs-fold (line folding)** and **whitespace before the colon** → rejected.
 - **Lenient Content-Length** (`+5`, `0x10`, embedded spaces, overflow) → rejected;
   parsing is digits-only with checked arithmetic.
-- **Version confusion** → only `HTTP/1.x` is accepted; `HTTP/0.9` / `HTTP/2.0`
-  request/status lines are rejected.
+- **Version confusion** → on an HTTP/1.1 request/status line only `HTTP/1.x` is
+  accepted; a smuggled `HTTP/0.9` / `HTTP/2.0` version token on the H1 line is
+  rejected. (HTTP/2 and HTTP/3 are first-class protocols selected at connection
+  construction, not by a version token on a request line - see below.)
 
 ### Memory safety and crashes
 
@@ -123,6 +131,84 @@ other control bytes. It also refuses to serialize ambiguous framing
 (Transfer-Encoding + Content-Length, or conflicting/duplicate Content-Length), so
 a re-serialized message cannot be turned into two.
 
+## HTTP/2 defenses
+
+HTTP/2 (RFC 9113) adds its own attack surface - multiplexing, HPACK compression,
+and flow control. The defenses below are enforced in `src/core/h2/` and covered
+by tests; the citations are to that tree.
+
+### DoS / resource exhaustion (the H2-specific CVE classes)
+
+| Defense | Limit (default) | Class |
+| --- | --- | --- |
+| **Rapid-reset** (CVE-2023-44487) → bounded total resets *and* total streams ever opened; exceeding either trips `ENHANCE_YOUR_CALM` → GOAWAY | `max_stream_resets` (256), `max_streams` (4096) | churn flood |
+| **CONTINUATION flood** (CVE-2024-27316) → an open field block is bounded by both a frame count and a byte size | `max_continuation_frames` (16), `max_field_block_bytes` (64 KiB) | unbounded field block |
+| **HPACK bomb** → the *decoded* header-list size is checked mid-decode, before the full list is materialized | `max_header_list_size` (64 KiB) | decompression amplification |
+| **Stream concurrency** → excess concurrent peer streams are refused with `REFUSED_STREAM`, never inserted into the map | `max_concurrent_streams` (128) | per-connection work |
+| **Oversized frame** → a frame whose declared length exceeds the advertised size is rejected at parse, before its payload is buffered | `max_frame_size` (16 KiB) | memory spike |
+| **Input buffer** → unconsumed bytes are capped (a fatal breach poisons the connection and owes a GOAWAY) | `max_buffer` (8 MiB) | slow-loris memory |
+
+The server advertises these limits in its SETTINGS preface, and **what it
+advertises is exactly what it enforces** (`localSettingsParams` builds the
+SETTINGS from the same `Limits`), so a conformant peer self-limits rather than
+flooding and being mass-refused.
+
+### Request smuggling and h2→h1 downgrade
+
+zttp is frequently a front-end that downgrades HTTP/2 to HTTP/1.1, so it
+validates inbound H2 messages against the exact shapes that smuggle across that
+boundary (RFC 9113 8):
+
+- **Connection-specific fields** (`connection`, `keep-alive`, `proxy-connection`,
+  `transfer-encoding`, `upgrade`) → rejected on the read path (request, response,
+  and trailers) and refused by the writer (8.2.2).
+- **`TE`** → only the literal `trailers` value is allowed (8.2.2).
+- **Field names** → must be lowercase RFC 9110 tokens; uppercase or any non-token
+  byte is malformed (8.2.1).
+- **Field values** → no CR/LF/NUL/other control or DEL, no leading/trailing
+  whitespace (8.2.1). The *write* side is intentionally stricter (it also rejects
+  an inner HTAB), so a value the read side accepts can always be re-serialized
+  without a peer re-trimming or splitting it.
+- **Content-Length vs body** → at end-of-stream a declared `content-length` that
+  does not equal the DATA bytes seen resets the stream (`PROTOCOL_ERROR`). The
+  check runs on **every** end path - DATA, a bodyless HEADERS frame, and trailers
+  - so a request that lies about its body length cannot be downgraded into a
+  smuggled HTTP/1.1 message. Legitimately bodyless responses (HEAD / 204 / 304)
+  skip it.
+- **Duplicate Content-Length** with disagreeing values → rejected (no folding
+  into a single ambiguous value).
+- **Pseudo-headers** → must precede regular fields, none may be duplicated or
+  unknown, `:method`/`:path`/`:scheme` are required, `:path` is non-empty, and
+  `:status` is exactly three digits in 100..599 (8.3). A malformed message is a
+  *stream* error - the field block is still HPACK-decoded so the
+  connection-global dynamic table stays in sync with the peer's encoder.
+
+### Framing, flow control, and protocol state
+
+- A server connection must begin with the exact client preface, and the peer's
+  first frame must be SETTINGS (3.4); per-frame-type fixed/minimum lengths are
+  enforced, and a PADDED frame whose pad length underflows the payload is
+  rejected (no OOB read).
+- Stream-state transitions are validated (5.1): frames on idle/closed/half-closed
+  streams are rejected; new request stream ids must be odd and strictly
+  increasing (5.1.1); the reserved id high bit is masked off.
+- Flow-control windows are overflow/underflow checked: a zero or 31-bit-overflow
+  WINDOW_UPDATE is rejected, and a peer cannot send more DATA than the advertised
+  receive window (6.9).
+- On a connection-fatal error the engine arms **exactly one** GOAWAY carrying the
+  RFC 9113 7 error code, emitted before the connection closes (5.4.1).
+- Frame dispatch is iterative (a run of no-event frames cannot overflow the
+  stack), and the frame codec is zero-copy (it never owns or copies payload).
+
+## HTTP/3
+
+HTTP/3 (RFC 9114) over QUIC is read-path-first and shares the H2 validation
+discipline (QPACK field validation, the same pseudo-header and smuggling rules).
+The QUIC transport (RFC 9000/9001/9002) is in scope - including the handshake,
+packet protection, and flow control - and is held to the same strict-reject bar.
+Its threat surface is large and still maturing; treat the HTTP/3 path as the
+newest and least battle-tested of the three.
+
 ## Integrator responsibilities
 
 zttp is sans-IO, so the embedding server/framework **must** handle these. Getting
@@ -155,6 +241,28 @@ them wrong can reintroduce a smuggling or DoS class that the core sidesteps.
    configurable from the Python API today; the host's own caps (timeouts,
    concurrency) are the tunable defense.
 
+### Additional HTTP/2 responsibilities
+
+The H2 core enforces the stream/frame/HPACK limits above, but a few duties stay
+with the host:
+
+8. **Rate-limit control-frame floods.** zttp auto-ACKs every peer SETTINGS and
+   PING (in `autoRespond`) with no per-connection budget. A peer that streams
+   SETTINGS/PING frames forces an equal stream of ACKs; the host must impose a
+   control-frame rate limit (or an overall idle/throughput timeout) so a peer
+   cannot pin a connection busy on ACKs.
+9. **Send the GOAWAY and close.** On a connection-fatal error zttp *queues* one
+   GOAWAY into the writer; the host must call `data_to_send()` to flush it and
+   then close the transport. The core cannot close a socket it does not own.
+10. **Own the h2→h1 translation contract.** A proxy that downgrades H2 to H1 must
+    strip the pseudo-headers, bridge `:authority` → `Host`, and never forward a
+    connection-specific field. zttp validates the *inbound* H2 message (above),
+    but the *downgraded* H1 message it builds is the proxy's to keep unambiguous.
+11. **Trust the h2c upgrade before seeding it.** `initiate_upgrade_connection`
+    takes an already-parsed HTTP/1.1 request on faith; the host must have decided
+    the `Upgrade: h2c` request is well-formed and authorized before seeding it as
+    stream 1.
+
 ## Residual risks
 
 These are not defects in the current parser; they are the places where the
@@ -167,9 +275,17 @@ These are not defects in the current parser; they are the places where the
   default to strict and are **not** exposed through the Python API. If a future
   binding ever exposes them, the bare-LF/CR smuggling classes re-open. Keep
   leniency non-configurable from Python, or document the risk loudly.
-- **Future features.** Adding body/form/multipart parsing, or `Upgrade`/`CONNECT`
-  support, brings new CVE classes (e.g. decompression bombs, tunnel desync) into
-  scope; they must be designed with the same strict-reject discipline.
+- **Control-frame ACK floods.** zttp auto-ACKs SETTINGS/PING without a budget
+  (integrator responsibility 8); a host that imposes no control-frame rate limit
+  can be kept busy answering ACKs even though no memory grows.
+- **HTTP/3 maturity.** The QUIC + HTTP/3 path is the newest code and has had less
+  adversarial exposure than the H1/H2 paths; the transport's threat surface
+  (amplification, key/packet handling) is broad. Treat it as the least
+  battle-tested protocol.
+- **Future features.** Adding body/form/multipart parsing, or WebSocket/`CONNECT`
+  tunnel support, brings new CVE classes (e.g. decompression bombs, tunnel
+  desync) into scope; they must be designed with the same strict-reject
+  discipline.
 
 ## Reporting a vulnerability
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -18,7 +18,9 @@ In scope:
 - HTTP/2 (RFC 9113): frame codec, HPACK, stream multiplexing and state, flow
   control, and the connection lifecycle, plus h2c upgrade (RFC 7540 3.2).
 - HTTP/3 (RFC 9114) over a QUIC transport (RFC 9000/9001/9002): the server read
-  path, QPACK, and the control/SETTINGS exchange.
+  path - QPACK decode and request-stream framing. The peer control stream and its
+  SETTINGS are **not yet processed** (only bidirectional request streams are
+  pumped), so HTTP/3 settings are neither negotiated nor enforced today.
 - The read side (`receive_data` / `next_event`) and the write side
   (`send_*` / `data_to_send`).
 
@@ -202,12 +204,28 @@ boundary (RFC 9113 8):
 
 ## HTTP/3
 
-HTTP/3 (RFC 9114) over QUIC is read-path-first and shares the H2 validation
-discipline (QPACK field validation, the same pseudo-header and smuggling rules).
-The QUIC transport (RFC 9000/9001/9002) is in scope - including the handshake,
-packet protection, and flow control - and is held to the same strict-reject bar.
-Its threat surface is large and still maturing; treat the HTTP/3 path as the
-newest and least battle-tested of the three.
+HTTP/3 (RFC 9114) over QUIC is read-path-first and the **least mature** of the
+three protocols. It reuses the shared field validators on **regular** header
+fields - lowercase token names, no control bytes in values, connection-specific
+fields and a non-`trailers` `TE` rejected, duplicate Content-Length conflict
+rejected (`decodeRequest`, `src/core/h3/connection.zig`). It also enforces the
+pseudo-header structure rules (pseudo before regular, no duplicates, required
+request pseudo-headers).
+
+Two gaps a downgrading proxy must NOT rely on yet:
+
+- **Pseudo-header *values* are not validated.** Unlike the H2 path, `decodeRequest`
+  does not run the value check on `:method`/`:path`/`:authority`/`:scheme`, so a
+  `:authority` carrying CR/LF is currently accepted and synthesized into a `host`
+  header. An h3→h1 downgrade must validate the pseudo-header values itself until
+  this is closed.
+- **The control stream and SETTINGS are not processed** (only request streams are
+  pumped), so HTTP/3 settings are neither negotiated nor enforced.
+
+The QUIC transport (RFC 9000/9001/9002) - handshake, packet protection, flow
+control - is in scope and held to the strict-reject bar, but its threat surface
+is broad and has had far less adversarial exposure than the H1/H2 paths. Treat
+HTTP/3 as experimental from a security standpoint.
 
 ## Integrator responsibilities
 


### PR DESCRIPTION
Fixes #54.

`THREAT_MODEL.md` still listed HTTP/2 and HTTP/3 as out-of-scope roadmap items and read as if HTTP/2 was rejected outright, while none of the shipped H2 defenses were documented - the security contract understated reality.

### Changes
- **Scope** now covers HTTP/2 (RFC 9113, including h2c) and HTTP/3 over QUIC. Clarified that the H1 "version confusion" reject is a defense on the *HTTP/1.1 request line* (a smuggled `HTTP/2.0` version token), not a rejection of the H2 protocol.
- **New "HTTP/2 defenses" section** covering what the code actually enforces:
  - DoS caps with their CVE classes - rapid-reset (CVE-2023-44487), CONTINUATION flood (CVE-2024-27316), HPACK bomb, concurrency/frame/buffer caps - with the **real defaults** (verified against `src/core/h2`).
  - Smuggling / h2→h1 downgrade validation: connection-specific fields, field name/value rules, the Content-Length-vs-body guard **on every end-of-stream path**, pseudo-header rules.
  - Framing, flow-control, GOAWAY-on-fatal-error, iterative dispatch.
- **New "HTTP/3" section** - in scope, but flagged as the least battle-tested path.
- **HTTP/2 integrator duties** (items 8-11): control-frame ACK rate-limiting, sending the GOAWAY + closing, the h2→h1 translation contract, and h2c upgrade trust.

The doc was produced from an adversarial audit of the actual defenses (every limit default and CVE cross-checked against the source). That audit also surfaced a real Content-Length smuggling gap, fixed separately in #92 - this doc describes the now-complete guard.

Docs-only change; defaults and CVE numbers verified against `src/core/h2/`.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
