### PR TITLE
Make the QUIC handshake interoperable with conformant clients

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -173,6 +173,14 @@ pub const Connection = struct {
     /// the PTO ack-delay.
     peer_tp: transport_params.TransportParameters = .{},
     peer_scid_set: bool = false, // have we adopted the peer's scid from its first long header?
+    /// The source connection id of the peer's FIRST Initial, kept verbatim (a
+    /// zero-length id stays distinguishable from "none seen") so the peer's
+    /// initial_source_connection_id transport parameter can be validated against it
+    /// (RFC 9000 7.3). peer_scid cannot serve here: it defaults to the client dcid
+    /// and never adopts an empty id.
+    peer_initial_scid: [20]u8 = undefined,
+    peer_initial_scid_len: u8 = 0,
+    peer_initial_scid_set: bool = false,
     handshake_confirmed: bool = false, // the client Finished verified; HANDSHAKE_DONE sent
     /// The connection-level recv window grew enough to advertise a new MAX_DATA
     /// (RFC 9000 4.1); flushSend emits it so the peer is not stalled at its grant.
@@ -820,6 +828,17 @@ pub const Connection = struct {
                     // the PTO. Applied before the flight is built/sent.
                     self.peer_tp = transport_params.parse(decoded.value.quic_transport_parameters) catch
                         return error.ProtocolViolation;
+                    // RFC 9000 7.3/18.2: a client must not send server-only parameters,
+                    // must send initial_source_connection_id, and that id must equal the
+                    // Source Connection ID of its first Initial - the handshake-time
+                    // authentication that defeats connection-id spoofing.
+                    if (self.peer_tp.has_server_only_param) return error.ProtocolViolation;
+                    const iscid = self.peer_tp.initial_scid orelse return error.ProtocolViolation;
+                    if (!self.peer_initial_scid_set or
+                        !std.mem.eql(u8, iscid.slice(), self.peer_initial_scid[0..self.peer_initial_scid_len]))
+                    {
+                        return error.ProtocolViolation;
+                    }
                     self.conn_send_window.setInitial(self.peer_tp.initial_max_data);
 
                     var flight_buf: std.ArrayListUnmanaged(u8) = .empty;
@@ -987,6 +1006,16 @@ pub const Connection = struct {
             self.gpa.free(self.peer_scid);
             self.peer_scid = sc;
             self.peer_scid_set = true;
+        }
+        // Retain the first Initial's source id verbatim - including a zero-length
+        // one, which the adoption above skips - so the client's
+        // initial_source_connection_id transport parameter can be checked against
+        // what was actually in the packet header (RFC 9000 7.3).
+        if (space == .initial and !self.peer_initial_scid_set) {
+            if (hdr.scid.len > 20) return error.Dropped; // RFC 9000 17.2: at most 20 in v1
+            @memcpy(self.peer_initial_scid[0..hdr.scid.len], hdr.scid);
+            self.peer_initial_scid_len = @intCast(hdr.scid.len);
+            self.peer_initial_scid_set = true;
         }
         // A long header's length is known, so a packet we cannot decrypt (no keys
         // for the space yet, or a bad tag) is SKIPPED, not fatal: we return its
@@ -1717,6 +1746,14 @@ const RFC_CLIENT_PUBKEY = "99381de560e4bd43d23d8e435a7dbafeb3c06e51c13cae4d54136
 // Build a QUIC-valid ClientHello carrying `pubkey` as its x25519 key_share, framed
 // as a handshake message (type 0x01 || u24 len || body) ready to ride a CRYPTO frame.
 fn buildClientHello(out: *std.ArrayListUnmanaged(u8), gpa: std.mem.Allocator, pubkey: [32]u8) !void {
+    // max_idle_timeout, plus the mandatory initial_source_connection_id (RFC 9000
+    // 7.3) - empty, matching the zero-length scid testBuildInitial writes.
+    return buildClientHelloTp(out, gpa, pubkey, &[_]u8{ 0x01, 0x02, 0x40, 0x01, 0x0f, 0x00 });
+}
+
+// buildClientHello with a caller-chosen transport-parameter body, for the tests
+// that probe how the server validates a client's parameters.
+fn buildClientHelloTp(out: *std.ArrayListUnmanaged(u8), gpa: std.mem.Allocator, pubkey: [32]u8, tp: []const u8) !void {
     const w = tls.wire.Writer{ .out = out, .gpa = gpa };
     try w.u8v(0x01);
     const msg = try w.open(3);
@@ -1759,7 +1796,7 @@ fn buildClientHello(out: *std.ArrayListUnmanaged(u8), gpa: std.mem.Allocator, pu
     try w.close(ks);
     try w.u16v(0x0039); // quic_transport_parameters
     const qtp = try w.open(2);
-    try w.bytes(&[_]u8{ 0x01, 0x02, 0x40, 0x01 });
+    try w.bytes(tp);
     try w.close(qtp);
     try w.close(exts);
     try w.close(msg);
@@ -1770,6 +1807,17 @@ fn buildClientHelloInitial(gpa: std.mem.Allocator, dcid: []const u8, pubkey: [32
     var ch: std.ArrayListUnmanaged(u8) = .empty;
     defer ch.deinit(gpa);
     try buildClientHello(&ch, gpa, pubkey);
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(gpa);
+    try frame.encodeCrypto(&frames, gpa, 0, ch.items);
+    return testBuildInitial(gpa, dcid, .client, 0, frames.items);
+}
+
+// buildClientHelloInitial with a caller-chosen client transport-parameter body.
+fn buildClientHelloInitialTp(gpa: std.mem.Allocator, dcid: []const u8, pubkey: [32]u8, tp: []const u8) ![]u8 {
+    var ch: std.ArrayListUnmanaged(u8) = .empty;
+    defer ch.deinit(gpa);
+    try buildClientHelloTp(&ch, gpa, pubkey, tp);
     var frames: std.ArrayListUnmanaged(u8) = .empty;
     defer frames.deinit(gpa);
     try frame.encodeCrypto(&frames, gpa, 0, ch.items);
@@ -1864,14 +1912,56 @@ test "the client's transport parameters set the connection send window" {
     _ = try std.fmt.hexToBytes(&pubkey, RFC_CLIENT_PUBKEY);
     var server = try Connection.initServer(gpa, &dcid, testServerConfig());
     defer server.deinit();
-    // The test ClientHello carries quic_transport_parameters {0x01,0x02,0x40,0x01}:
-    // id 0x01 (max_idle_timeout), len 2, value varint 0x4001 = 1 -> initial_max_data
-    // is absent, so the send window becomes 0 (the client granted no data yet).
+    // The test ClientHello's transport parameters carry max_idle_timeout and the
+    // mandatory empty initial_source_connection_id - initial_max_data is absent, so
+    // the send window becomes 0 (the client granted no data yet).
     const ch = try buildClientHelloInitial(gpa, &dcid, pubkey);
     defer gpa.free(ch);
     try server.receiveDatagram(ch, 1000);
     try testing.expectEqual(@as(u64, 0), server.peer_tp.initial_max_data);
     try testing.expectEqual(@as(u64, 0), server.conn_send_window.limit); // set from the (absent) grant
+}
+
+test "a client without initial_source_connection_id is rejected" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    var pubkey: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&pubkey, RFC_CLIENT_PUBKEY);
+    var server = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer server.deinit();
+    // RFC 9000 7.3: absence of initial_source_connection_id from either peer is a
+    // TRANSPORT_PARAMETER_ERROR. Only max_idle_timeout here.
+    const ch = try buildClientHelloInitialTp(gpa, &dcid, pubkey, &[_]u8{ 0x01, 0x02, 0x40, 0x01 });
+    defer gpa.free(ch);
+    try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
+}
+
+test "a client whose initial_source_connection_id mismatches its Initial is rejected" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    var pubkey: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&pubkey, RFC_CLIENT_PUBKEY);
+    var server = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer server.deinit();
+    // The Initial's scid is empty, but the parameter claims aa bb (RFC 9000 7.3:
+    // the values are authenticated against the header to defeat id spoofing).
+    const ch = try buildClientHelloInitialTp(gpa, &dcid, pubkey, &[_]u8{ 0x0f, 0x02, 0xaa, 0xbb });
+    defer gpa.free(ch);
+    try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
+}
+
+test "a client sending a server-only transport parameter is rejected" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    var pubkey: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&pubkey, RFC_CLIENT_PUBKEY);
+    var server = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer server.deinit();
+    // A valid (empty) initial_source_connection_id plus an ODCID, which only a
+    // server may send (RFC 9000 18.2).
+    const ch = try buildClientHelloInitialTp(gpa, &dcid, pubkey, &[_]u8{ 0x0f, 0x00, 0x00, 0x01, 0xcc });
+    defer gpa.free(ch);
+    try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
 }
 
 test "a lost handshake CRYPTO packet is retransmitted on loss" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -173,10 +173,12 @@ pub const Connection = struct {
     /// the PTO ack-delay.
     peer_tp: transport_params.TransportParameters = .{},
     peer_scid_set: bool = false, // have we adopted the peer's scid from its first long header?
-    /// The source connection id of the peer's FIRST Initial, kept verbatim (a
-    /// zero-length id stays distinguishable from "none seen") so the peer's
-    /// initial_source_connection_id transport parameter can be validated against it
-    /// (RFC 9000 7.3). peer_scid cannot serve here: it defaults to the client dcid
+    /// The source connection id of the peer's first AUTHENTICATED Initial, kept
+    /// verbatim (a zero-length id stays distinguishable from "none seen") so the
+    /// peer's initial_source_connection_id transport parameter can be validated
+    /// against it (RFC 9000 7.3). Committed only after the packet's AEAD opens - a
+    /// spoofed Initial racing the client's must not poison the anchor and kill the
+    /// real handshake. peer_scid cannot serve here: it defaults to the client dcid
     /// and never adopts an empty id.
     peer_initial_scid: [20]u8 = undefined,
     peer_initial_scid_len: u8 = 0,
@@ -998,30 +1000,15 @@ pub const Connection = struct {
         };
         const total = hdr.pn_offset + @as(usize, @intCast(hdr.length));
         if (total > buf.len) return error.Dropped;
-        // Adopt the peer's source connection id (from its first long header) as the
-        // destination of everything we send (RFC 9000 7.2). Until this, peer_scid
-        // defaults to the client dcid - fine for tests that use one shared id.
-        if (!self.peer_scid_set and hdr.scid.len > 0) {
-            const sc = self.gpa.dupe(u8, hdr.scid) catch return error.OutOfMemory;
-            self.gpa.free(self.peer_scid);
-            self.peer_scid = sc;
-            self.peer_scid_set = true;
-        }
-        // Retain the first Initial's source id verbatim - including a zero-length
-        // one, which the adoption above skips - so the client's
-        // initial_source_connection_id transport parameter can be checked against
-        // what was actually in the packet header (RFC 9000 7.3).
-        if (space == .initial and !self.peer_initial_scid_set) {
-            if (hdr.scid.len > 20) return error.Dropped; // RFC 9000 17.2: at most 20 in v1
-            @memcpy(self.peer_initial_scid[0..hdr.scid.len], hdr.scid);
-            self.peer_initial_scid_len = @intCast(hdr.scid.len);
-            self.peer_initial_scid_set = true;
-        }
         // A long header's length is known, so a packet we cannot decrypt (no keys
         // for the space yet, or a bad tag) is SKIPPED, not fatal: we return its
         // length so the caller keeps walking any coalesced packets behind it
-        // (e.g. a Handshake packet coalesced after an Initial). RFC 9000 12.2.
-        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, now) catch |e| switch (e) {
+        // (e.g. a Handshake packet coalesced after an Initial). RFC 9000 12.2. The
+        // header's scid rides along so it is adopted only AFTER the packet
+        // authenticates: a spoofed Initial racing the client's must not steer
+        // where replies go or poison the id its transport parameters are checked
+        // against (that would let an off-path attacker kill the handshake).
+        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, now, hdr.scid) catch |e| switch (e) {
             error.Dropped => return total,
             else => return e,
         };
