### PR TITLE
Resolve the open H2 code-health and documentation issues

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -289,6 +289,27 @@ These are not defects in the current parser; they are the places where the
 - **Misuse of the integration contract** (items 3-5 above) - parsing a response
   on a connection that never sent the request, or a mishandled `CONNECT`, can
   desynchronize a stream that the core itself parses correctly.
+- **The h2→h1 downgrade boundary (integrator responsibility 10).** zttp's
+  inbound validation makes an H2 request *safe to read*, but the H1 request a
+  proxy *synthesizes* from it is the proxy's to keep unambiguous. The residual
+  hazards live entirely on that outbound path:
+  - **`:path` is a request target, not a header value.** zttp rejects CR/LF/NUL
+    inside header *values*, but a downgrading proxy that splices `:path` into an
+    H1 request line without its own request-target check can still emit a
+    smuggled line if it ever relaxes that. Re-validate the target you write.
+  - **Body framing is yours to re-declare.** The inbound `content-length`-vs-DATA
+    guard guarantees the H2 body length is *honest*; it does not write your H1
+    framing. When you build the H1 message, emit exactly one unambiguous framing
+    (a single `Content-Length`, or `Transfer-Encoding: chunked`) - never both,
+    and never a `content-length` you copied without re-counting the bytes you
+    actually forward.
+  - **Don't reintroduce hop-by-hop fields.** zttp strips `connection`,
+    `transfer-encoding`, `upgrade`, etc. on the way in; do not let your H1
+    builder re-add a `Connection`/`Keep-Alive` header derived from anything the
+    peer controlled.
+  A proxy that forwards the *parsed* `Request` fields verbatim and re-derives its
+  own framing is safe; one that string-concatenates peer-controlled bytes into an
+  H1 message owns the smuggling risk regardless of zttp's inbound checks.
 - **Lenient mode.** The Zig core has `strict_crlf` / chunk-strictness toggles that
   default to strict and are **not** exposed through the Python API. If a future
   binding ever exposes them, the bare-LF/CR smuggling classes re-open. Keep

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -399,7 +399,7 @@ pub const Connection = struct {
         const t = s.creditSendWindow(increment);
         switch (t.action) {
             .ok => self.push(.{ .window_update = .{ .stream_id = f.header.stream_id, .increment = increment } }),
-            .stream_error => self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(t.code) } }),
+            .stream_error => self.pushRst(f.header.stream_id, t.code),
             .connection_error => return error.FlowControlError,
         }
     }
@@ -428,21 +428,21 @@ pub const Connection = struct {
             // a closed/evicted id is a stream error STREAM_CLOSED (RFC 9113 5.1,
             // mirroring stream.classifyRecv's .closed branch).
             if (self.isIdle(f.header.stream_id)) return error.ProtocolError;
-            self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(ErrorCode.stream_closed) } });
+            self.pushRst(f.header.stream_id, .stream_closed);
             return;
         };
         const classify = s.classifyRecv(.data, end_stream);
         switch (classify.action) {
             .ok => {},
             .stream_error => {
-                self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(classify.code) } });
+                self.pushRst(f.header.stream_id, classify.code);
                 return;
             },
             .connection_error => return error.ProtocolError,
         }
         const wt = s.debitRecvWindow(f.header.length);
         if (wt.action == .stream_error) {
-            self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = @intFromEnum(ErrorCode.flow_control_error) } });
+            self.pushRst(f.header.stream_id, .flow_control_error);
             return;
         }
         s.recordData(content.len);
@@ -481,6 +481,8 @@ pub const Connection = struct {
         s.recvApply(.rst_stream, false);
         self.evictStream(f.header.stream_id);
         try self.chargeReset();
+        // Surface the peer's RST verbatim (not pushRst: the wire code is an
+        // arbitrary u32, passed through rather than one of our ErrorCode resets).
         self.push(.{ .rst_stream = .{ .stream_id = f.header.stream_id, .error_code = code } });
     }
 
