### PR TITLE
Add typed h3_server / h3_client construction helpers

### DIFF
--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -192,6 +192,31 @@ You get the same `Request` / `Data` / `EndOfMessage` events, now tagged with the
 QUIC `stream_id`. An HTTP/3 request collapses its pseudo-headers into the same
 shape the other protocols use, and `http_version` is `b"3"`.
 
+## Typed construction
+
+The raw `Connection(role, HTTP3, ...)` constructor takes a dozen `bytes` keyword
+arguments; because every value is `bytes`, nothing stops a certificate and a
+private key from being swapped. The `h3_server` / `h3_client` factories take named
+value objects instead, so a swap is a type error:
+
+```python
+import zttp
+
+server = zttp.h3_server(
+    zttp.TlsCredentials(certificate=cert_bytes, private_key=key_bytes),
+)
+
+client = zttp.h3_client(
+    server_name=b"example.com",
+    resumption=zttp.SessionResumption(identity=ticket_id, psk=ticket_psk),
+    early_data=True,
+)
+```
+
+`h3_server()` with no credentials creates an ephemeral local identity for
+development. The 0-RTT knobs (`early_data`, `obfuscated_ticket_age`,
+`remembered_transport_params`) require a `resumption` and raise otherwise.
+
 ## The transport is inside
 
 For HTTP/1.1 and HTTP/2, the kernel's TCP gives zttp an ordered, reliable byte

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import pytest
+
+import zttp
+from zttp import config
+
+
+def test_value_objects_are_frozen() -> None:
+    creds = zttp.TlsCredentials(certificate=b"CERT", private_key=b"KEY")
+    resumption = zttp.SessionResumption(identity=b"id", psk=b"psk")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        creds.certificate = b"other"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        resumption.psk = b"other"  # type: ignore[misc]
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> list[tuple[tuple[Any, ...], dict[str, Any]]]:
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def fake(*args: Any, **kwargs: Any) -> str:
+        calls.append((args, kwargs))
+        return "connection"
+
+    monkeypatch.setattr(config, "Connection", fake)
+    return calls
+
+
+def test_h3_server_maps_credentials_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _capture(monkeypatch)
+    config.h3_server(
+        zttp.TlsCredentials(certificate=b"CERT", private_key=b"KEY"),
+        alpn=b"h3",
+        resumption=zttp.SessionResumption(identity=b"id", psk=b"psk"),
+    )
+    (args, kwargs) = calls[0]
+    assert args == (zttp.SERVER, zttp.HTTP3)
+    # The point of the value object: cert and key land in the right slots.
+    assert kwargs["certificate"] == b"CERT"
+    assert kwargs["private_key"] == b"KEY"
+    assert kwargs["alpn"] == b"h3"
+    assert kwargs["resumption_identity"] == b"id"
+    assert kwargs["resumption_psk"] == b"psk"
+
+
+def test_h3_server_defaults_to_ephemeral_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _capture(monkeypatch)
+    config.h3_server()
+    (_, kwargs) = calls[0]
+    assert kwargs["certificate"] is None
+    assert kwargs["private_key"] is None
+
+
+def test_h3_client_maps_resumption_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _capture(monkeypatch)
+    config.h3_client(
+        server_name=b"example.com",
+        resumption=zttp.SessionResumption(identity=b"id", psk=b"psk"),
+        early_data=True,
+        obfuscated_ticket_age=42,
+    )
+    (args, kwargs) = calls[0]
+    assert args == (zttp.CLIENT, zttp.HTTP3)
+    assert kwargs["server_name"] == b"example.com"
+    assert kwargs["resumption_identity"] == b"id"
+    assert kwargs["resumption_psk"] == b"psk"
+    assert kwargs["early_data"] is True
+    assert kwargs["obfuscated_ticket_age"] == 42
+
+
+def test_h3_client_without_resumption_omits_zero_rtt(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _capture(monkeypatch)
+    config.h3_client(server_name=b"example.com")
+    (_, kwargs) = calls[0]
+    assert "obfuscated_ticket_age" not in kwargs
+    assert "early_data" not in kwargs
+    assert "resumption_identity" not in kwargs
+
+
+def test_h3_client_zero_rtt_without_resumption_is_rejected() -> None:
+    with pytest.raises(ValueError, match="require `resumption`"):
+        zttp.h3_client(server_name=b"example.com", early_data=True)
+    with pytest.raises(ValueError, match="require `resumption`"):
+        zttp.h3_client(server_name=b"example.com", obfuscated_ticket_age=1)
+
+
+def test_factories_build_real_h3_connections() -> None:
+    assert isinstance(zttp.h3_server(), zttp.H3Connection)
+    assert isinstance(zttp.h3_client(server_name=b"example.com"), zttp.H3Connection)

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -28,6 +28,7 @@ from zttp._zttp import (
     Stream,
     WindowUpdate,
 )
+from zttp.config import SessionResumption, TlsCredentials, h3_client, h3_server
 
 Event = (
     Request
@@ -68,7 +69,11 @@ __all__ = [
     "Request",
     "Response",
     "RstStream",
+    "SessionResumption",
     "Settings",
     "Stream",
+    "TlsCredentials",
     "WindowUpdate",
+    "h3_client",
+    "h3_server",
 ]

--- a/zttp/config.py
+++ b/zttp/config.py
@@ -111,9 +111,7 @@ def h3_client(
     """
     if resumption is None:
         if early_data or obfuscated_ticket_age or remembered_transport_params is not None:
-            raise ValueError(
-                "early_data, obfuscated_ticket_age and remembered_transport_params require `resumption`"
-            )
+            raise ValueError("early_data, obfuscated_ticket_age and remembered_transport_params require `resumption`")
         return Connection(
             CLIENT,
             HTTP3,

--- a/zttp/config.py
+++ b/zttp/config.py
@@ -1,0 +1,143 @@
+"""Typed construction helpers for HTTP/3 connections.
+
+The raw `Connection(role, HTTP3, ...)` constructor takes a dozen order-independent
+`bytes` keyword arguments. Because every value is `bytes`, the type checker cannot
+tell a certificate from a private key, or one PSK from another. These value objects
+name the pieces, and the `h3_server` / `h3_client` factories assemble them into a
+connection - so a swap is a type error, not a silent handshake failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from zttp._zttp import CLIENT, HTTP3, SERVER, Connection
+
+if TYPE_CHECKING:
+    from zttp._zttp import H3Connection
+
+__all__ = [
+    "SessionResumption",
+    "TlsCredentials",
+    "h3_client",
+    "h3_server",
+]
+
+
+@dataclass(frozen=True)
+class TlsCredentials:
+    """An HTTP/3 server's TLS identity: the certificate and its private key."""
+
+    certificate: bytes
+    private_key: bytes
+
+
+@dataclass(frozen=True)
+class SessionResumption:
+    """A TLS-PSK resumption secret: the ticket identity and its pre-shared key."""
+
+    identity: bytes
+    psk: bytes
+
+
+def h3_server(
+    credentials: TlsCredentials | None = None,
+    *,
+    transport_params: bytes | None = None,
+    alpn: bytes | None = None,
+    resumption: SessionResumption | None = None,
+    random: bytes | None = None,
+    ephemeral_seed: bytes | None = None,
+) -> H3Connection:
+    """Create an HTTP/3 server connection.
+
+    Args:
+        credentials: The server's TLS identity. Defaults to an ephemeral local
+            identity (development only - not a production server identity).
+        transport_params: Encoded QUIC transport parameters. Defaults to zttp's.
+        alpn: The ALPN token. Defaults to ``b"h3"``.
+        resumption: A PSK to accept for session resumption.
+        random: Deterministic randomness (testing).
+        ephemeral_seed: Deterministic key-share seed (testing).
+    """
+    return Connection(
+        SERVER,
+        HTTP3,
+        certificate=credentials.certificate if credentials is not None else None,
+        private_key=credentials.private_key if credentials is not None else None,
+        transport_params=transport_params,
+        alpn=alpn,
+        resumption_identity=resumption.identity if resumption is not None else None,
+        resumption_psk=resumption.psk if resumption is not None else None,
+        random=random,
+        ephemeral_seed=ephemeral_seed,
+    )
+
+
+def h3_client(
+    *,
+    server_name: bytes | None = None,
+    alpn: bytes | None = None,
+    transport_params: bytes | None = None,
+    connection_id: bytes | None = None,
+    resumption: SessionResumption | None = None,
+    early_data: bool = False,
+    obfuscated_ticket_age: int = 0,
+    remembered_transport_params: bytes | None = None,
+    validation_token: bytes | None = None,
+    random: bytes | None = None,
+    ephemeral_seed: bytes | None = None,
+) -> H3Connection:
+    """Create an HTTP/3 client connection.
+
+    Args:
+        server_name: The TLS SNI / :authority host.
+        alpn: The ALPN token. Defaults to ``b"h3"``.
+        transport_params: Encoded QUIC transport parameters. Defaults to zttp's.
+        connection_id: The initial destination connection ID.
+        resumption: A PSK from a prior session to offer for resumption / 0-RTT.
+        early_data: Offer 0-RTT early data (only meaningful with ``resumption``).
+        obfuscated_ticket_age: The obfuscated ticket age for 0-RTT anti-replay.
+        remembered_transport_params: Transport parameters remembered from the
+            resumed session, required to send 0-RTT.
+        validation_token: A NEW_TOKEN address-validation token from a prior connection.
+        random: Deterministic randomness (testing).
+        ephemeral_seed: Deterministic key-share seed (testing).
+
+    Raises:
+        ValueError: if a 0-RTT parameter (``early_data``, ``obfuscated_ticket_age``,
+            ``remembered_transport_params``) is given without ``resumption``.
+    """
+    if resumption is None:
+        if early_data or obfuscated_ticket_age or remembered_transport_params is not None:
+            raise ValueError(
+                "early_data, obfuscated_ticket_age and remembered_transport_params require `resumption`"
+            )
+        return Connection(
+            CLIENT,
+            HTTP3,
+            server_name=server_name,
+            alpn=alpn,
+            transport_params=transport_params,
+            connection_id=connection_id,
+            validation_token=validation_token,
+            random=random,
+            ephemeral_seed=ephemeral_seed,
+        )
+    return Connection(
+        CLIENT,
+        HTTP3,
+        server_name=server_name,
+        alpn=alpn,
+        transport_params=transport_params,
+        connection_id=connection_id,
+        resumption_identity=resumption.identity,
+        resumption_psk=resumption.psk,
+        early_data=early_data,
+        obfuscated_ticket_age=obfuscated_ticket_age,
+        remembered_transport_params=remembered_transport_params,
+        validation_token=validation_token,
+        random=random,
+        ephemeral_seed=ephemeral_seed,
+    )


### PR DESCRIPTION
Addresses the bytes-blob H3 constructor from the API audit.

### Problem
`Connection(role, HTTP3, ...)` takes a dozen order-independent `bytes` keyword arguments (`certificate`, `private_key`, `transport_params`, `resumption_identity`, `resumption_psk`, ...). Because every value is `bytes`, the type checker cannot tell a certificate from a private key - a swap is a silent handshake failure, not a type error.

### Change
Introduce typed, additive construction helpers in a new `zttp.config` module (re-exported from `zttp`):

- Frozen value objects: `TlsCredentials(certificate, private_key)` and `SessionResumption(identity, psk)`.
- Factories `h3_server(...)` / `h3_client(...)` that take those objects and assemble the connection.

```python
server = zttp.h3_server(zttp.TlsCredentials(certificate=cert, private_key=key))
client = zttp.h3_client(
    server_name=b"example.com",
    resumption=zttp.SessionResumption(identity=tid, psk=tpsk),
    early_data=True,
)
```

The 0-RTT parameters are validated up front: `early_data` / `obfuscated_ticket_age` / `remembered_transport_params` without a `resumption` raise `ValueError` instead of failing deeper in the core.

### Scope
The raw constructor keyword arguments are **unchanged** - this is purely additive. A follow-up can move structured encoding (e.g. QUIC transport parameters from a typed object) behind these types in the Zig core; this PR is the type-safe Python surface as the first step. Happy to adjust the shape (e.g. grouping transport params, entropy) to your preference.

### Verification
- New `tests/test_config.py` (7 tests): value objects are frozen; cert/key and PSK map to the right constructor slots (via a captured constructor); 0-RTT omitted without resumption and rejected when passed alone; factories build real `H3Connection`s.
- `pytest`: 278 passed, 2 skipped. `mypy zttp` (strict) and `ruff` clean.
- Docs: "Typed construction" section in `docs/usage/http3.md`.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)