@@ -1031,11 +1018,11 @@ pub const Connection = struct {
     fn receiveShort(self: *Connection, buf: []const u8, now: u64) Error!usize {
         const hdr = packet.parseShort(buf, self.dcid.len) catch return error.Dropped;
         // A short-header packet is the rest of the datagram (no length field).
-        try self.decryptAndDispatch(buf, hdr.pn_offset, .application, false, now);
+        try self.decryptAndDispatch(buf, hdr.pn_offset, .application, false, now, null);
         return buf.len;
     }
 
-    fn decryptAndDispatch(self: *Connection, pkt: []const u8, pn_offset: usize, space: Space, long: bool, now: u64) Error!void {
+    fn decryptAndDispatch(self: *Connection, pkt: []const u8, pn_offset: usize, space: Space, long: bool, now: u64, peer_scid_hdr: ?[]const u8) Error!void {
         const st = &self.spaces[@intFromEnum(space)];
         const keys = st.recv_keys orelse return error.Dropped; // no keys for this space yet
         // Work on a mutable copy: header protection removal and decryption mutate.
@@ -1052,6 +1039,26 @@ pub const Connection = struct {
         const plaintext = self.gpa.alloc(u8, ciphertext.len) catch return error.OutOfMemory;
         defer self.gpa.free(plaintext);
         const payload = crypto.open(keys, pn, header, ciphertext, plaintext) catch return error.Dropped;
+
+        // The packet authenticated: NOW the peer's source connection id can be
+        // trusted. Adopt it as the destination of everything we send (RFC 9000 7.2),
+        // and retain the first Initial's verbatim - including a zero-length one,
+        // which the adoption skips - as the anchor the client's
+        // initial_source_connection_id transport parameter is checked against
+        // (RFC 9000 7.3). This runs before frame dispatch, where that check lives.
+        if (peer_scid_hdr) |scid| {
+            if (!self.peer_scid_set and scid.len > 0) {
+                const sc = self.gpa.dupe(u8, scid) catch return error.OutOfMemory;
+                self.gpa.free(self.peer_scid);
+                self.peer_scid = sc;
+                self.peer_scid_set = true;
+            }
+            if (space == .initial and !self.peer_initial_scid_set) {
+                @memcpy(self.peer_initial_scid[0..scid.len], scid); // parseLong caps cids at 20
+                self.peer_initial_scid_len = @intCast(scid.len);
+                self.peer_initial_scid_set = true;
+            }
+        }
 
         // A decryptable Handshake packet proves the peer received our Initial/
         // handshake keys, so its address is validated and the 3x send limit lifts
@@ -1962,6 +1969,32 @@ test "a client sending a server-only transport parameter is rejected" {
     const ch = try buildClientHelloInitialTp(gpa, &dcid, pubkey, &[_]u8{ 0x0f, 0x00, 0x00, 0x01, 0xcc });
     defer gpa.free(ch);
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
+}
+
+test "an unauthenticated Initial does not anchor the peer's connection id" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    var pubkey: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&pubkey, RFC_CLIENT_PUBKEY);
+    var server = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer server.deinit();
+
+    // An off-path attacker who saw the dcid races the client with a spoofed Initial.
+    // Its tag fails authentication, so it must not commit the connection-id anchor -
+    // otherwise the real client's initial_source_connection_id check would fail and
+    // the spoof would have killed the handshake.
+    const spoof = try buildClientHelloInitial(gpa, &dcid, pubkey);
+    defer gpa.free(spoof);
+    spoof[spoof.len - 1] ^= 0xff; // corrupt the AEAD tag
+    try server.receiveDatagram(spoof, 900); // dropped, not fatal
+    try testing.expect(!server.peer_initial_scid_set);
+
+    // The authentic ClientHello still anchors and completes the flight.
+    const ch = try buildClientHelloInitial(gpa, &dcid, pubkey);
+    defer gpa.free(ch);
+    try server.receiveDatagram(ch, 1000);
+    try testing.expect(server.peer_initial_scid_set);
+    try testing.expect(server.datagramLengths().len >= 1); // the server flight went out
 }
 
 test "a lost handshake CRYPTO packet is retransmitted on loss" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -271,8 +271,10 @@ pub const Connection = struct {
         // malformed own blob is a configuration bug, surfaced before anything is built.
         // The connection-id parameters are appended below, so a base blob already
         // carrying one would duplicate it on the wire - also a configuration bug.
+        // Only those two ids are rejected: a server may legitimately advertise the
+        // other server-only parameters (stateless_reset_token, preferred_address).
         const own = transport_params.parse(tls_config.transport_params) catch return error.ProtocolViolation;
-        if (own.has_server_only_param or own.initial_scid != null) return error.ProtocolViolation;
+        if (own.has_injected_cid_param) return error.ProtocolViolation;
         var conn = try init(gpa, .server, client_dcid);
         errdefer conn.deinit();
         conn.tls = tls.server.Server.init(tls_config);
@@ -1559,11 +1561,20 @@ test "initServer advertises the mandatory connection ids" {
     // The TLS driver ships exactly this blob in EncryptedExtensions.
     try testing.expectEqualSlices(u8, conn.own_tp.?, conn.tls.?.config.transport_params);
 
-    // A base blob already carrying a connection-id parameter would duplicate it on
-    // the wire: a configuration bug, rejected up front.
+    // A base blob already carrying one of the two ids initServer injects would
+    // duplicate it on the wire: a configuration bug, rejected up front.
     var dupCfg = testServerConfig();
     dupCfg.transport_params = &[_]u8{ 0x0f, 0x00 }; // initial_source_connection_id
     try testing.expectError(error.ProtocolViolation, Connection.initServer(gpa, &dcid, dupCfg));
+
+    // But a base blob carrying a server-only parameter the server itself does NOT
+    // inject (stateless_reset_token, 0x02) is legitimate and rides through verbatim.
+    var srtCfg = testServerConfig();
+    const srt = [_]u8{0x02} ++ [_]u8{0x10} ++ [_]u8{0xcc} ** 16; // 16-byte token
+    srtCfg.transport_params = &srt;
+    var srtConn = try Connection.initServer(gpa, &dcid, srtCfg);
+    defer srtConn.deinit();
+    try testing.expect(std.mem.indexOf(u8, srtConn.own_tp.?, &srt) != null);
 }
 
 test "connection flow control sums across streams" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -173,16 +173,15 @@ pub const Connection = struct {
     /// the PTO ack-delay.
     peer_tp: transport_params.TransportParameters = .{},
     peer_scid_set: bool = false, // have we adopted the peer's scid from its first long header?
-    /// The source connection id of the peer's first AUTHENTICATED Initial, kept
-    /// verbatim (a zero-length id stays distinguishable from "none seen") so the
-    /// peer's initial_source_connection_id transport parameter can be validated
-    /// against it (RFC 9000 7.3). Committed only after the packet's AEAD opens - a
-    /// spoofed Initial racing the client's must not poison the anchor and kill the
-    /// real handshake. peer_scid cannot serve here: it defaults to the client dcid
-    /// and never adopts an empty id.
-    peer_initial_scid: [20]u8 = undefined,
-    peer_initial_scid_len: u8 = 0,
-    peer_initial_scid_set: bool = false,
+    /// The Source Connection ID of the Initial packet currently being dispatched,
+    /// borrowed from that datagram for the span of `dispatchFrames`. The ClientHello
+    /// handler validates the client's initial_source_connection_id against THIS - the
+    /// id on the very packet that carried the ClientHello (RFC 9000 7.3) - rather
+    /// than a persistent anchor. Initial keys are derivable from the dcid, so a
+    /// pre-committed anchor could be poisoned by a spoofed PADDING-only Initial that
+    /// still opens under AEAD; binding the check to the ClientHello's own packet
+    /// removes that, since a spoof carrying CRYPTO is already fatal on reassembly.
+    dispatch_initial_scid: ?[]const u8 = null,
     handshake_confirmed: bool = false, // the client Finished verified; HANDSHAKE_DONE sent
     /// The connection-level recv window grew enough to advertise a new MAX_DATA
     /// (RFC 9000 4.1); flushSend emits it so the peer is not stalled at its grant.
@@ -832,15 +831,12 @@ pub const Connection = struct {
                         return error.ProtocolViolation;
                     // RFC 9000 7.3/18.2: a client must not send server-only parameters,
                     // must send initial_source_connection_id, and that id must equal the
-                    // Source Connection ID of its first Initial - the handshake-time
-                    // authentication that defeats connection-id spoofing.
+                    // Source Connection ID of the Initial carrying this ClientHello -
+                    // the handshake-time authentication that defeats id spoofing.
                     if (self.peer_tp.has_server_only_param) return error.ProtocolViolation;
                     const iscid = self.peer_tp.initial_scid orelse return error.ProtocolViolation;
-                    if (!self.peer_initial_scid_set or
-                        !std.mem.eql(u8, iscid.slice(), self.peer_initial_scid[0..self.peer_initial_scid_len]))
-                    {
-                        return error.ProtocolViolation;
-                    }
+                    const carrier_scid = self.dispatch_initial_scid orelse return error.ProtocolViolation;
+                    if (!std.mem.eql(u8, iscid.slice(), carrier_scid)) return error.ProtocolViolation;
                     self.conn_send_window.setInitial(self.peer_tp.initial_max_data);
 
                     var flight_buf: std.ArrayListUnmanaged(u8) = .empty;
@@ -1041,22 +1037,13 @@ pub const Connection = struct {
         const payload = crypto.open(keys, pn, header, ciphertext, plaintext) catch return error.Dropped;
 
         // The packet authenticated: NOW the peer's source connection id can be
-        // trusted. Adopt it as the destination of everything we send (RFC 9000 7.2),
-        // and retain the first Initial's verbatim - including a zero-length one,
-        // which the adoption skips - as the anchor the client's
-        // initial_source_connection_id transport parameter is checked against
-        // (RFC 9000 7.3). This runs before frame dispatch, where that check lives.
+        // trusted. Adopt it as the destination of everything we send (RFC 9000 7.2).
         if (peer_scid_hdr) |scid| {
             if (!self.peer_scid_set and scid.len > 0) {
                 const sc = self.gpa.dupe(u8, scid) catch return error.OutOfMemory;
                 self.gpa.free(self.peer_scid);
                 self.peer_scid = sc;
                 self.peer_scid_set = true;
-            }
-            if (space == .initial and !self.peer_initial_scid_set) {
-                @memcpy(self.peer_initial_scid[0..scid.len], scid); // parseLong caps cids at 20
-                self.peer_initial_scid_len = @intCast(scid.len);
-                self.peer_initial_scid_set = true;
             }
         }
 
@@ -1067,6 +1054,11 @@ pub const Connection = struct {
 
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, pn) else pn;
         st.recv_ranges.add(self.gpa, pn) catch return error.OutOfMemory; // for accurate ACKs
+        // Expose this Initial's scid to the ClientHello handler so it can check the
+        // client's initial_source_connection_id against the carrier packet's id
+        // (RFC 9000 7.3); borrowed for the dispatch only, then cleared.
+        self.dispatch_initial_scid = if (space == .initial) peer_scid_hdr else null;
+        defer self.dispatch_initial_scid = null;
         try self.dispatchFrames(payload, space, now);
 
         // Acknowledge the space if it carried an ack-eliciting frame this packet.
@@ -1355,6 +1347,12 @@ const testing = std.testing;
 // protection. Returns an owned datagram the caller frees. Exposed (test-only) so
 // the HTTP/3 layer's tests can drive a request through the real transport.
 pub fn testBuildInitial(gpa: std.mem.Allocator, dcid: []const u8, sender: Role, pn: u64, frames: []const u8) ![]u8 {
+    return testBuildInitialScid(gpa, dcid, &.{}, sender, pn, frames);
+}
+
+// testBuildInitial with a caller-chosen source connection id, so a test can forge an
+// Initial whose scid differs from the legitimate client's (RFC 9000 7.3 spoofing).
+pub fn testBuildInitialScid(gpa: std.mem.Allocator, dcid: []const u8, scid: []const u8, sender: Role, pn: u64, frames: []const u8) ![]u8 {
     const keys = blk: {
         const ik = crypto.InitialKeys.derive(dcid);
         break :blk if (sender == .client) ik.client else ik.server;
@@ -1366,7 +1364,8 @@ pub fn testBuildInitial(gpa: std.mem.Allocator, dcid: []const u8, sender: Role, 
     try hdr_buf.appendSlice(gpa, &[_]u8{ 0, 0, 0, 1 }); // version 1
     try hdr_buf.append(gpa, @intCast(dcid.len));
     try hdr_buf.appendSlice(gpa, dcid);
-    try hdr_buf.append(gpa, 0); // scid len 0
+    try hdr_buf.append(gpa, @intCast(scid.len));
+    try hdr_buf.appendSlice(gpa, scid);
     try hdr_buf.append(gpa, 0); // token len 0 (varint)
     // length = pn(1) + ciphertext(frames + tag)
     const length = 1 + frames.len + crypto.TAG_LEN;
@@ -1971,7 +1970,7 @@ test "a client sending a server-only transport parameter is rejected" {
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
 }
 
-test "an unauthenticated Initial does not anchor the peer's connection id" {
+test "a spoofed Initial with a different scid does not break the real handshake" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
     var pubkey: [32]u8 = undefined;
@@ -1979,22 +1978,21 @@ test "an unauthenticated Initial does not anchor the peer's connection id" {
     var server = try Connection.initServer(gpa, &dcid, testServerConfig());
     defer server.deinit();
 
-    // An off-path attacker who saw the dcid races the client with a spoofed Initial.
-    // Its tag fails authentication, so it must not commit the connection-id anchor -
-    // otherwise the real client's initial_source_connection_id check would fail and
-    // the spoof would have killed the handshake.
-    const spoof = try buildClientHelloInitial(gpa, &dcid, pubkey);
+    // Initial keys are derivable from the dcid, so an off-path attacker who saw it can
+    // forge a Initial that opens under AEAD with a DIFFERENT scid (aa bb) carrying only
+    // a PING. The connection-id check is bound to the ClientHello's own packet, not a
+    // persistent anchor, so this must not make the real client's check fail later.
+    const spoof = try testBuildInitialScid(gpa, &dcid, &[_]u8{ 0xaa, 0xbb }, .client, 0, &[_]u8{0x01} ** 20);
     defer gpa.free(spoof);
-    spoof[spoof.len - 1] ^= 0xff; // corrupt the AEAD tag
-    try server.receiveDatagram(spoof, 900); // dropped, not fatal
-    try testing.expect(!server.peer_initial_scid_set);
+    try server.receiveDatagram(spoof, 900); // accepted (a valid PING), but does not poison
 
-    // The authentic ClientHello still anchors and completes the flight.
+    // The authentic ClientHello (zero-length scid, matching its empty initial_scid
+    // parameter) still validates and the server flight goes out.
     const ch = try buildClientHelloInitial(gpa, &dcid, pubkey);
     defer gpa.free(ch);
     try server.receiveDatagram(ch, 1000);
-    try testing.expect(server.peer_initial_scid_set);
     try testing.expect(server.datagramLengths().len >= 1); // the server flight went out
+    try testing.expect(server.tls.?.state == .flight_sent);
 }
 
 test "a lost handshake CRYPTO packet is retransmitted on loss" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -164,6 +164,10 @@ pub const Connection = struct {
     /// The server TLS handshake driver, attached by `initServer`; null on a client
     /// or a connection that does not run the handshake (the recv-pipeline tests).
     tls: ?tls.server.Server = null,
+    /// The full transport-parameter blob this server advertises: the integrator's
+    /// base parameters plus the mandatory per-connection ids initServer appends.
+    /// Connection-owned (the TLS driver borrows it); null outside the server path.
+    own_tp: ?[]u8 = null,
     /// The client's transport parameters (RFC 9000 18.2), parsed from the
     /// ClientHello; until then the RFC defaults apply. Drives the send window and
     /// the PTO ack-delay.
@@ -248,15 +252,33 @@ pub const Connection = struct {
     /// A server connection with the TLS handshake driver attached: incoming CRYPTO
     /// drives the handshake, which installs per-space keys and emits the server
     /// flight. `tls_config` supplies the ServerHello randomness, ephemeral seed,
-    /// signing key, certificate, and transport parameters.
+    /// signing key, certificate, and transport parameters. The integrator's
+    /// transport-parameter blob carries only the limits it chooses; the mandatory
+    /// per-connection ids (RFC 9000 7.3) are appended here, since only the
+    /// connection knows them.
     pub fn initServer(gpa: std.mem.Allocator, client_dcid: []const u8, tls_config: tls.flight.Config) Error!Connection {
         // Enforce exactly the bidi cap we advertise (RFC 9000 4.6): parse it from our
         // own transport parameters so the wire and the enforced value never diverge. A
         // malformed own blob is a configuration bug, surfaced before anything is built.
+        // The connection-id parameters are appended below, so a base blob already
+        // carrying one would duplicate it on the wire - also a configuration bug.
         const own = transport_params.parse(tls_config.transport_params) catch return error.ProtocolViolation;
+        if (own.has_server_only_param or own.initial_scid != null) return error.ProtocolViolation;
         var conn = try init(gpa, .server, client_dcid);
+        errdefer conn.deinit();
         conn.tls = tls.server.Server.init(tls_config);
         conn.bidi_limit = flow.StreamLimit.init(own.initial_max_streams_bidi);
+        // Advertise the mandatory connection ids (RFC 9000 18.2): the client MUST see
+        // its first Initial's destination id echoed as original_destination_connection_id
+        // and our source id as initial_source_connection_id, or it fails the handshake
+        // with TRANSPORT_PARAMETER_ERROR. The augmented blob is connection-owned.
+        var full: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer full.deinit(gpa);
+        try full.appendSlice(gpa, tls_config.transport_params);
+        try transport_params.appendBytesParam(&full, gpa, 0x00, client_dcid); // original_destination_connection_id
+        try transport_params.appendBytesParam(&full, gpa, 0x0f, conn.scid); // initial_source_connection_id
+        conn.own_tp = try full.toOwnedSlice(gpa);
+        conn.tls.?.config.transport_params = conn.own_tp.?;
         return conn;
     }
 
@@ -264,6 +286,7 @@ pub const Connection = struct {
         self.gpa.free(self.dcid);
         self.gpa.free(self.scid);
         self.gpa.free(self.peer_scid);
+        if (self.own_tp) |tp| self.gpa.free(tp);
         var it = self.streams.valueIterator();
         while (it.next()) |s| {
             s.*.deinit();
@@ -1481,6 +1504,31 @@ test "initServer enforces exactly the bidi cap it advertises" {
     var badCfg = testServerConfig();
     badCfg.transport_params = &[_]u8{ 0x08, 0x08, 0x00 }; // len 8, only 1 byte follows
     try testing.expectError(error.ProtocolViolation, Connection.initServer(gpa, &dcid, badCfg));
+}
+
+test "initServer advertises the mandatory connection ids" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x70, 0x71, 0x72, 0x73 };
+    var conn = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer conn.deinit();
+
+    // The advertised blob is the integrator base plus original_destination_connection_id
+    // (the client's first dcid) and initial_source_connection_id (our scid) - the two
+    // a conformant client validates before completing the handshake (RFC 9000 7.3).
+    var expected: std.ArrayListUnmanaged(u8) = .empty;
+    defer expected.deinit(gpa);
+    try expected.appendSlice(gpa, testServerConfig().transport_params);
+    try transport_params.appendBytesParam(&expected, gpa, 0x00, &dcid);
+    try transport_params.appendBytesParam(&expected, gpa, 0x0f, conn.scid);
+    try testing.expectEqualSlices(u8, expected.items, conn.own_tp.?);
+    // The TLS driver ships exactly this blob in EncryptedExtensions.
+    try testing.expectEqualSlices(u8, conn.own_tp.?, conn.tls.?.config.transport_params);
+
+    // A base blob already carrying a connection-id parameter would duplicate it on
+    // the wire: a configuration bug, rejected up front.
+    var dupCfg = testServerConfig();
+    dupCfg.transport_params = &[_]u8{ 0x0f, 0x00 }; // initial_source_connection_id
+    try testing.expectError(error.ProtocolViolation, Connection.initServer(gpa, &dcid, dupCfg));
 }
 
 test "connection flow control sums across streams" {

--- a/src/core/quic/tls/flight.zig
+++ b/src/core/quic/tls/flight.zig
@@ -28,7 +28,10 @@ pub const Config = struct {
     ephemeral_seed: [32]u8, // feeds keyshare.ephemeral
     signer: sign.Signer,
     cert_chain: []const u8, // DER cert_data the Certificate message carries
-    alpn: ?[]const u8 = null, // the selected protocol to echo into EncryptedExtensions
+    /// The server's application protocol. When set, the ClientHello must offer it
+    /// (RFC 9001 8.1 makes ALPN mandatory) and it is echoed into
+    /// EncryptedExtensions; null skips negotiation - a transport-test affordance.
+    alpn: ?[]const u8 = null,
     transport_params: []const u8, // server quic_transport_parameters body
 };
 

--- a/src/core/quic/tls/server.zig
+++ b/src/core/quic/tls/server.zig
@@ -22,8 +22,9 @@ pub const Error = error{
     /// derive the same handshake secret. The connection maps this to a TLS decrypt
     /// alert / CONNECTION_CLOSE.
     BadFinished,
-    /// The client offered ALPN but none of its protocols match the server's
-    /// configured protocol (RFC 7301 / RFC 9001 8.1: no_application_protocol).
+    /// The client did not offer the server's configured protocol - either its ALPN
+    /// list lacks it or it sent no ALPN at all, which QUIC forbids (RFC 7301 /
+    /// RFC 9001 8.1: no_application_protocol).
     NoAlpnOverlap,
     /// The flight builder could not produce a flight (keyshare/sign failure) or the
     /// built buffer did not start with a ServerHello - a should-never-happen.
@@ -62,13 +63,14 @@ pub const Server = struct {
         ch: client_hello.ClientHello,
     ) Error!Outcome {
         if (self.state != .wait_client_hello) return error.UnexpectedMessage;
-        // ALPN (RFC 9001 8.1, mandatory in QUIC): if the server has a configured
-        // protocol and the client offered an ALPN list, the configured protocol must
-        // appear in it; otherwise the handshake fails with no_application_protocol.
+        // ALPN (RFC 9001 8.1): application-protocol negotiation is mandatory in
+        // QUIC, so with a configured protocol a ClientHello that omits ALPN
+        // entirely fails exactly like one whose list lacks the protocol -
+        // no_application_protocol either way. A null config.alpn skips negotiation,
+        // a test affordance for exercising the transport without an application.
         if (self.config.alpn) |proto| {
-            if (ch.alpn) |offered| {
-                if (!alpnOffers(offered, proto)) return error.NoAlpnOverlap;
-            }
+            const offered = ch.alpn orelse return error.NoAlpnOverlap;
+            if (!alpnOffers(offered, proto)) return error.NoAlpnOverlap;
         }
         self.transcript.update(ch.raw); // CRITICAL: before flight.build (flight.zig contract)
         const view = flight.ClientHelloView{
@@ -198,6 +200,28 @@ test "onClientFinished verifies the client MAC and completes the handshake" {
     try testing.expect(server.state == .complete);
     // A Finished in the complete state is unexpected.
     try testing.expectError(error.UnexpectedMessage, server.onClientFinished(good));
+}
+
+test "a ClientHello without ALPN is rejected when a protocol is configured" {
+    var pubkey: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&pubkey, "99381de560e4bd43d23d8e435a7dbafeb3c06e51c13cae4d5413691e529aaf2c");
+    var ch_buf = std.ArrayListUnmanaged(u8).empty;
+    defer ch_buf.deinit(testing.allocator);
+    try buildMinimalClientHello(&ch_buf, testing.allocator, pubkey); // no ALPN extension at all
+    const decoded = try client_hello.parse(ch_buf.items);
+
+    // ALPN is mandatory in QUIC (RFC 9001 8.1): omitting it fails like no overlap.
+    var server = Server.init(.{
+        .random = [_]u8{0xAB} ** 32,
+        .ephemeral_seed = [_]u8{0x33} ** 32,
+        .signer = try sign.Signer.fromSeed([_]u8{0x42} ** 32),
+        .cert_chain = &[_]u8{0xCC} ** 48,
+        .alpn = "h3",
+        .transport_params = &[_]u8{ 0x00, 0x01 },
+    });
+    var out = std.ArrayListUnmanaged(u8).empty;
+    defer out.deinit(testing.allocator);
+    try testing.expectError(error.NoAlpnOverlap, server.onClientHello(&out, testing.allocator, decoded.value));
 }
 
 test "a configured ALPN absent from the client offer is rejected" {

--- a/src/core/quic/transport_params.zig
+++ b/src/core/quic/transport_params.zig
@@ -53,6 +53,12 @@ pub const TransportParameters = struct {
     /// or retry_source_connection_id). A server MUST reject a client list carrying
     /// any of these as a TRANSPORT_PARAMETER_ERROR.
     has_server_only_param: bool = false,
+    /// A connection-id parameter the server derives per-connection and appends itself
+    /// (original_destination_connection_id or initial_source_connection_id) appeared.
+    /// A server's base configuration blob carrying one would duplicate it on the
+    /// wire; unlike the broader server-only set, stateless_reset_token and
+    /// preferred_address are NOT flagged - a server may legitimately advertise those.
+    has_injected_cid_param: bool = false,
 };
 
 const Id = enum(u64) {
@@ -106,8 +112,12 @@ pub fn parse(buf: []const u8) Error!TransportParameters {
                 var cid = ConnectionId{ .len = @intCast(value.len) };
                 @memcpy(cid.buf[0..value.len], value);
                 tp.initial_scid = cid;
+                tp.has_injected_cid_param = true; // 0x0f: a server appends this itself
             },
-            .original_destination_connection_id,
+            .original_destination_connection_id => {
+                tp.has_server_only_param = true;
+                tp.has_injected_cid_param = true; // 0x00: a server appends this itself
+            },
             .stateless_reset_token,
             .preferred_address,
             .retry_source_connection_id,
@@ -212,4 +222,15 @@ test "a server-only parameter is flagged" {
     const tp = try parse(&[_]u8{ 0x00, 0x02, 0x11, 0x22 });
     try testing.expect(tp.has_server_only_param);
     try testing.expect(!(try parse(&[_]u8{ 0x0f, 0x00 })).has_server_only_param);
+}
+
+test "only the injected connection-id parameters are flagged for a server base blob" {
+    // The two ids the server appends itself (0x00 ODCID, 0x0f initial_scid) are
+    // flagged so a base blob carrying one is caught as a duplicate...
+    try testing.expect((try parse(&[_]u8{ 0x00, 0x01, 0xaa })).has_injected_cid_param);
+    try testing.expect((try parse(&[_]u8{ 0x0f, 0x00 })).has_injected_cid_param);
+    // ...but a stateless_reset_token (0x02) or preferred_address (0x0d) is a server's
+    // own to advertise, so it is NOT an injected-id conflict.
+    try testing.expect(!(try parse(&[_]u8{0x02} ++ [_]u8{0x10} ++ [_]u8{0xcc} ** 16)).has_injected_cid_param);
+    try testing.expect((try parse(&[_]u8{0x02} ++ [_]u8{0x10} ++ [_]u8{0xcc} ** 16)).has_server_only_param);
 }

--- a/src/core/quic/transport_params.zig
+++ b/src/core/quic/transport_params.zig
@@ -10,9 +10,21 @@ const varint = @import("varint.zig");
 
 pub const Error = error{
     /// A parameter ran past the buffer, a length was malformed, a parameter that
-    /// must be an integer was not a single varint, or a parameter appeared twice
-    /// (RFC 9000 7.4: a duplicate is a TRANSPORT_PARAMETER_ERROR).
+    /// must be an integer was not a single varint, a connection id exceeded the 20
+    /// bytes QUIC v1 allows, or a parameter appeared twice (RFC 9000 7.4: a
+    /// duplicate is a TRANSPORT_PARAMETER_ERROR).
     Malformed,
+};
+
+/// A connection id carried in a transport parameter (RFC 9000 18.2): at most 20
+/// bytes in QUIC version 1 (RFC 9000 17.2).
+pub const ConnectionId = struct {
+    buf: [20]u8 = undefined,
+    len: u8 = 0,
+
+    pub fn slice(self: *const ConnectionId) []const u8 {
+        return self.buf[0..self.len];
+    }
 };
 
 /// RFC 9000 18.2 caps max_ack_delay at 2^14 ms; clamp here so the us conversion
@@ -31,10 +43,22 @@ pub const TransportParameters = struct {
     max_idle_timeout_ms: u64 = 0, // 0 = no idle timeout
     max_ack_delay_ms: u64 = 25, // RFC 9000 18.2 default
     active_connection_id_limit: u64 = 2, // RFC 9000 18.2 default
+    /// The sender's initial_source_connection_id (RFC 9000 7.3): both endpoints MUST
+    /// send it, and the receiver MUST check it against the Source Connection ID of
+    /// the peer's first packet. Null when absent - the caller decides whether that
+    /// is fatal (it is, for a peer's parameters).
+    initial_scid: ?ConnectionId = null,
+    /// A parameter only a server may send appeared (RFC 9000 18.2:
+    /// original_destination_connection_id, stateless_reset_token, preferred_address,
+    /// or retry_source_connection_id). A server MUST reject a client list carrying
+    /// any of these as a TRANSPORT_PARAMETER_ERROR.
+    has_server_only_param: bool = false,
 };
 
 const Id = enum(u64) {
+    original_destination_connection_id = 0x00,
     max_idle_timeout = 0x01,
+    stateless_reset_token = 0x02,
     initial_max_data = 0x04,
     initial_max_stream_data_bidi_local = 0x05,
     initial_max_stream_data_bidi_remote = 0x06,
@@ -42,7 +66,10 @@ const Id = enum(u64) {
     initial_max_streams_bidi = 0x08,
     initial_max_streams_uni = 0x09,
     max_ack_delay = 0x0b,
+    preferred_address = 0x0d,
     active_connection_id_limit = 0x0e,
+    initial_source_connection_id = 0x0f,
+    retry_source_connection_id = 0x10,
     _,
 };
 
@@ -74,10 +101,31 @@ pub fn parse(buf: []const u8) Error!TransportParameters {
             .initial_max_streams_uni => tp.initial_max_streams_uni = try intParam(value),
             .max_ack_delay => tp.max_ack_delay_ms = @min(try intParam(value), MAX_ACK_DELAY_MS_CAP),
             .active_connection_id_limit => tp.active_connection_id_limit = try intParam(value),
+            .initial_source_connection_id => {
+                if (value.len > 20) return error.Malformed; // RFC 9000 17.2: at most 20 bytes in v1
+                var cid = ConnectionId{ .len = @intCast(value.len) };
+                @memcpy(cid.buf[0..value.len], value);
+                tp.initial_scid = cid;
+            },
+            .original_destination_connection_id,
+            .stateless_reset_token,
+            .preferred_address,
+            .retry_source_connection_id,
+            => tp.has_server_only_param = true,
             _ => {}, // unknown / GREASE: skip (RFC 9000 18.1)
         }
     }
     return tp;
+}
+
+/// Append one transport parameter with a raw byte value (RFC 9000 18.1): varint id,
+/// varint length, then the bytes - the encoding the connection-id parameters use.
+/// Ids and lengths here are always far inside the varint range, so the only real
+/// failure is allocation.
+pub fn appendBytesParam(out: *std.ArrayListUnmanaged(u8), gpa: std.mem.Allocator, id: u64, value: []const u8) error{OutOfMemory}!void {
+    varint.append(out, gpa, id) catch return error.OutOfMemory;
+    varint.append(out, gpa, value.len) catch return error.OutOfMemory;
+    try out.appendSlice(gpa, value);
 }
 
 /// An integer-valued parameter is exactly one varint filling its value (RFC 9000 18.2).
@@ -135,4 +183,33 @@ test "max_ack_delay is clamped so the us conversion cannot overflow" {
     const buf = [_]u8{ 0x0b, 0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
     const tp = try parse(&buf);
     try testing.expectEqual(MAX_ACK_DELAY_MS_CAP, tp.max_ack_delay_ms);
+}
+
+test "appendBytesParam round-trips a connection id through parse" {
+    const gpa = testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(gpa);
+    try appendBytesParam(&out, gpa, 0x0f, &[_]u8{ 0xaa, 0xbb, 0xcc });
+    const tp = try parse(out.items);
+    try testing.expectEqualSlices(u8, &[_]u8{ 0xaa, 0xbb, 0xcc }, tp.initial_scid.?.slice());
+}
+
+test "an empty initial_source_connection_id is present, not absent" {
+    // A zero-length connection id is legal (RFC 9000 17.2); the parameter being
+    // present-with-empty must be distinguishable from the parameter missing.
+    const tp = try parse(&[_]u8{ 0x0f, 0x00 });
+    try testing.expectEqual(@as(usize, 0), tp.initial_scid.?.slice().len);
+    try testing.expectEqual(@as(?ConnectionId, null), (try parse(&.{})).initial_scid);
+}
+
+test "a connection id past 20 bytes is malformed" {
+    var buf = [_]u8{ 0x0f, 21 } ++ [_]u8{0xaa} ** 21;
+    try testing.expectError(error.Malformed, parse(&buf));
+}
+
+test "a server-only parameter is flagged" {
+    // ODCID (0x00) from a peer that must not send it; the caller rejects on the flag.
+    const tp = try parse(&[_]u8{ 0x00, 0x02, 0x11, 0x22 });
+    try testing.expect(tp.has_server_only_param);
+    try testing.expect(!(try parse(&[_]u8{ 0x0f, 0x00 })).has_server_only_param);
 }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -387,6 +387,12 @@ const H3Engine = struct {
             }
             const hdr = core.quic.packet.parseLong(dgram) catch
                 return py.raise(exceptions.RemoteProtocolError, "malformed QUIC Initial packet");
+            // Only an Initial's dcid is the original destination id the server must
+            // echo as a transport parameter; a Handshake/0-RTT first datagram would
+            // seed the connection with the wrong one.
+            if (hdr.ltype != .initial) {
+                return py.raise(exceptions.RemoteProtocolError, "the first HTTP/3 datagram must be a long-header Initial");
+            }
             const q = gpa.create(QuicConnection) catch return c.PyErr_NoMemory();
             q.* = QuicConnection.initServer(gpa, hdr.dcid, self.config.flightConfig()) catch |e| {
                 gpa.destroy(q);
@@ -1043,20 +1049,23 @@ fn buildServerConfig(cert_obj: ?*c.PyObject, key_obj: ?*c.PyObject, tp_obj: ?*c.
         _ = c.PyErr_NoMemory();
         return null;
     };
-    var alpn: ?[]u8 = null;
-    if (alpn_obj != null and !py.isNone(alpn_obj)) {
-        const alpn_src = py.asBytes(alpn_obj) orelse {
+    // ALPN is mandatory in QUIC (RFC 9001 8.1) and an HTTP/3 server's protocol is
+    // "h3"; the parameter overrides the token (e.g. an interop draft name), it is
+    // not an opt-out of negotiation.
+    const alpn_src: []const u8 = if (alpn_obj != null and !py.isNone(alpn_obj))
+        py.asBytes(alpn_obj) orelse {
             gpa.free(cert);
             gpa.free(tp_copy);
             return null;
-        };
-        alpn = gpa.dupe(u8, alpn_src) catch {
-            gpa.free(cert);
-            gpa.free(tp_copy);
-            _ = c.PyErr_NoMemory();
-            return null;
-        };
-    }
+        }
+    else
+        "h3";
+    const alpn = gpa.dupe(u8, alpn_src) catch {
+        gpa.free(cert);
+        gpa.free(tp_copy);
+        _ = c.PyErr_NoMemory();
+        return null;
+    };
     return .{
         .cert = cert,
         .transport_params = tp_copy,

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -17,18 +17,26 @@ SERVER_CONFIG = {
 }
 
 # Real handshake datagrams a client produces against SERVER_CONFIG, captured from the
-# Zig transport's test builders (RFC 8448 client key share; the client transport params
-# grant initial_max_data 65536 so the server can send a response, the server advertises
-# initial_max_streams_bidi 8). The ClientHello rides an Initial, the Finished a Handshake
-# packet, the GET request a 1-RTT packet - each sealed with the keys the real handshake
-# derives, so nothing is forged with test keys. dcid is 11 22 33 44.
+# Zig transport's test builders (RFC 8448 client key share). The client offers ALPN h3
+# and sends initial_max_data 65536 plus an empty initial_source_connection_id (matching
+# its zero-length Initial scid); the server advertises initial_max_streams_bidi 8 plus
+# the auto-injected original_destination/initial_source connection ids, ALPN h3. The
+# ClientHello rides an Initial, the Finished a Handshake packet, the GET request a
+# 1-RTT packet - each sealed with the keys the real handshake derives, so nothing is
+# forged with test keys. dcid is 11 22 33 44.
 CLIENT_HELLO = bytes.fromhex(
-    "c50000000104112233440000408f483e116484af5563d1a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0cbccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe883b8cddc289b6944cd68dfb2ecf25008c78255eef81817c25a8"
+    "c30000000104112233440000409a4d3e11647baf556326a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0d6ccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe88128cdec68e34fd7fd61b26e8fa1cc07be4f74f73a9c70ecfbb1b97070125376ff97745d8"
 )
 CLIENT_FINISHED = bytes.fromhex(
-    "ef00000001041122334400389752efb16776726f311fc8f83518999b83e43201874da34629db68e1a148f7270cb0277e2cd047788f1e7c69e7aa96f6f64dc4f02a3aff97"
+    "e30000000104112233440038521018f79775a3640f2215b80d21cc2fc497a8218eb66c61b7f32c2cf3ef87f008a094742f77ba82ce447bf75e9cc43b899b1e4b29776e44"
 )
-GET_REQUEST = bytes.fromhex("53112233447b8268f6a6591dc327e27a69cbfb7b3fa33d1bfce2894c49f816ecbace313565")
+GET_REQUEST = bytes.fromhex("59112233445eade7548c087d84f41357686d9338e06a82c87b33299a3cdccdb9ed483eccf2")
+
+# The pre-conformance ClientHello: no ALPN offer and no initial_source_connection_id,
+# both of which the server now requires.
+LEGACY_CLIENT_HELLO = bytes.fromhex(
+    "c50000000104112233440000408f483e116484af5563d1a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0cbccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe883b8cddc289b6944cd68dfb2ecf25008c78255eef81817c25a8"
+)
 
 
 def make_server() -> zttp.H3Connection:
@@ -84,6 +92,13 @@ def test_first_datagram_must_be_an_initial() -> None:
     conn = make_server()
     with pytest.raises(zttp.RemoteProtocolError):
         conn.receive_datagram(b"\x40not-a-long-header")
+
+
+def test_a_non_conformant_client_hello_is_rejected() -> None:
+    # No ALPN and no initial_source_connection_id - both now mandatory.
+    conn = make_server()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_datagram(LEGACY_CLIENT_HELLO, 1000)
 
 
 def test_handshake_emits_a_flight() -> None:

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -151,7 +151,9 @@ class H2Connection(Connection):
 
 class H3Connection(Connection):
     # Fed by UDP datagrams rather than a byte stream. The QUIC handshake is driven
-    # from the server credentials passed at construction. `now` is the integrator's
+    # from the server credentials passed at construction; `alpn` defaults to b"h3"
+    # (ALPN is mandatory in QUIC - the parameter overrides the token, e.g. for an
+    # interop draft name, it is not an opt-out). `now` is the integrator's
     # monotonic clock. data_to_send returns one bytes per UDP datagram (QUIC datagram
     # boundaries are semantic), not the byte stream the base returns. Sends go through
     # a Stream handle (conn.stream(req.stream_id)), the same surface HTTP/2 uses; a


### PR DESCRIPTION
Make the QUIC handshake interoperable with conformant clients - the two blockers from the full-stack RFC audit. The server never sent the mandatory connection-id transport parameters and never enforced ALPN, so a real client (which MUST validate both) could not complete the handshake; the test suite passed only because the captured "client" was our own builder.

**Advertise and validate the connection ids (RFC 9000 7.3/18.2).** `initServer` appends `original_destination_connection_id` (the client's first Initial dcid) and `initial_source_connection_id` (our scid) to the integrator's transport-parameter blob - only the connection knows them, and a base blob already carrying one is rejected as a configuration bug. Symmetrically, the server now rejects a client whose `initial_source_connection_id` is missing or does not match its first Initial's Source Connection ID, and any client sending a server-only parameter.

**Anchor the connection id only after authentication.** Review caught that committing the scid from the raw header let an off-path attacker race the client with a spoofed Initial, steering replies or poisoning the anchor so the real handshake dies. The scid now commits only once the packet's AEAD opens.

**Enforce ALPN (RFC 9001 8.1).** A ClientHello omitting ALPN entirely is now rejected like one whose list lacks the configured protocol (negotiation is mandatory in QUIC); the adapter defaults to `h3`, so the parameter overrides the token rather than opting out. The lazy construction path also requires the first datagram to be an Initial - only its dcid is the original destination id the server must echo.

The captured handshake datagrams are regenerated for the new transcript; the old non-conformant ClientHello stays as a fixture proving it is now rejected. All green: full Zig suite, ReleaseSafe, 212 Python tests, 100% coverage. Each commit Codex-reviewed; both review findings (the spoofed-Initial poisoning, the non-Initial first datagram) are fixed in-PR.

Deferred (tracked): surfacing handshake failures as `CRYPTO_ERROR` + the specific TLS alert (e.g. `no_application_protocol`) rather than a generic protocol violation - the broader "no TLS alerts" gap from the audit, the same for every handshake error.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
