### PR TITLE
End the zttp primer streams in the H2 response benchmark

### DIFF
--- a/benchmarks/http2.py
+++ b/benchmarks/http2.py
@@ -282,7 +282,7 @@ def make_zttp(w: Workload) -> Runner:
             conn = Connection(role, protocol=HTTP2)
             if not is_request:
                 for _ in range(count):
-                    conn.send_request(b"GET", b"/", b"2", [(b"host", b"x")])
+                    conn.send_request(b"GET", b"/", b"2", [(b"host", b"x")]).end_message()
             conn.receive_data(wire)
             while conn.next_event() is not NEED_DATA:
                 pass
@@ -336,7 +336,7 @@ def extract_zttp(w: Workload) -> list[Message]:
     conn = zttp.Connection(role, protocol=zttp.HTTP2)
     if w.kind != "request":
         for _ in range(w.messages):
-            conn.send_request(b"GET", b"/", b"2", [(b"host", b"x")])
+            conn.send_request(b"GET", b"/", b"2", [(b"host", b"x")]).end_message()
     conn.receive_data(w.wire)
     pending: dict[int, list[tuple[bytes, bytes]]] = {}
     starts: dict[int, object] = {}


### PR DESCRIPTION
Follow-up to #103, addressing a Codex review comment that landed after it merged.

In the HTTP/2 response-workload benchmark, the primer that opens the client streams before decoding the response left each zttp stream un-ended (`send_request(...)` with no `end_message()`), while the h2 side sends `end_stream=True`. So zttp was timed after less send-side work and with its request streams left half-open, making the response-workload ratios not apples-to-apples. This calls `.end_message()` on the primer to match h2, in both the timed runner and the verifier.

All 11 workloads still verify equal; the response ratios shift slightly down (JSON 31.5x -> 30.2x, multiplexed 40.0x -> 38.0x) as zttp now does the matching END_STREAM send work. Request workloads are unaffected.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.