### PR TITLE
Open the server's QPACK encoder and decoder streams

### DIFF
--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -72,6 +72,9 @@ const MAX_FIELD_SECTION_SIZE: u64 = 1 << 16;
 const CONTROL_STREAM_ID: u64 = 3;
 const QPACK_ENCODER_STREAM_ID: u64 = 7;
 const QPACK_DECODER_STREAM_ID: u64 = 11;
+/// The count of server-initiated uni streams HTTP/3 always opens (the three above);
+/// a peer must grant at least this many in initial_max_streams_uni.
+const SERVER_UNI_STREAMS: u64 = 3;
 
 pub const Connection = struct {
     gpa: std.mem.Allocator,
@@ -171,6 +174,13 @@ pub const Connection = struct {
     /// content; the QPACK streams carry no instructions (table capacity 0).
     pub fn initiateControl(self: *Connection) Error!void {
         if (self.control_sent) return;
+        // HTTP/3 needs three server-initiated uni streams (control + the two QPACK
+        // streams). A peer that grants fewer cannot run HTTP/3, so rather than open
+        // streams past its initial_max_streams_uni - which it would answer with a
+        // STREAM_LIMIT_ERROR - close cleanly up front (RFC 9000 4.6 / RFC 9114 6.2).
+        if (self.qc.peerMaxStreamsUni() < SERVER_UNI_STREAMS) {
+            return self.fail(.general_protocol_error, "peer granted too few unidirectional streams for HTTP/3");
+        }
         var settings: std.ArrayListUnmanaged(u8) = .empty;
         defer settings.deinit(self.gpa);
         // SETTINGS_MAX_FIELD_SECTION_SIZE = our decode cap. QPACK capacity and
@@ -191,12 +201,9 @@ pub const Connection = struct {
         try self.streamSend(CONTROL_STREAM_ID, out.items, false);
         // The QPACK encoder/decoder streams: just the type byte each. At table
         // capacity 0 no encoder/decoder instructions are ever sent, but the streams
-        // must exist for the peer's QPACK to consider the connection well-formed.
-        // These three are the only server-initiated uni streams; HTTP/3 cannot run
-        // without them, so a conformant client grants initial_max_streams_uni >= 3.
-        // The send side does not yet track the peer's uni-stream limit (a follow-up,
-        // mirroring the inbound bidi StreamLimit) - moot until server push or a
-        // non-zero QPACK table would open more.
+        // must exist for the peer's QPACK to consider the connection well-formed. The
+        // grant was checked above; full credit accounting (a peer MAX_STREAMS raising
+        // the limit, blocking past it) is a follow-up, mooted here by the fixed count.
         try self.streamSend(QPACK_ENCODER_STREAM_ID, &.{@intFromEnum(h3_stream.UniStreamType.qpack_encoder)}, false);
         try self.streamSend(QPACK_DECODER_STREAM_ID, &.{@intFromEnum(h3_stream.UniStreamType.qpack_decoder)}, false);
     }
@@ -1476,6 +1483,22 @@ test "a reset after the response finished is a no-op" {
     try h3.resetStream(0, 0x010c);
     try qc.flushSend(1000);
     try testing.expectEqual(@as(usize, 0), qc.datagramsToSend().len); // nothing sent
+}
+
+test "a peer granting too few uni streams cannot run HTTP/3" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x3a, 0x3b, 0x3c, 0x3d };
+    var qc = try quic_conn.Connection.init(gpa, .server, &dcid);
+    defer qc.deinit();
+    quic_conn.testInstallAppKeys(&qc);
+    qc.peer_tp.initial_max_streams_uni = 2; // below the 3 HTTP/3 requires
+    var h3 = Connection.init(gpa, &qc);
+    defer h3.deinit();
+
+    // Opening the mandatory streams would exceed the peer's limit, so the connection
+    // is closed cleanly up front rather than provoking a STREAM_LIMIT_ERROR.
+    try testing.expectError(error.H3Error, h3.initiateControl());
+    try testing.expect(qc.closed);
 }
 
 test "the server opens its control stream with a SETTINGS frame" {

--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -65,9 +65,13 @@ const UniStream = struct {
 /// as SETTINGS_MAX_FIELD_SECTION_SIZE so it does not send a larger one.
 const MAX_FIELD_SECTION_SIZE: u64 = 1 << 16;
 
-/// The first server-initiated unidirectional stream id (RFC 9000 2.1): server uni
-/// ids are 4*N+3, so the control stream is 3.
+/// The server-initiated unidirectional stream ids (RFC 9000 2.1): server uni ids are
+/// 4*N+3. The control stream is the first; the two QPACK streams (RFC 9204 4.2) are
+/// the next two. A peer MUST open all three regardless of QPACK table capacity, so
+/// strict clients (nghttp3, quiche) abort if the encoder/decoder streams are missing.
 const CONTROL_STREAM_ID: u64 = 3;
+const QPACK_ENCODER_STREAM_ID: u64 = 7;
+const QPACK_DECODER_STREAM_ID: u64 = 11;
 
 pub const Connection = struct {
     gpa: std.mem.Allocator,
@@ -158,11 +162,13 @@ pub const Connection = struct {
         }
     }
 
-    /// Open our unidirectional control stream and send SETTINGS as its first frame
-    /// (RFC 9114 6.2.1, 7.2.4). A conformant peer treats the absence of our SETTINGS
-    /// as H3_MISSING_SETTINGS and may refuse to send requests, so this must precede
-    /// any response. Idempotent: the control stream is opened at most once. The
-    /// stream-type byte (0x00) prefixes the SETTINGS frame on the same stream.
+    /// Open our three server-initiated unidirectional streams (RFC 9114 6.2.1,
+    /// RFC 9204 4.2): the control stream carrying SETTINGS, plus the QPACK encoder and
+    /// decoder streams. A conformant peer treats the absence of our SETTINGS as
+    /// H3_MISSING_SETTINGS and may refuse to send requests, and strict clients abort
+    /// if the QPACK streams are missing - so all three must precede any response.
+    /// Idempotent: each is opened at most once. Each stream's type byte prefixes its
+    /// content; the QPACK streams carry no instructions (table capacity 0).
     pub fn initiateControl(self: *Connection) Error!void {
         if (self.control_sent) return;
         var settings: std.ArrayListUnmanaged(u8) = .empty;
@@ -176,8 +182,23 @@ pub const Connection = struct {
         defer out.deinit(self.gpa);
         out.append(self.gpa, @intFromEnum(h3_stream.UniStreamType.control)) catch return error.OutOfMemory;
         h3_frame.append(&out, self.gpa, .settings, settings.items) catch return error.OutOfMemory;
-        try self.streamSend(CONTROL_STREAM_ID, out.items, false);
+
+        // Commit BEFORE sending: a failure partway through (OOM) must not let a later
+        // call re-open the control stream and queue a second SETTINGS, which a peer
+        // treats as a connection error. A half-initialised connection is already
+        // degraded; re-attempting would corrupt it, not recover it.
         self.control_sent = true;
+        try self.streamSend(CONTROL_STREAM_ID, out.items, false);
+        // The QPACK encoder/decoder streams: just the type byte each. At table
+        // capacity 0 no encoder/decoder instructions are ever sent, but the streams
+        // must exist for the peer's QPACK to consider the connection well-formed.
+        // These three are the only server-initiated uni streams; HTTP/3 cannot run
+        // without them, so a conformant client grants initial_max_streams_uni >= 3.
+        // The send side does not yet track the peer's uni-stream limit (a follow-up,
+        // mirroring the inbound bidi StreamLimit) - moot until server push or a
+        // non-zero QPACK table would open more.
+        try self.streamSend(QPACK_ENCODER_STREAM_ID, &.{@intFromEnum(h3_stream.UniStreamType.qpack_encoder)}, false);
+        try self.streamSend(QPACK_DECODER_STREAM_ID, &.{@intFromEnum(h3_stream.UniStreamType.qpack_decoder)}, false);
     }
 
     /// Begin a graceful shutdown: send a GOAWAY on the control stream (RFC 9114 5.2)
@@ -1491,6 +1512,18 @@ test "the server opens its control stream with a SETTINGS frame" {
     try testing.expectEqual(h3_frame.FrameType.settings, f.frame.ftype);
     const s = try h3_stream.parseSettings(f.frame.payload);
     try testing.expectEqual(@as(u64, 1 << 16), s.max_field_section_size);
+
+    // The two QPACK streams are opened too (RFC 9204 4.2): stream 7 is the encoder
+    // (type 0x02), stream 11 the decoder (type 0x03), each just its type byte since
+    // table capacity 0 means no instructions ever follow.
+    const enc = peer.streamData(7);
+    const et = h3_stream.decodeUniType(enc).?;
+    try testing.expectEqual(h3_stream.UniStreamType.qpack_encoder, et.utype);
+    try testing.expectEqual(@as(usize, enc.len), et.len); // nothing after the type byte
+    const dec = peer.streamData(11);
+    const dt = h3_stream.decodeUniType(dec).?;
+    try testing.expectEqual(h3_stream.UniStreamType.qpack_decoder, dt.utype);
+    try testing.expectEqual(@as(usize, dec.len), dt.len);
 }
 
 test "shutdown sends a GOAWAY on the control stream after SETTINGS" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1313,6 +1313,16 @@ pub const Connection = struct {
         return self.streams.contains(id);
     }
 
+    /// How many unidirectional streams the peer's transport parameters let us open
+    /// (RFC 9000 4.6, initial_max_streams_uni). The HTTP/3 layer checks this before
+    /// opening its mandatory control + QPACK streams. Zero until a ClientHello is
+    /// parsed (the RFC default), so the no-handshake test path reports zero - those
+    /// tests set it directly. (A peer MAX_STREAMS would raise it; the send side does
+    /// not yet track that - see the outbound uni-limit follow-up.)
+    pub fn peerMaxStreamsUni(self: *const Connection) u64 {
+        return self.peer_tp.initial_max_streams_uni;
+    }
+
     /// Snapshot the ids of every stream the transport currently knows about, into
     /// `out`, returning how many were written (capped at `out.len`). The HTTP/3
     /// layer iterates these to advance each request stream's parse.
@@ -1427,6 +1437,10 @@ fn testAppKeys() crypto.Keys {
 // which is all the recv path needs) so it can decrypt a testBuildApp datagram.
 pub fn testInstallAppKeys(conn: *Connection) void {
     conn.installKeys(.application, testAppKeys(), testAppKeys());
+    // The no-handshake test path skips parsing a client's transport parameters, which
+    // would grant unidirectional-stream credit; stand in for a normal H3 client so the
+    // H3 layer can open its mandatory control + QPACK streams.
+    conn.peer_tp.initial_max_streams_uni = 16;
 }
 
 // Build a 1-RTT (short-header) Application packet carrying `frames`, sealed with

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -176,11 +176,13 @@ def test_http3_initiate_connection_sends_the_control_stream() -> None:
     conn.receive_datagram(CLIENT_FINISHED, 2000)
     conn.data_to_send()
 
-    # The control stream + SETTINGS leaves as a 1-RTT datagram; idempotent.
+    # The control stream + SETTINGS and the two QPACK streams (RFC 9204 4.2) leave as
+    # 1-RTT datagrams; idempotent. The byte-level stream contents are asserted in the
+    # Zig core test - here we only confirm the flush happens once.
     conn.initiate_connection()
     datagrams = conn.data_to_send()
     assert len(datagrams) >= 1
-    conn.initiate_connection()  # no second control stream
+    conn.initiate_connection()  # no second set of streams
     assert conn.data_to_send() == []
 
 

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -18,19 +18,20 @@ SERVER_CONFIG = {
 
 # Real handshake datagrams a client produces against SERVER_CONFIG, captured from the
 # Zig transport's test builders (RFC 8448 client key share). The client offers ALPN h3
-# and sends initial_max_data 65536 plus an empty initial_source_connection_id (matching
+# and grants initial_max_data 65536 plus initial_max_streams_uni 3 (so the server may
+# open its control + QPACK streams) plus an empty initial_source_connection_id (matching
 # its zero-length Initial scid); the server advertises initial_max_streams_bidi 8 plus
 # the auto-injected original_destination/initial_source connection ids, ALPN h3. The
 # ClientHello rides an Initial, the Finished a Handshake packet, the GET request a
 # 1-RTT packet - each sealed with the keys the real handshake derives, so nothing is
 # forged with test keys. dcid is 11 22 33 44.
 CLIENT_HELLO = bytes.fromhex(
-    "c30000000104112233440000409a4d3e11647baf556326a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0d6ccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe88128cdec68e34fd7fd61b26e8fa1cc07be4f74f73a9c70ecfbb1b97070125376ff97745d8"
+    "c30000000104112233440000409d523e116476af556323a75f6008b3bd937f3813bffcd39197feb9abf2d8e61aa5539d39a5ad06de38a6dc8d18f8fce9149a9ff0d9ccfed7b594a6ba97093d0bb9c28a356e228c80d2cb5b9d032fc90398e3d954fe2ae7920f670e3c6f5cdffb8c35d5c75e16582b613c34d322445b10160480d791fe88128cdec68e34fd7fd61b26ebfa1cc07be4f74f73519a1f918fbc5bae47921e0ed07b24d11df74b"
 )
 CLIENT_FINISHED = bytes.fromhex(
-    "e30000000104112233440038521018f79775a3640f2215b80d21cc2fc497a8218eb66c61b7f32c2cf3ef87f008a094742f77ba82ce447bf75e9cc43b899b1e4b29776e44"
+    "e50000000104112233440038cecc75a9cb1a1fd3d294606942f3fbd6ed69fcc56d4bf7a56c6704cbe3fdf52293209f8bb0fb3ea577cc8e0bce7ed4832243a04ed488b97f"
 )
-GET_REQUEST = bytes.fromhex("59112233445eade7548c087d84f41357686d9338e06a82c87b33299a3cdccdb9ed483eccf2")
+GET_REQUEST = bytes.fromhex("4f11223344f5655f22d79dbffd5180e4c1e863acb121a200a66fb43f3234da18b348111c30")
 
 # The pre-conformance ClientHello: no ALPN offer and no initial_source_connection_id,
 # both of which the server now requires.


### PR DESCRIPTION
Open the server's QPACK encoder and decoder unidirectional streams (RFC 9204 4.2), the audit's next interop fix after the handshake blockers. The server opened only its control stream, so strict clients (nghttp3, quiche) abort the connection before reading a response, even though our QPACK uses no dynamic table.

`initiateControl` now also opens stream 7 (encoder, type 0x02) and stream 11 (decoder, type 0x03), each carrying just its type byte - at table capacity 0 no instructions ever follow, but the streams must exist for the peer's QPACK to consider the connection well-formed. `control_sent` is committed before the sends so a failure partway through can never re-queue a second SETTINGS (a peer connection error). The inbound side already drained the peer's QPACK streams, so no change there.

Per-commit Codex review: the partial-failure idempotency gap is fixed; the second finding - the send side does not yet honor the peer's `initial_max_streams_uni` - is deferred (task tracked): every conformant HTTP/3 client grants at least the 3 server uni streams H3 needs, and the proper fix is a send-side uni StreamLimit mirroring the inbound bidi one, only material once server push or a non-zero QPACK table would open more.

All green: full Zig suite, ReleaseSafe, 212 Python tests, 100% coverage.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
