### PR TITLE
Close with CRYPTO_ERROR on a failed TLS handshake

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -52,8 +52,18 @@ pub const Error = error{
     /// address is validated (RFC 9000 8.1). Not fatal: the send path stops and
     /// resumes once the client's later packets raise the budget.
     AmplificationLimited,
+    /// The TLS handshake failed (RFC 9001 4.8): a CONNECTION_CLOSE carrying
+    /// CRYPTO_ERROR (0x0100 | alert) has been queued, so the peer learns which TLS
+    /// rule broke. Fatal, like ProtocolViolation, but with a specific cause.
+    CryptoError,
     OutOfMemory,
 };
+
+/// The QUIC error code for a TLS alert (RFC 9001 4.8): the CRYPTO_ERROR range is
+/// 0x0100-0x01ff, the low byte being the TLS alert description.
+fn cryptoErrorCode(alert: tls.server.Alert) u64 {
+    return 0x0100 | @as(u64, @intFromEnum(alert));
+}
 
 /// One packet-number space's protection keys, recovery state, and CRYPTO receive
 /// reassembly. Initial keys are derived up front; Handshake/Application keys arrive
@@ -1071,6 +1081,15 @@ pub const Connection = struct {
         try self.driveTls(space, now);
     }
 
+    /// Queue a CONNECTION_CLOSE carrying CRYPTO_ERROR for a failed TLS handshake
+    /// (RFC 9001 4.8) and return the fatal error. The close rides whatever space
+    /// has keys; a pre-validation amplification stall is swallowed (the error is
+    /// still fatal, the integrator tears the connection down regardless).
+    fn failHandshake(self: *Connection, alert: tls.server.Alert) Error {
+        self.close(false, cryptoErrorCode(alert), "") catch {};
+        return error.CryptoError;
+    }
+
     fn driveTls(self: *Connection, space: Space, now: u64) Error!void {
         const server = if (self.tls) |*s| s else return; // only the server drives the handshake here
         const st = &self.spaces[@intFromEnum(space)];
@@ -1079,7 +1098,7 @@ pub const Connection = struct {
             const msg = tls.handshake.peek(buf) orelse break; // need more CRYPTO bytes
             switch (msg.msg_type) {
                 .client_hello => {
-                    const decoded = tls.client_hello.parse(buf[0..msg.len]) catch return error.ProtocolViolation;
+                    const decoded = tls.client_hello.parse(buf[0..msg.len]) catch return self.failHandshake(.decode_error);
 
                     // Honour the client's transport parameters (RFC 9000 7.4): its
                     // initial_max_data is the send-window ceiling, max_ack_delay feeds
@@ -1104,7 +1123,7 @@ pub const Connection = struct {
 
                     var flight_buf: std.ArrayListUnmanaged(u8) = .empty;
                     defer flight_buf.deinit(self.gpa);
-                    const outcome = server.onClientHello(&flight_buf, self.gpa, decoded.value) catch return error.ProtocolViolation;
+                    const outcome = server.onClientHello(&flight_buf, self.gpa, decoded.value) catch |e| return self.failHandshake(tls.server.alertFor(e));
 
                     // A server RECVs with the client traffic secret, SENDs with the server one.
                     self.installKeys(.handshake, outcome.built.handshake_secrets.clientKeys(), outcome.built.handshake_secrets.serverKeys());
@@ -1118,12 +1137,12 @@ pub const Connection = struct {
                     continue;
                 },
                 .finished => {
-                    const body = tls.handshake.finishedBody(msg.body) catch return error.ProtocolViolation;
-                    server.onClientFinished(body) catch return error.ProtocolViolation;
+                    const body = tls.handshake.finishedBody(msg.body) catch return self.failHandshake(.decode_error);
+                    server.onClientFinished(body) catch |e| return self.failHandshake(tls.server.alertFor(e));
                     st.crypto.advance(msg.len);
                     try self.confirmHandshake(now);
                 },
-                else => return error.ProtocolViolation, // unexpected message at the server
+                else => return self.failHandshake(.unexpected_message), // unexpected message at the server
             }
         }
     }
@@ -2632,7 +2651,7 @@ test "a STREAM frame in an Initial packet is a protocol violation" {
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(dgram, 1000));
 }
 
-test "a malformed ClientHello (no supported_versions) poisons the connection" {
+test "a malformed ClientHello closes with CRYPTO_ERROR (decode_error)" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x31, 0x32, 0x33, 0x34 };
     var pubkey: [32]u8 = undefined;
@@ -2652,7 +2671,18 @@ test "a malformed ClientHello (no supported_versions) poisons the connection" {
     try frame.encodeCrypto(&frames, gpa, 0, ch.items);
     const dgram = try testBuildInitial(gpa, &dcid, .client, 0, frames.items);
     defer gpa.free(dgram);
-    try testing.expectError(error.ProtocolViolation, server.receiveDatagram(dgram, 1000));
+    try testing.expectError(error.CryptoError, server.receiveDatagram(dgram, 1000));
+
+    // RFC 9001 4.8: the failure rode out as a CONNECTION_CLOSE carrying
+    // CRYPTO_ERROR (0x0100 | decode_error). A peer deriving the same Initial keys
+    // from the dcid reads it back.
+    try testing.expect(server.closed);
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    try peer.receiveDatagram(server.datagramsToSend(), 2000);
+    const pc = peer.peer_close.?;
+    try testing.expect(!pc.app);
+    try testing.expectEqual(cryptoErrorCode(.decode_error), pc.error_code);
 }
 
 // ---- STREAM send tests -----------------------------------------------------

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1092,6 +1092,14 @@ pub const Connection = struct {
         return error.CryptoError;
     }
 
+    /// Map a TLS server error to its CRYPTO_ERROR close, but let an allocation
+    /// failure surface as OutOfMemory (a local resource fault, not a peer protocol
+    /// error) rather than a misattributed CryptoError.
+    fn failHandshakeErr(self: *Connection, e: tls.server.Error) Error {
+        if (e == error.OutOfMemory) return error.OutOfMemory;
+        return self.failHandshake(tls.server.alertFor(e));
+    }
+
     /// Queue a CONNECTION_CLOSE carrying a QUIC TRANSPORT_PARAMETER_ERROR for a
     /// malformed/forbidden/spoofed transport parameter (RFC 9000 7.3/7.4/18.2), so
     /// a peer with bad parameters learns why rather than seeing a silent drop.
@@ -1142,7 +1150,7 @@ pub const Connection = struct {
 
                     var flight_buf: std.ArrayListUnmanaged(u8) = .empty;
                     defer flight_buf.deinit(self.gpa);
-                    const outcome = server.onClientHello(&flight_buf, self.gpa, decoded.value) catch |e| return self.failHandshake(tls.server.alertFor(e));
+                    const outcome = server.onClientHello(&flight_buf, self.gpa, decoded.value) catch |e| return self.failHandshakeErr(e);
 
                     // A server RECVs with the client traffic secret, SENDs with the server one.
                     self.installKeys(.handshake, outcome.built.handshake_secrets.clientKeys(), outcome.built.handshake_secrets.serverKeys());
@@ -1157,7 +1165,7 @@ pub const Connection = struct {
                 },
                 .finished => {
                     const body = tls.handshake.finishedBody(msg.body) catch return self.failHandshake(.decode_error);
-                    server.onClientFinished(body) catch |e| return self.failHandshake(tls.server.alertFor(e));
+                    server.onClientFinished(body) catch |e| return self.failHandshakeErr(e);
                     st.crypto.advance(msg.len);
                     try self.confirmHandshake(now);
                 },

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1083,11 +1083,30 @@ pub const Connection = struct {
 
     /// Queue a CONNECTION_CLOSE carrying CRYPTO_ERROR for a failed TLS handshake
     /// (RFC 9001 4.8) and return the fatal error. The close rides whatever space
-    /// has keys; a pre-validation amplification stall is swallowed (the error is
-    /// still fatal, the integrator tears the connection down regardless).
+    /// has keys. A pre-validation amplification stall is swallowed (the error is
+    /// still fatal, the integrator tears the connection down regardless), but an
+    /// allocation failure propagates so the caller sees a MemoryError, not a
+    /// misattributed protocol error.
     fn failHandshake(self: *Connection, alert: tls.server.Alert) Error {
-        self.close(false, cryptoErrorCode(alert), "") catch {};
+        try self.queueFatalClose(false, cryptoErrorCode(alert));
         return error.CryptoError;
+    }
+
+    /// Queue a CONNECTION_CLOSE carrying a QUIC TRANSPORT_PARAMETER_ERROR for a
+    /// malformed/forbidden/spoofed transport parameter (RFC 9000 7.3/7.4/18.2), so
+    /// a peer with bad parameters learns why rather than seeing a silent drop.
+    fn failTransportParams(self: *Connection) Error {
+        try self.queueFatalClose(false, @intFromEnum(constants.TransportError.transport_parameter_error));
+        return error.ProtocolViolation;
+    }
+
+    /// Queue a fatal CONNECTION_CLOSE, swallowing only the amplification stall (the
+    /// caller's error is fatal regardless); OutOfMemory propagates.
+    fn queueFatalClose(self: *Connection, app: bool, code: u64) Error!void {
+        self.close(app, code, "") catch |e| switch (e) {
+            error.AmplificationLimited => {},
+            else => return e,
+        };
     }
 
     fn driveTls(self: *Connection, space: Space, now: u64) Error!void {
@@ -1104,15 +1123,15 @@ pub const Connection = struct {
                     // initial_max_data is the send-window ceiling, max_ack_delay feeds
                     // the PTO. Applied before the flight is built/sent.
                     self.peer_tp = transport_params.parse(decoded.value.quic_transport_parameters) catch
-                        return error.ProtocolViolation;
+                        return self.failTransportParams();
                     // RFC 9000 7.3/18.2: a client must not send server-only parameters,
                     // must send initial_source_connection_id, and that id must equal the
                     // Source Connection ID of the Initial carrying this ClientHello -
                     // the handshake-time authentication that defeats id spoofing.
-                    if (self.peer_tp.has_server_only_param) return error.ProtocolViolation;
-                    const iscid = self.peer_tp.initial_scid orelse return error.ProtocolViolation;
-                    const carrier_scid = self.dispatch_initial_scid orelse return error.ProtocolViolation;
-                    if (!std.mem.eql(u8, iscid.slice(), carrier_scid)) return error.ProtocolViolation;
+                    if (self.peer_tp.has_server_only_param) return self.failTransportParams();
+                    const iscid = self.peer_tp.initial_scid orelse return self.failTransportParams();
+                    const carrier_scid = self.dispatch_initial_scid orelse return self.failTransportParams();
+                    if (!std.mem.eql(u8, iscid.slice(), carrier_scid)) return self.failTransportParams();
                     self.conn_send_window.setInitial(self.peer_tp.initial_max_data);
                     // Our responses ride bidi streams the client opens, bounded by its
                     // bidi_local; a bidi stream we open is bounded by its bidi_remote;
@@ -2502,6 +2521,13 @@ test "a client without initial_source_connection_id is rejected" {
     const ch = try buildClientHelloInitialTp(gpa, &dcid, pubkey, &[_]u8{ 0x01, 0x02, 0x40, 0x01 });
     defer gpa.free(ch);
     try testing.expectError(error.ProtocolViolation, server.receiveDatagram(ch, 1000));
+
+    // The rejection rode out as a CONNECTION_CLOSE carrying TRANSPORT_PARAMETER_ERROR.
+    try testing.expect(server.closed);
+    var peer = try Connection.init(gpa, .client, &dcid);
+    defer peer.deinit();
+    try peer.receiveDatagram(server.datagramsToSend(), 2000);
+    try testing.expectEqual(@intFromEnum(constants.TransportError.transport_parameter_error), peer.peer_close.?.error_code);
 }
 
 test "a client whose initial_source_connection_id mismatches its Initial is rejected" {

--- a/src/core/quic/tls/server.zig
+++ b/src/core/quic/tls/server.zig
@@ -14,6 +14,28 @@ const client_hello = @import("client_hello.zig");
 
 pub const State = enum { wait_client_hello, flight_sent, complete };
 
+/// The TLS 1.3 alert descriptions (RFC 8446 6) this server raises. QUIC carries a
+/// fatal alert as a CONNECTION_CLOSE with code CRYPTO_ERROR (0x0100 | alert), so a
+/// peer learns which TLS rule was broken (RFC 9001 4.8).
+pub const Alert = enum(u8) {
+    unexpected_message = 10,
+    decode_error = 50,
+    decrypt_error = 51,
+    internal_error = 80,
+    no_application_protocol = 120,
+};
+
+/// The alert a handshake error maps to. A malformed handshake message decodes to
+/// `decode_error`; the rest follow RFC 8446's named conditions.
+pub fn alertFor(e: Error) Alert {
+    return switch (e) {
+        error.UnexpectedMessage => .unexpected_message,
+        error.BadFinished => .decrypt_error,
+        error.NoAlpnOverlap => .no_application_protocol,
+        error.Internal, error.OutOfMemory => .internal_error,
+    };
+}
+
 pub const Error = error{
     /// A handshake message arrived in a state that forbids it (e.g. a second
     /// ClientHello). The connection maps this to PROTOCOL_VIOLATION.

--- a/src/python/exceptions.zig
+++ b/src/python/exceptions.zig
@@ -68,6 +68,7 @@ pub fn raiseQuic(e: QuicError) py.Object {
         error.FlowControlError => "QUIC flow-control error",
         error.StreamLimitError => "QUIC stream limit exceeded",
         error.FinalSizeError => "QUIC final size error",
+        error.CryptoError => "QUIC TLS handshake failed (CRYPTO_ERROR)",
         // A send-side backpressure signal the send paths handle (defer the bytes), so
         // it never escapes to here; mapped only to keep the switch exhaustive.
         error.AmplificationLimited => "QUIC anti-amplification limit",


### PR DESCRIPTION
A failed TLS handshake previously collapsed to a generic `ProtocolViolation` and the peer just saw the connection drop. The server now reports *why* the handshake failed, per RFC 9001 4.8.

- A TLS handshake failure (malformed ClientHello, bad Finished MAC, no ALPN overlap, an unexpected handshake message) rides out as a CONNECTION_CLOSE carrying `CRYPTO_ERROR (0x0100 | alert)`, where `alert` is the RFC 8446 alert description for the condition.
- A malformed, forbidden, or spoofed transport parameter rides out as a CONNECTION_CLOSE carrying `TRANSPORT_PARAMETER_ERROR` (RFC 9000 7.3/7.4/18.2) - the QUIC-transport analogue, not a TLS alert.

The TLS layer maps each error to its alert; the connection queues the close and returns a distinct `CryptoError` (or `ProtocolViolation` for the transport-parameter case). The shared fatal-close helper swallows only the anti-amplification stall - an allocation failure propagates so the caller sees a `MemoryError`.

Each commit was reviewed by Codex; the second commit folds its two findings (don't swallow close OOM; close on a bad transport parameter rather than dropping silently).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
