### PR TITLE
Move the byte-stream read surface off the Connection base

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2346,15 +2346,22 @@ fn h2_has_pending_send(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.
 // Connection is the factory: constructing it picks H1Connection / H2Connection by
 // protocol (new_base), so the runtime type is truthful while isinstance(obj,
 // Connection) still holds.
+// Only `next_event()` is common to every transport. The read/write *byte* surface
+// is transport-specific: HTTP/1.1 and HTTP/2 are byte streams (receive_data +
+// data_to_send()->bytes); HTTP/3 rides UDP datagrams (receive_datagram +
+// data_to_send()->list[bytes]). Keeping the byte surface off the base means
+// H3Connection does not inherit an incompatible receive_data / data_to_send - the
+// type hierarchy states exactly what each transport supports (see issue #113).
 var base_methods = [_]py.MethodDef{
-    .{ .ml_name = "receive_data", .ml_meth = receive_data, .ml_flags = c.METH_O, .ml_doc = "Append received bytes (empty bytes signals EOF)." },
     .{ .ml_name = "next_event", .ml_meth = next_event, .ml_flags = c.METH_NOARGS, .ml_doc = "Return the next parse event, or NEED_DATA." },
-    .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing bytes." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
 
-// HTTP/1.1: the message-scoped send API plus keep-alive / upgrade signals.
+// HTTP/1.1: the byte-stream read/write surface plus the message-scoped send API and
+// keep-alive / upgrade signals.
 var h1_methods = [_]py.MethodDef{
+    .{ .ml_name = "receive_data", .ml_meth = receive_data, .ml_flags = c.METH_O, .ml_doc = "Append received bytes (empty bytes signals EOF)." },
+    .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing bytes." },
     .{ .ml_name = "start_next_cycle", .ml_meth = next_message, .ml_flags = c.METH_NOARGS, .ml_doc = "Reset to read the next message on a keep-alive connection." },
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a request head: send_request(method, target, version, headers)." },
     .{ .ml_name = "send_response", .ml_meth = send_response, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize a response head: send_response(status, headers=None). The reason phrase is derived from the status; the version is 1.1. Bodyless framing (HEAD / 204 / 304) is derived automatically." },
@@ -2370,6 +2377,8 @@ var h1_methods = [_]py.MethodDef{
 // a request (returns a Stream); the server reaches one with stream(id). There is
 // no connection-level body send - that is what the Stream handle is for.
 var h2_methods = [_]py.MethodDef{
+    .{ .ml_name = "receive_data", .ml_meth = receive_data, .ml_flags = c.METH_O, .ml_doc = "Append received bytes (empty bytes signals EOF)." },
+    .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing bytes." },
     .{ .ml_name = "initiate_connection", .ml_meth = h2_initiate, .ml_flags = c.METH_NOARGS, .ml_doc = "Emit the connection preface (client preface + SETTINGS, or the server's SETTINGS) now, rather than lazily on the first send. Idempotent." },
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Open a request stream and return its Stream: send_request(method, target, version, headers). :authority is derived from a host header; the version arg is ignored." },
     .{ .ml_name = "initiate_upgrade_connection", .ml_meth = @ptrCast(&initiate_upgrade_connection), .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS, .ml_doc = "Initialise an h2c-upgraded connection: initiate_upgrade_connection(method, target, headers, settings_header=None). Seeds the already-parsed HTTP/1.1 request as stream 1 and applies the client's base64url HTTP2-Settings, returning the stream's Stream. Call on a fresh server connection before feeding the client's HTTP/2 preface; next_event() then yields the request." },
@@ -2393,6 +2402,7 @@ var h2_getset = [_]c.PyGetSetDef{
 // feeds handle_timeout; a Stream send uses the most recent `now` the caller gave.
 var h3_methods = [_]py.MethodDef{
     .{ .ml_name = "receive_datagram", .ml_meth = receive_datagram, .ml_flags = c.METH_VARARGS, .ml_doc = "Feed one received UDP datagram: receive_datagram(datagram, now=0, peer_address=None). peer_address is an optional opaque bytes key for QUIC path validation and migration." },
+    .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing UDP datagrams as a list of bytes (one per datagram - QUIC datagram boundaries are semantic)." },
     .{ .ml_name = "data_to_send_with_addresses", .ml_meth = h3_data_to_send_with_addresses, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear pending HTTP/3 datagrams as (datagram, peer_address) pairs. peer_address is None when no address key is known." },
     .{ .ml_name = "challenge_path", .ml_meth = h3_challenge_path, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC PATH_CHALLENGE for a peer address: challenge_path(peer_address, data). data must be 8 unpredictable bytes. Drain with data_to_send_with_addresses." },
     .{ .ml_name = "use_peer_connection_id", .ml_meth = h3_use_peer_connection_id, .ml_flags = c.METH_O, .ml_doc = "Switch future QUIC packets to a peer-issued NEW_CONNECTION_ID sequence: use_peer_connection_id(sequence_number)." },

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -95,10 +95,13 @@ class Stream:
     def reset(self, error_code: int = ..., /) -> None: ...
 
 class Connection:
-    # The read API, shared by every protocol. Constructing a Connection returns the
-    # protocol-specific subtype (H1Connection / H2Connection / H3Connection): the
-    # send surface differs, so each is its own type rather than methods that raise
-    # at runtime.
+    # A factory base: constructing a Connection returns the protocol-specific subtype
+    # (H1Connection / H2Connection / H3Connection). Only next_event() is common to
+    # every transport. The read/write *byte* surface is transport-specific and lives
+    # on the subtypes - HTTP/1.1 and HTTP/2 are byte streams (receive_data +
+    # data_to_send() -> bytes), HTTP/3 rides UDP datagrams (receive_datagram +
+    # data_to_send() -> list[bytes]) - so the base does not promise a surface a given
+    # transport cannot honour.
     @overload
     def __new__(
         cls,
@@ -137,11 +140,11 @@ class Connection:
     def __new__(cls, role: int, protocol: Literal[2]) -> H2Connection: ...
     @overload
     def __new__(cls, role: int, protocol: Literal[1] = ...) -> H1Connection: ...
-    def receive_data(self, data: bytes) -> None: ...
     def next_event(self) -> Event: ...
-    def data_to_send(self) -> bytes: ...
 
 class H1Connection(Connection):
+    def receive_data(self, data: bytes, /) -> None: ...
+    def data_to_send(self) -> bytes: ...
     def start_next_cycle(self) -> None: ...
     def send_request(
         self, method: bytes, target: bytes, version: bytes, headers: list[tuple[bytes, bytes]]
@@ -155,6 +158,8 @@ class H1Connection(Connection):
 
 class H2Connection(Connection):
     send_window: int
+    def receive_data(self, data: bytes, /) -> None: ...
+    def data_to_send(self) -> bytes: ...
     def initiate_connection(self) -> None: ...
     def send_request(
         self, method: bytes, target: bytes, version: bytes, headers: list[tuple[bytes, bytes]]
@@ -176,10 +181,11 @@ class H3Connection(Connection):
     # in QUIC - the parameter overrides the token, e.g. for an interop draft name,
     # it is not an opt-out). `now` is the integrator's
     # monotonic clock. data_to_send returns one bytes per UDP datagram (QUIC datagram
-    # boundaries are semantic), not the byte stream the base returns. Sends go through
+    # boundaries are semantic), rather than the single byte string the H1/H2 stream
+    # transports return. Sends go through
     # a Stream handle (conn.stream(req.stream_id)), the same surface HTTP/2 uses; a
     # Stream send packetises against the most recent `now`.
-    def data_to_send(self) -> list[bytes]: ...  # type: ignore[override]
+    def data_to_send(self) -> list[bytes]: ...
     def receive_datagram(self, datagram: bytes, now: int = ..., peer_address: bytes | None = ..., /) -> None: ...
     def data_to_send_with_addresses(self) -> list[tuple[bytes, bytes | None]]: ...
     def challenge_path(self, peer_address: bytes, data: bytes, /) -> None: ...


### PR DESCRIPTION
Resolves the two Liskov violations in `H3Connection` from the API audit.

### Problem
`H3Connection` subtypes `Connection` but broke the base contract in two directions:
- it inherited `receive_data` from the base, which only raised `RuntimeError` on an H3 connection (datagram transport uses `receive_datagram`);
- it overrode `data_to_send` with an incompatible `list[bytes]` return, papered over by a `# type: ignore[override]` in the stub.

### Change
Only `next_event()` is common to every transport. The byte-stream read/write surface (`receive_data`, `data_to_send() -> bytes`) now lives on the byte-stream subtypes `H1Connection` / `H2Connection`; `H3Connection` gets its own datagram `data_to_send() -> list[bytes]`. The base type keeps only `next_event()`.

Result: `H3Connection` no longer carries a meaningless `receive_data`, and the stub's `type: ignore[override]` is gone - the type hierarchy now states exactly what each transport supports.

### Safety
`Connection(...)` has always returned a protocol-specific subtype via the `__new__` factory, so the base type never has live instances. Dropping the two methods from it is behaviour-preserving for every real object.

### Verification
- `pytest`: 271 passed, 2 skipped (optional-dep interop).
- `mypy.stubtest zttp._zttp`: no method-hierarchy mismatches for the moved methods (the remaining `@final`/`@disjoint_base` notes are pre-existing and are the subject of #116).
- `mypy zttp` and `ruff check` clean.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)