@@ -587,7 +589,7 @@ pub const Connection = struct {
         if (refused) {
             // Decoded for HPACK sync; the request is not surfaced and no stream
             // record exists, so nothing to close.
-            self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = @intFromEnum(ErrorCode.refused_stream) } });
+            self.pushRst(id, .refused_stream);
             return;
         }
 
@@ -661,7 +663,7 @@ pub const Connection = struct {
         s.recvApply(.rst_stream, false); // -> closed
         self.evictStream(id);
         try self.chargeReset();
-        self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = @intFromEnum(code) } });
+        self.pushRst(id, code);
     }
 
     const CollapseError = error{ Malformed, OutOfMemory };
@@ -1136,6 +1138,13 @@ pub const Connection = struct {
         const slot = (self.pending_head + self.pending_len) % PENDING_CAP;
         self.pending[slot] = ev;
         self.pending_len += 1;
+    }
+
+    /// Queue a RST_STREAM event for `id` with `code`. This is the bare emit: it
+    /// does not touch stream state - callers that own a live stream record go
+    /// through `resetStream`, which applies state and charges churn before this.
+    fn pushRst(self: *Connection, id: u32, code: ErrorCode) void {
+        self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = @intFromEnum(code) } });
     }
 
     fn popPending(self: *Connection) Event {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -43,7 +43,9 @@ const H1Engine = struct {
     writer: ?*Writer = null,
     /// The method of the message the next response answers (server: the parsed
     /// request; client: the request we sent), so the connection auto-derives
-    /// bodyless framing. Cleared per cycle by start_next_cycle.
+    /// bodyless framing. NOT cleared by start_next_cycle - it is overwritten when
+    /// the next request is parsed, so send_response can read it before the previous
+    /// response is serialized (see next_message).
     req_method: [16]u8 = undefined,
     req_method_len: usize = 0,
     /// Connection signals for the last parsed request, captured at event time so

--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -157,84 +157,20 @@ var window_update_members = [_]py.MemberDef{
     .{ .name = null, .type = 0, .offset = 0, .flags = 0, .doc = null },
 };
 
-// -- dealloc ------------------------------------------------------------------
-
-fn deallocRequest(o: ?*c.PyObject) callconv(.c) void {
-    const s: *RequestObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.method);
-    py.xdecref(s.target);
-    py.xdecref(s.path);
-    py.xdecref(s.query);
-    py.xdecref(s.http_version);
-    py.xdecref(s.headers);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocResponse(o: ?*c.PyObject) callconv(.c) void {
-    const s: *ResponseObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.status_code);
-    py.xdecref(s.reason);
-    py.xdecref(s.http_version);
-    py.xdecref(s.headers);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocData(o: ?*c.PyObject) callconv(.c) void {
-    const s: *DataObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.data);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocEom(o: ?*c.PyObject) callconv(.c) void {
-    const s: *EndOfMessageObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.trailers);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocRstStream(o: ?*c.PyObject) callconv(.c) void {
-    const s: *RstStreamObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.stream_id);
-    py.xdecref(s.error_code);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocGoaway(o: ?*c.PyObject) callconv(.c) void {
-    const s: *GoawayObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.last_stream_id);
-    py.xdecref(s.error_code);
-    py.xdecref(s.debug);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocSettings(o: ?*c.PyObject) callconv(.c) void {
-    const s: *SettingsEventObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.params);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocPing(o: ?*c.PyObject) callconv(.c) void {
-    const s: *PingObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.ack);
-    py.xdecref(s.data);
-    py.freeInstance(@ptrCast(s));
-}
-fn deallocWindowUpdate(o: ?*c.PyObject) callconv(.c) void {
-    const s: *WindowUpdateObject = @ptrCast(o.?);
-    py.gcUntrack(s);
-    py.xdecref(s.stream_id);
-    py.xdecref(s.increment);
-    py.freeInstance(@ptrCast(s));
-}
-
 // -- GC support ---------------------------------------------------------------
 
 // The event types hold strong references to Python objects (and Request/
 // Response/EndOfMessage expose mutable header/trailer lists), so they must be
-// GC types with traverse/clear; otherwise a cycle through them leaks. tp_alloc
-// (PyType_GenericAlloc) already GC-tracks a HAVE_GC instance on creation, so we
-// only untrack in dealloc; no explicit track is needed (and double-tracking
-// trips an assertion in a debug build).
+// GC types with dealloc/traverse/clear over every owned reference; otherwise a
+// cycle through them leaks. tp_alloc (PyType_GenericAlloc) already GC-tracks a
+// HAVE_GC instance on creation, so we only untrack in dealloc; no explicit track
+// is needed (and double-tracking trips an assertion in a debug build).
+//
+// dealloc/traverse/clear are identical across the event types up to their field
+// list, so gcOps generates the trio from the struct itself: it walks exactly the
+// `py.Object`-typed fields, skipping `ob_base` and the plain-integer fields. This
+// covers fields the repr/equality lists deliberately omit (Request's path/query),
+// which is why it introspects the type rather than reusing the *_fields tuples.
 
 fn visitObj(obj: py.Object, visit: c.visitproc, arg: ?*anyopaque) c_int {
     if (obj != null) {
@@ -244,132 +180,64 @@ fn visitObj(obj: py.Object, visit: c.visitproc, arg: ?*anyopaque) c_int {
     return 0;
 }
 
-fn traverseRequest(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *RequestObject = @ptrCast(o.?);
-    inline for (.{ s.method, s.target, s.path, s.query, s.http_version, s.headers }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
+/// Names of the `py.Object`-typed fields of an event struct - the owned refs the
+/// GC trio must walk.
+fn objectFields(comptime T: type) []const []const u8 {
+    comptime {
+        var names: []const []const u8 = &.{};
+        for (@typeInfo(T).@"struct".fields) |f| {
+            if (f.type == py.Object) names = names ++ .{f.name};
+        }
+        return names;
     }
-    return 0;
 }
-fn clearRequest(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *RequestObject = @ptrCast(o.?);
-    py.clear(&s.method);
-    py.clear(&s.target);
-    py.clear(&s.path);
-    py.clear(&s.query);
-    py.clear(&s.http_version);
-    py.clear(&s.headers);
-    return 0;
+
+const GcOps = struct {
+    dealloc: fn (?*c.PyObject) callconv(.c) void,
+    traverse: fn (?*c.PyObject, c.visitproc, ?*anyopaque) callconv(.c) c_int,
+    clear: fn (?*c.PyObject) callconv(.c) c_int,
+};
+
+fn gcOps(comptime T: type) GcOps {
+    const fields = objectFields(T);
+    return .{
+        .dealloc = struct {
+            fn dealloc(o: ?*c.PyObject) callconv(.c) void {
+                const s: *T = @ptrCast(o.?);
+                py.gcUntrack(s);
+                inline for (fields) |name| py.xdecref(@field(s, name));
+                py.freeInstance(@ptrCast(s));
+            }
+        }.dealloc,
+        .traverse = struct {
+            fn traverse(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
+                const s: *T = @ptrCast(o.?);
+                inline for (fields) |name| {
+                    const r = visitObj(@field(s, name), visit, arg);
+                    if (r != 0) return r;
+                }
+                return 0;
+            }
+        }.traverse,
+        .clear = struct {
+            fn clear(o: ?*c.PyObject) callconv(.c) c_int {
+                const s: *T = @ptrCast(o.?);
+                inline for (fields) |name| py.clear(&@field(s, name));
+                return 0;
+            }
+        }.clear,
+    };
 }
-fn traverseResponse(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *ResponseObject = @ptrCast(o.?);
-    inline for (.{ s.status_code, s.reason, s.http_version, s.headers }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearResponse(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *ResponseObject = @ptrCast(o.?);
-    py.clear(&s.status_code);
-    py.clear(&s.reason);
-    py.clear(&s.http_version);
-    py.clear(&s.headers);
-    return 0;
-}
-fn traverseData(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *DataObject = @ptrCast(o.?);
-    inline for (.{s.data}) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearData(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *DataObject = @ptrCast(o.?);
-    py.clear(&s.data);
-    return 0;
-}
-fn traverseEom(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *EndOfMessageObject = @ptrCast(o.?);
-    inline for (.{s.trailers}) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearEom(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *EndOfMessageObject = @ptrCast(o.?);
-    py.clear(&s.trailers);
-    return 0;
-}
-fn traverseRstStream(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *RstStreamObject = @ptrCast(o.?);
-    inline for (.{ s.stream_id, s.error_code }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearRstStream(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *RstStreamObject = @ptrCast(o.?);
-    py.clear(&s.stream_id);
-    py.clear(&s.error_code);
-    return 0;
-}
-fn traverseGoaway(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *GoawayObject = @ptrCast(o.?);
-    inline for (.{ s.last_stream_id, s.error_code, s.debug }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearGoaway(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *GoawayObject = @ptrCast(o.?);
-    py.clear(&s.last_stream_id);
-    py.clear(&s.error_code);
-    py.clear(&s.debug);
-    return 0;
-}
-fn traverseSettings(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *SettingsEventObject = @ptrCast(o.?);
-    return visitObj(s.params, visit, arg);
-}
-fn clearSettings(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *SettingsEventObject = @ptrCast(o.?);
-    py.clear(&s.params);
-    return 0;
-}
-fn traversePing(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *PingObject = @ptrCast(o.?);
-    inline for (.{ s.ack, s.data }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearPing(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *PingObject = @ptrCast(o.?);
-    py.clear(&s.ack);
-    py.clear(&s.data);
-    return 0;
-}
-fn traverseWindowUpdate(o: ?*c.PyObject, visit: c.visitproc, arg: ?*anyopaque) callconv(.c) c_int {
-    const s: *WindowUpdateObject = @ptrCast(o.?);
-    inline for (.{ s.stream_id, s.increment }) |f| {
-        const r = visitObj(f, visit, arg);
-        if (r != 0) return r;
-    }
-    return 0;
-}
-fn clearWindowUpdate(o: ?*c.PyObject) callconv(.c) c_int {
-    const s: *WindowUpdateObject = @ptrCast(o.?);
-    py.clear(&s.stream_id);
-    py.clear(&s.increment);
-    return 0;
-}
+
+const request_gc = gcOps(RequestObject);
+const response_gc = gcOps(ResponseObject);
+const data_gc = gcOps(DataObject);
+const eom_gc = gcOps(EndOfMessageObject);
+const rst_stream_gc = gcOps(RstStreamObject);
+const goaway_gc = gcOps(GoawayObject);
+const settings_gc = gcOps(SettingsEventObject);
+const ping_gc = gcOps(PingObject);
+const window_update_gc = gcOps(WindowUpdateObject);
 
 // -- repr & equality ----------------------------------------------------------
 
@@ -517,15 +385,15 @@ fn slots(comptime dealloc: anytype, comptime members: anytype, comptime traverse
     };
 }
 
-var request_slots = slots(deallocRequest, &request_members, traverseRequest, clearRequest, reprRequest, cmpRequest);
-var response_slots = slots(deallocResponse, &response_members, traverseResponse, clearResponse, reprResponse, cmpResponse);
-var data_slots = slots(deallocData, &data_members, traverseData, clearData, reprData, cmpData);
-var eom_slots = slots(deallocEom, &eom_members, traverseEom, clearEom, reprEom, cmpEom);
-var rst_stream_slots = slots(deallocRstStream, &rst_stream_members, traverseRstStream, clearRstStream, reprRstStream, cmpRstStream);
-var goaway_slots = slots(deallocGoaway, &goaway_members, traverseGoaway, clearGoaway, reprGoaway, cmpGoaway);
-var settings_slots = slots(deallocSettings, &settings_members, traverseSettings, clearSettings, reprSettings, cmpSettings);
-var ping_slots = slots(deallocPing, &ping_members, traversePing, clearPing, reprPing, cmpPing);
-var window_update_slots = slots(deallocWindowUpdate, &window_update_members, traverseWindowUpdate, clearWindowUpdate, reprWindowUpdate, cmpWindowUpdate);
+var request_slots = slots(request_gc.dealloc, &request_members, request_gc.traverse, request_gc.clear, reprRequest, cmpRequest);
+var response_slots = slots(response_gc.dealloc, &response_members, response_gc.traverse, response_gc.clear, reprResponse, cmpResponse);
+var data_slots = slots(data_gc.dealloc, &data_members, data_gc.traverse, data_gc.clear, reprData, cmpData);
+var eom_slots = slots(eom_gc.dealloc, &eom_members, eom_gc.traverse, eom_gc.clear, reprEom, cmpEom);
+var rst_stream_slots = slots(rst_stream_gc.dealloc, &rst_stream_members, rst_stream_gc.traverse, rst_stream_gc.clear, reprRstStream, cmpRstStream);
+var goaway_slots = slots(goaway_gc.dealloc, &goaway_members, goaway_gc.traverse, goaway_gc.clear, reprGoaway, cmpGoaway);
+var settings_slots = slots(settings_gc.dealloc, &settings_members, settings_gc.traverse, settings_gc.clear, reprSettings, cmpSettings);
+var ping_slots = slots(ping_gc.dealloc, &ping_members, ping_gc.traverse, ping_gc.clear, reprPing, cmpPing);
+var window_update_slots = slots(window_update_gc.dealloc, &window_update_members, window_update_gc.traverse, window_update_gc.clear, reprWindowUpdate, cmpWindowUpdate);
 
 fn spec(comptime name: [*c]const u8, comptime size: usize, sl: anytype) py.Spec {
     return .{


### PR DESCRIPTION
Closes the actionable open issues. Per request, limit configurability (#49) is intentionally left out - we don't need tunable limits for now.

## What changed

**#58 - H2 code-health cleanups**
- **pushRst helper** (`connection.zig`): the five sites that generate a stream reset now go through `pushRst(id, code)` instead of an inline `push(.{ .rst_stream = ... })`. The one site that surfaces a *received* peer RST stays a direct push, since it forwards an arbitrary wire `u32` code rather than one of our `ErrorCode` resets (noted in a comment).
- **Stale comment** (`connection_obj.zig`): the `req_method` field said "Cleared per cycle by start_next_cycle", which contradicts `next_message`, where it is deliberately *not* cleared (it's overwritten on the next parse so `send_response` can read it before the previous response is serialized). Comment corrected to match.
- **Comptime GC trio** (`events_obj.zig`): the dealloc/traverse/clear functions were ~27 near-identical hand-written functions. They're now generated by a `gcOps(T)` that introspects each struct for its `py.Object`-typed fields - mirroring the existing `richcompareFields`/`reprFields` pattern. This covers every owned reference by construction, including `Request`'s `path`/`query` (which the repr/equality field lists deliberately omit), so it can't drift out of sync. Net -132 lines in that file.
- #58b (the `makeStream` comment) was already accurate and left unchanged.

**#57 - h2→h1 downgrade contract** (`THREAT_MODEL.md`): added a residual-risk note spelling out the smuggling hazards an integrator owns on the *outbound* H1 synthesis path (request-target validation, re-declaring body framing, not reintroducing hop-by-hop fields) - complementing the existing inbound-validation guarantees.

**#36 and #55** were already implemented in earlier PRs (inbound window replenishment, SETTINGS/PING auto-ack, GOAWAY/RST send APIs, HEAD-response handling, eager preface, `end_stream`/`send_informational`, h2c seeding, send-side backpressure visibility). The test suite already exercises all of them, so this PR just closes them out.

## Verification

- All 216 tests pass; coverage stays at 100%.
- The GC refactor verified against reference-cycle traverse/clear and 1000 event-object dealloc lifecycles - no leak or crash.
- `zig build test`, ruff, mypy, and `zig fmt` all clean.

Closes #36
Closes #55
Closes #57
Closes #58

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.