### PR TITLE
Enforce and replenish the bidirectional stream limit (MAX_STREAMS)

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1591,6 +1591,39 @@ test "completing request streams advertises a raised MAX_STREAMS" {
     try testing.expect(conn.datagramsToSend().len > 0); // the cap rode again
 }
 
+test "a cap of one request still slides after the request completes" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x59, 0x5a, 0x5b, 0x5c };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.bidi_limit = flow.StreamLimit.init(1); // one request at a time
+
+    // The one allowed request (stream 0): a single byte with FIN, drained to terminal.
+    var s0: std.ArrayListUnmanaged(u8) = .empty;
+    defer s0.deinit(gpa);
+    try frame.encodeStream(&s0, gpa, 0, 0, &[_]u8{0x7a}, true);
+    const d0 = try testBuildApp(gpa, &dcid, 0, s0.items);
+    defer gpa.free(d0);
+    try conn.receiveDatagram(d0, 1000);
+    conn.consumeStream(0, 1);
+    try testing.expect(conn.dropStream(0));
+
+    // Completing it slides the cap to 2 and queues a MAX_STREAMS (the window-of-1 edge).
+    try testing.expect(conn.max_streams_pending);
+    try testing.expectEqual(@as(u64, 2), conn.bidi_limit.?.max);
+    try conn.flushSend(2000);
+
+    // The next request (stream 4) is now within the raised cap.
+    var s4: std.ArrayListUnmanaged(u8) = .empty;
+    defer s4.deinit(gpa);
+    try frame.encodeStream(&s4, gpa, 4, 0, &[_]u8{0x7a}, true);
+    const d4 = try testBuildApp(gpa, &dcid, 1, s4.items);
+    defer gpa.free(d4);
+    try conn.receiveDatagram(d4, 2100); // no StreamLimitError
+    try testing.expectEqualStrings("z", conn.streamData(4));
+}
+
 // ---- TLS handshake seam tests ----------------------------------------------
 
 // The RFC 8448 section 3 client x25519 public key, the same value tls/keyshare.zig

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -188,6 +188,13 @@ pub const Connection = struct {
     /// legitimate new lower id as retired. One u64 per retired stream is far smaller
     /// than the RecvStream it replaces, so this still bounds the per-stream memory.
     retired_recv: std.AutoHashMapUnmanaged(u64, void) = .empty,
+    /// The cap on client-initiated bidirectional streams (RFC 9000 4.6): exactly the
+    /// initial_max_streams_bidi we advertise, enforced on each newly opened request
+    /// stream so a peer cannot exhaust memory by opening unboundedly many. The wire and
+    /// the enforced value are always identical (a server advertising 0 rejects every
+    /// bidi stream). `null` on the non-server `init` path, which advertises nothing, so
+    /// the recv-pipeline tests open streams unchecked; initServer always sets it.
+    bidi_limit: ?flow.StreamLimit = null,
 
     /// `client_dcid` is the destination connection id on the client's first
     /// Initial: both endpoints derive the Initial keys from it. The server picks
@@ -230,8 +237,13 @@ pub const Connection = struct {
     /// flight. `tls_config` supplies the ServerHello randomness, ephemeral seed,
     /// signing key, certificate, and transport parameters.
     pub fn initServer(gpa: std.mem.Allocator, client_dcid: []const u8, tls_config: tls.flight.Config) Error!Connection {
+        // Enforce exactly the bidi cap we advertise (RFC 9000 4.6): parse it from our
+        // own transport parameters so the wire and the enforced value never diverge. A
+        // malformed own blob is a configuration bug, surfaced before anything is built.
+        const own = transport_params.parse(tls_config.transport_params) catch return error.ProtocolViolation;
         var conn = try init(gpa, .server, client_dcid);
         conn.tls = tls.server.Server.init(tls_config);
+        conn.bidi_limit = flow.StreamLimit.init(own.initial_max_streams_bidi);
         return conn;
     }
 
@@ -1041,6 +1053,7 @@ pub const Connection = struct {
 
     fn onStreamFrame(self: *Connection, id: u64, offset: u64, data: []const u8, fin: bool) Error!void {
         if (self.isRetired(id)) return; // a late frame for a completed-and-dropped stream
+        try self.noteClientStream(id);
         const s = try self.recvStream(id);
         const delta = s.push(offset, data, fin) catch |e| switch (e) {
             error.FinalSizeError => return error.FinalSizeError,
@@ -1054,8 +1067,20 @@ pub const Connection = struct {
 
     fn onReset(self: *Connection, id: u64, error_code: u64, final_size: u64) Error!void {
         if (self.isRetired(id)) return; // a reset for an already-completed-and-dropped stream
+        try self.noteClientStream(id);
         const s = try self.recvStream(id);
         s.onReset(error_code, final_size) catch return error.FinalSizeError;
+    }
+
+    /// Charge a peer-initiated bidirectional stream against the advertised cap (RFC
+    /// 9000 4.6): a STREAM_LIMIT_ERROR if `id` is beyond it. Idempotent - the limit
+    /// records the high-water count, so re-noting an already-open stream is a no-op.
+    /// Only client-bidi request streams are gated here; enforcement is off (null) on
+    /// the non-server path, and uni control streams are bounded by their own logic.
+    fn noteClientStream(self: *Connection, id: u64) Error!void {
+        const limit = if (self.bidi_limit) |*l| l else return; // unenforced (non-server) path
+        if (stream.StreamType.of(id) != .client_bidi) return;
+        limit.onOpened(id / 4) catch return error.StreamLimitError;
     }
 
     /// A peer STOP_SENDING (RFC 9000 19.5) asks us to stop sending on `id`. Reset that
@@ -1067,6 +1092,10 @@ pub const Connection = struct {
     /// layer above, so it never resets the critical control stream.
     fn onStopSending(self: *Connection, id: u64, error_code: u64) Error!void {
         if (stream.StreamType.of(id) != .client_bidi) return;
+        // Charge the stream against the bidi cap before stashing any state for it (RFC
+        // 9000 4.6): a STOP_SENDING for a never-seen high id is otherwise an unchecked
+        // way to grow peer_stop_sending unbounded.
+        try self.noteClientStream(id);
         if (self.send_streams.get(id)) |s| {
             s.reset(error_code);
         } else {
@@ -1322,6 +1351,55 @@ test "consume re-grants connection flow-control credit" {
     try testing.expectEqualStrings("", conn.streamData(0));
 }
 
+test "a bidi stream past the advertised cap is a stream-limit error" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x51, 0x52, 0x53, 0x54 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.bidi_limit = flow.StreamLimit.init(2); // allow client-bidi 0 and 4, reject 8
+
+    // Two request streams open within the cap (ids 0 and 4); a STREAM frame each.
+    const s0 = [_]u8{ 0x0b, 0x00, 0x01, 'a' }; // STREAM|LEN|FIN id 0
+    const d0 = try testBuildApp(gpa, &dcid, 0, &s0);
+    defer gpa.free(d0);
+    try conn.receiveDatagram(d0, 1000);
+    const s4 = [_]u8{ 0x0b, 0x04, 0x01, 'b' }; // id 4
+    const d4 = try testBuildApp(gpa, &dcid, 1, &s4);
+    defer gpa.free(d4);
+    try conn.receiveDatagram(d4, 1000);
+
+    // The third (id 8) is one beyond the cap of 2: STREAM_LIMIT_ERROR.
+    const s8 = [_]u8{ 0x0b, 0x08, 0x01, 'c' }; // id 8
+    const d8 = try testBuildApp(gpa, &dcid, 2, &s8);
+    defer gpa.free(d8);
+    try testing.expectError(error.StreamLimitError, conn.receiveDatagram(d8, 1000));
+}
+
+test "initServer enforces exactly the bidi cap it advertises" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x60, 0x61, 0x62, 0x63 };
+
+    // The cap enforced is the initial_max_streams_bidi the config advertises (8 here).
+    var conn = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer conn.deinit();
+    try testing.expectEqual(@as(u64, 8), conn.bidi_limit.?.max);
+
+    // A config advertising no initial_max_streams_bidi enforces 0: a conformant client
+    // opens no request stream, and the server rejects any it does open.
+    var noneCfg = testServerConfig();
+    noneCfg.transport_params = &.{};
+    var none = try Connection.initServer(gpa, &dcid, noneCfg);
+    defer none.deinit();
+    try testing.expectEqual(@as(u64, 0), none.bidi_limit.?.max);
+
+    // A malformed own transport-parameter blob is a configuration bug, not silently
+    // defaulted: initServer surfaces it.
+    var badCfg = testServerConfig();
+    badCfg.transport_params = &[_]u8{ 0x08, 0x08, 0x00 }; // len 8, only 1 byte follows
+    try testing.expectError(error.ProtocolViolation, Connection.initServer(gpa, &dcid, badCfg));
+}
+
 test "connection flow control sums across streams" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x0a, 0x0b, 0x0c, 0x0d };
@@ -1498,7 +1576,7 @@ fn testServerConfig() tls.flight.Config {
         .ephemeral_seed = [_]u8{0x33} ** 32,
         .signer = tls.sign.Signer.fromSeed([_]u8{0x42} ** 32) catch unreachable,
         .cert_chain = &[_]u8{0xCC} ** 48,
-        .transport_params = &[_]u8{ 0x00, 0x01 },
+        .transport_params = &[_]u8{ 0x08, 0x01, 0x08 }, // initial_max_streams_bidi = 8
     };
 }
 

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -170,8 +170,14 @@ pub const Connection = struct {
     /// (RFC 9000 4.1); flushSend emits it so the peer is not stalled at its grant.
     max_data_pending: bool = false,
     /// Enough request streams completed to advertise a higher bidi cap (RFC 9000 4.6);
-    /// flushSend emits a MAX_STREAMS so the peer is not stuck at the old limit.
+    /// flushSend emits a MAX_STREAMS (carrying `bidi_limit.max`, already granted) so the
+    /// peer is not stuck at the old limit.
     max_streams_pending: bool = false,
+    /// The packet number an emitted MAX_STREAMS is riding, so a lost one is re-sent (RFC
+    /// 9000 13.3): without this a lost MAX_STREAMS would deadlock the peer, which - being
+    /// out of stream credit - cannot open the streams whose completion would re-trigger
+    /// the advertisement. Cleared when that packet is acked.
+    max_streams_sent: ?u64 = null,
     /// Anti-amplification (RFC 9000 8.1): until the client's address is validated, the
     /// server may send at most AMPLIFICATION_FACTOR x the bytes it has received. A
     /// received Handshake packet (only a real client can produce one) validates the
@@ -473,14 +479,16 @@ pub const Connection = struct {
         }
 
         // Advertise a raised bidi-stream cap if one is pending, so a peer serving a long
-        // run of requests is not stuck at the old MAX_STREAMS limit (RFC 9000 4.6).
+        // run of requests is not stuck at the old MAX_STREAMS limit (RFC 9000 4.6). The
+        // value was granted in dropStream; emit it and record the pn so a lost frame is
+        // re-sent (the cap only grows, so a duplicate is harmless).
         if (self.max_streams_pending) {
             if (self.bidi_limit) |*limit| {
                 var msf: std.ArrayListUnmanaged(u8) = .empty;
                 defer msf.deinit(self.gpa);
-                frame.encodeMaxStreams(&msf, self.gpa, true, limit.grant()) catch return error.OutOfMemory;
+                frame.encodeMaxStreams(&msf, self.gpa, true, limit.max) catch return error.OutOfMemory;
                 while (msf.items.len < 20) msf.append(self.gpa, 0x00) catch return error.OutOfMemory; // PADDING for HP
-                _ = try self.buildPacket(space, msf.items, true, now);
+                self.max_streams_sent = try self.buildPacket(space, msf.items, true, now);
             }
             self.max_streams_pending = false;
         }
@@ -597,6 +605,7 @@ pub const Connection = struct {
                 }
             }
             if (self.stop_sending_inflight.fetchRemove(pn)) |e| _ = self.stop_sending.remove(e.value); // acked: done
+            if (self.max_streams_sent == pn) self.max_streams_sent = null; // the advertised cap is confirmed
         }
         // ACK progress resets the PTO backoff (in recovery), so release the fire-once
         // latch: a fresh PTO epoch may arm even if another packet sharing the fired
@@ -631,6 +640,11 @@ pub const Connection = struct {
             // A lost STOP_SENDING: clear in_flight so the next flushSend re-emits it.
             if (self.stop_sending_inflight.fetchRemove(pn)) |e| {
                 if (self.stop_sending.getPtr(e.value)) |ss| ss.in_flight = false;
+            }
+            // A lost MAX_STREAMS: re-arm so the next flushSend re-advertises the cap.
+            if (self.max_streams_sent == pn) {
+                self.max_streams_sent = null;
+                self.max_streams_pending = true;
             }
         }
         if (crypto_lost) try self.flushCrypto(space, now); // resend the lost handshake bytes now
@@ -729,6 +743,12 @@ pub const Connection = struct {
                 ss.in_flight = false;
                 return; // the next flushSend re-sends it
             }
+        }
+        // ... or the MAX_STREAMS the probed packet carried: re-arm it to re-advertise.
+        if (self.max_streams_sent == pn) {
+            self.max_streams_sent = null;
+            self.max_streams_pending = true;
+            return; // the next flushSend re-sends it
         }
         // No data to resend (the range was already acked, or a PING-only packet): a
         // PING is a valid probe that elicits an ACK and keeps the recovery loop alive.
@@ -1161,9 +1181,14 @@ pub const Connection = struct {
         self.gpa.destroy(s);
         // A finished request frees a bidi slot: re-advertise a higher cap once the
         // headroom ahead of the highest opened stream runs low (RFC 9000 4.6), so a
-        // long-lived connection serving many requests is not stranded at the limit.
+        // long-lived connection serving many requests is not stranded at the limit. The
+        // grant happens here (once per slide); flushSend just emits the new max, so a
+        // retransmit re-sends the same value rather than ratcheting it up each time.
         if (self.bidi_limit) |*limit| {
-            if (stream.StreamType.of(id) == .client_bidi and limit.shouldUpdate()) self.max_streams_pending = true;
+            if (stream.StreamType.of(id) == .client_bidi and limit.shouldUpdate()) {
+                _ = limit.grant();
+                self.max_streams_pending = true;
+            }
         }
         return true;
     }
@@ -1548,13 +1573,22 @@ test "completing request streams advertises a raised MAX_STREAMS" {
     }
     conn.clearSend();
 
-    // Three of four opened crossed the auto-tune threshold: a MAX_STREAMS is queued
-    // and flushSend emits it, sliding the cap to opened (3) + window (4).
+    // Three of four opened crossed the auto-tune threshold: the cap slid to opened (3)
+    // + window (4) and a MAX_STREAMS is queued, which flushSend emits.
     try testing.expect(conn.max_streams_pending);
+    try testing.expectEqual(@as(u64, 7), conn.bidi_limit.?.max);
     try conn.flushSend(2000);
     try testing.expect(!conn.max_streams_pending); // emitted
     try testing.expect(conn.datagramLengths().len >= 1);
-    try testing.expectEqual(@as(u64, 7), conn.bidi_limit.?.max);
+    try testing.expect(conn.max_streams_sent != null); // recorded for loss recovery
+    conn.clearSend();
+
+    // A lost MAX_STREAMS must be re-sent, or the peer - out of stream credit - can never
+    // open the streams whose completion would re-trigger the advertisement (RFC 9000 13.3).
+    const d = conn.nextTimeout().?;
+    try conn.onTimeout(d + 1);
+    try conn.flushSend(d + 2);
+    try testing.expect(conn.datagramsToSend().len > 0); // the cap rode again
 }
 
 // ---- TLS handshake seam tests ----------------------------------------------

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -169,6 +169,9 @@ pub const Connection = struct {
     /// The connection-level recv window grew enough to advertise a new MAX_DATA
     /// (RFC 9000 4.1); flushSend emits it so the peer is not stalled at its grant.
     max_data_pending: bool = false,
+    /// Enough request streams completed to advertise a higher bidi cap (RFC 9000 4.6);
+    /// flushSend emits a MAX_STREAMS so the peer is not stuck at the old limit.
+    max_streams_pending: bool = false,
     /// Anti-amplification (RFC 9000 8.1): until the client's address is validated, the
     /// server may send at most AMPLIFICATION_FACTOR x the bytes it has received. A
     /// received Handshake packet (only a real client can produce one) validates the
@@ -467,6 +470,19 @@ pub const Connection = struct {
             while (mf.items.len < 20) mf.append(self.gpa, 0x00) catch return error.OutOfMemory; // PADDING for HP
             _ = try self.buildPacket(space, mf.items, true, now);
             self.max_data_pending = false;
+        }
+
+        // Advertise a raised bidi-stream cap if one is pending, so a peer serving a long
+        // run of requests is not stuck at the old MAX_STREAMS limit (RFC 9000 4.6).
+        if (self.max_streams_pending) {
+            if (self.bidi_limit) |*limit| {
+                var msf: std.ArrayListUnmanaged(u8) = .empty;
+                defer msf.deinit(self.gpa);
+                frame.encodeMaxStreams(&msf, self.gpa, true, limit.grant()) catch return error.OutOfMemory;
+                while (msf.items.len < 20) msf.append(self.gpa, 0x00) catch return error.OutOfMemory; // PADDING for HP
+                _ = try self.buildPacket(space, msf.items, true, now);
+            }
+            self.max_streams_pending = false;
         }
 
         // A conservative single-packet budget: one STREAM frame per packet.
@@ -1143,6 +1159,12 @@ pub const Connection = struct {
         _ = self.streams.remove(id);
         s.deinit();
         self.gpa.destroy(s);
+        // A finished request frees a bidi slot: re-advertise a higher cap once the
+        // headroom ahead of the highest opened stream runs low (RFC 9000 4.6), so a
+        // long-lived connection serving many requests is not stranded at the limit.
+        if (self.bidi_limit) |*limit| {
+            if (stream.StreamType.of(id) == .client_bidi and limit.shouldUpdate()) self.max_streams_pending = true;
+        }
         return true;
     }
 
@@ -1500,6 +1522,39 @@ test "consuming stream data advertises a raised MAX_DATA" {
     try conn.flushSend(2000);
     try testing.expect(!conn.max_data_pending); // emitted
     try testing.expect(conn.datagramLengths().len >= 1);
+}
+
+test "completing request streams advertises a raised MAX_STREAMS" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x55, 0x56, 0x57, 0x58 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.bidi_limit = flow.StreamLimit.init(4); // window 4: opening 3 trips the auto-tune
+
+    // Open, drain and drop three request streams (ids 0, 4, 8). Each is one byte with
+    // FIN, consumed to terminal so dropStream reclaims it and frees a bidi slot.
+    var pn: u64 = 0;
+    for ([_]u64{ 0, 4, 8 }) |id| {
+        var sframe: std.ArrayListUnmanaged(u8) = .empty;
+        defer sframe.deinit(gpa);
+        try frame.encodeStream(&sframe, gpa, id, 0, &[_]u8{0x7a}, true);
+        const dgram = try testBuildApp(gpa, &dcid, pn, sframe.items);
+        defer gpa.free(dgram);
+        try conn.receiveDatagram(dgram, 1000);
+        conn.consumeStream(id, 1);
+        try testing.expect(conn.dropStream(id));
+        pn += 1;
+    }
+    conn.clearSend();
+
+    // Three of four opened crossed the auto-tune threshold: a MAX_STREAMS is queued
+    // and flushSend emits it, sliding the cap to opened (3) + window (4).
+    try testing.expect(conn.max_streams_pending);
+    try conn.flushSend(2000);
+    try testing.expect(!conn.max_streams_pending); // emitted
+    try testing.expect(conn.datagramLengths().len >= 1);
+    try testing.expectEqual(@as(u64, 7), conn.bidi_limit.?.max);
 }
 
 // ---- TLS handshake seam tests ----------------------------------------------

--- a/src/core/quic/flow.zig
+++ b/src/core/quic/flow.zig
@@ -123,9 +123,12 @@ pub const StreamLimit = struct {
     }
 
     /// Should a higher cap be advertised? True once the headroom ahead of the highest
-    /// opened stream falls below half the window (RFC 9000 4.6 auto-tuning).
+    /// opened stream falls below half the window (RFC 9000 4.6 auto-tuning). The half is
+    /// rounded up so a window of 1 still trips after its single slot is used - an
+    /// integer `window / 2` would be 0, a threshold unsigned headroom can never fall
+    /// below, stranding a one-request-at-a-time server.
     pub fn shouldUpdate(self: *const StreamLimit) bool {
-        return self.max - self.opened < self.window / 2;
+        return self.max - self.opened < (self.window + 1) / 2;
     }
 
     /// Slide the cap to `opened + window` and record it; the new value to advertise.
@@ -182,4 +185,13 @@ test "stream limit re-advertises once headroom runs low" {
     try std.testing.expectEqual(@as(u64, 7), l.grant()); // opened 3 + window 4
     try std.testing.expect(!l.shouldUpdate());
     try l.onOpened(6); // the newly granted ids are now usable
+}
+
+test "a window of 1 still slides after its single slot is used" {
+    var l = StreamLimit.init(1);
+    try std.testing.expect(!l.shouldUpdate()); // nothing opened yet
+    try l.onOpened(0); // the one allowed stream
+    try std.testing.expect(l.shouldUpdate()); // would be never-true with `window / 2`
+    try std.testing.expectEqual(@as(u64, 2), l.grant()); // opened 1 + window 1
+    try l.onOpened(1); // the next stream is now permitted
 }

--- a/src/core/quic/flow.zig
+++ b/src/core/quic/flow.zig
@@ -95,15 +95,19 @@ pub const SendWindow = struct {
 };
 
 /// The concurrency cap on streams a peer may open (RFC 9000 4.6, MAX_STREAMS).
-/// Bidi and uni are tracked separately by the caller with two of these.
+/// Bidi and uni are tracked separately by the caller with two of these. It mirrors
+/// `Window`: the cap slides above the highest stream opened so a steady stream of
+/// short-lived requests is never starved, re-advertising once headroom runs low.
 pub const StreamLimit = struct {
     /// The maximum stream count the peer may open (a count, not an id).
     max: u64,
-    /// The highest stream count opened so far.
+    /// The highest stream count opened so far; the floor the cap slides above.
     opened: u64 = 0,
+    /// The headroom to keep ahead of `opened`; a new cap is `opened + window`.
+    window: u64,
 
     pub fn init(max: u64) StreamLimit {
-        return .{ .max = max };
+        return .{ .max = max, .window = max };
     }
 
     pub const Error = error{
@@ -118,12 +122,15 @@ pub const StreamLimit = struct {
         self.opened = @max(self.opened, index + 1);
     }
 
+    /// Should a higher cap be advertised? True once the headroom ahead of the highest
+    /// opened stream falls below half the window (RFC 9000 4.6 auto-tuning).
     pub fn shouldUpdate(self: *const StreamLimit) bool {
-        return self.max - self.opened < self.max / 2;
+        return self.max - self.opened < self.window / 2;
     }
 
-    pub fn grant(self: *StreamLimit, increment: u64) u64 {
-        self.max += increment;
+    /// Slide the cap to `opened + window` and record it; the new value to advertise.
+    pub fn grant(self: *StreamLimit) u64 {
+        self.max = self.opened + self.window;
         return self.max;
     }
 };
@@ -163,4 +170,16 @@ test "stream limit rejects too many streams" {
     try l.onOpened(0);
     try l.onOpened(2);
     try std.testing.expectError(error.StreamLimitError, l.onOpened(3));
+}
+
+test "stream limit re-advertises once headroom runs low" {
+    var l = StreamLimit.init(4);
+    try std.testing.expect(!l.shouldUpdate());
+    try l.onOpened(0);
+    try l.onOpened(1);
+    try l.onOpened(2); // 3 of 4 opened: headroom 1 < window/2 (2)
+    try std.testing.expect(l.shouldUpdate());
+    try std.testing.expectEqual(@as(u64, 7), l.grant()); // opened 3 + window 4
+    try std.testing.expect(!l.shouldUpdate());
+    try l.onOpened(6); // the newly granted ids are now usable
 }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -388,9 +388,9 @@ const H3Engine = struct {
             const hdr = core.quic.packet.parseLong(dgram) catch
                 return py.raise(exceptions.RemoteProtocolError, "malformed QUIC Initial packet");
             const q = gpa.create(QuicConnection) catch return c.PyErr_NoMemory();
-            q.* = QuicConnection.initServer(gpa, hdr.dcid, self.config.flightConfig()) catch {
+            q.* = QuicConnection.initServer(gpa, hdr.dcid, self.config.flightConfig()) catch |e| {
                 gpa.destroy(q);
-                return c.PyErr_NoMemory();
+                return exceptions.raiseQuic(e);
             };
             const h = gpa.create(H3Connection) catch {
                 q.deinit();

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -11,24 +11,24 @@ import zttp
 SERVER_CONFIG = {
     "certificate": b"\xcc" * 48,
     "private_key": b"\x42" * 32,
-    "transport_params": b"\x00\x01",
+    "transport_params": b"\x08\x01\x08",
     "random": b"\xab" * 32,
     "ephemeral_seed": b"\x33" * 32,
 }
 
 # Real handshake datagrams a client produces against SERVER_CONFIG, captured from the
-# Zig transport's test builders (RFC 8448 client key share; client transport params
-# grant initial_max_data 65536 so the server can send a response). The ClientHello
-# rides an Initial, the Finished a Handshake packet, the GET request a 1-RTT packet -
-# each sealed with the keys the real handshake derives, so nothing is forged with test
-# keys. dcid is 11 22 33 44.
+# Zig transport's test builders (RFC 8448 client key share; the client transport params
+# grant initial_max_data 65536 so the server can send a response, the server advertises
+# initial_max_streams_bidi 8). The ClientHello rides an Initial, the Finished a Handshake
+# packet, the GET request a 1-RTT packet - each sealed with the keys the real handshake
+# derives, so nothing is forged with test keys. dcid is 11 22 33 44.
 CLIENT_HELLO = bytes.fromhex(
     "c50000000104112233440000408f483e116484af5563d1a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0cbccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe883b8cddc289b6944cd68dfb2ecf25008c78255eef81817c25a8"
 )
 CLIENT_FINISHED = bytes.fromhex(
-    "ec00000001041122334400382752efb16776726f129f2798e7cee3ab080e10925a8331338a626e045753f05e8faf92e68fa71b216c74ad62328c98266e9a02dfc1e04b73"
+    "ef00000001041122334400389752efb16776726f311fc8f83518999b83e43201874da34629db68e1a148f7270cb0277e2cd047788f1e7c69e7aa96f6f64dc4f02a3aff97"
 )
-GET_REQUEST = bytes.fromhex("43112233444d9d682e5bf0ebaf0a11b98027c97bf97fd885a8313873436ad9bbdfce745335")
+GET_REQUEST = bytes.fromhex("53112233447b8268f6a6591dc327e27a69cbfb7b3fa33d1bfce2894c49f816ecbace313565")
 
 
 def make_server() -> zttp.H3Connection:


### PR DESCRIPTION
Enforce and replenish the advertised bidirectional stream limit (RFC 9000 4.6, MAX_STREAMS), the last DoS-hardening piece of the QUIC server: a peer could previously open unboundedly many request streams. The `flow.StreamLimit` was built and tested but never instantiated; this wires it in.

**Enforce exactly what we advertise.** `initServer` parses its own transport parameters and enforces precisely the `initial_max_streams_bidi` it puts on the wire, so the advertised and enforced values never diverge - absent means cap 0 (a conformant client opens no request stream), and a malformed own blob is surfaced as a protocol error rather than silently defaulted. Every newly opened client-bidi stream (via STREAM, RESET_STREAM, or STOP_SENDING) is charged against the cap; one beyond it is a `STREAM_LIMIT_ERROR`, surfaced as a `RemoteProtocolError`.

**Replenish as requests complete.** When a request stream finishes and frees a slot, the server re-advertises a higher cap once headroom runs low, so a long-lived connection serving many requests is not stranded at the initial limit. `StreamLimit` now mirrors `Window`: the cap slides above the highest opened stream.

The deterministic HTTP/3 test fixtures (and the captured handshake datagrams) were regenerated to advertise `initial_max_streams_bidi = 8`, since the server's transport parameters ride the handshake transcript.

All checks green: full Zig suite, ReleaseSafe, 211 Python tests, 100% coverage, ruff/mypy/zig-fmt. Each commit Codex-reviewed.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
