### PR TITLE
Run mypy stubtest in CI to guard the extension stub

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -10,6 +10,9 @@ set -x
 # Python.
 uv run --no-sync ruff format --check --diff $SOURCE_FILES
 uv run --no-sync mypy zttp
+# Verify the hand-written extension stub matches the compiled module, so the
+# types cannot silently drift from _zttp. Intentional gaps live in the allowlist.
+uv run --no-sync python -m mypy.stubtest zttp._zttp --allowlist tests/stubtest_allowlist.txt
 uv run --no-sync ruff check $SOURCE_FILES
 
 # Zig.

--- a/tests/stubtest_allowlist.txt
+++ b/tests/stubtest_allowlist.txt
@@ -1,0 +1,7 @@
+# Intentional, reviewed discrepancies between zttp/_zttp.pyi and the compiled
+# extension. Everything else is a hard error, so the stub cannot silently drift.
+#
+# `Event` is a stub-only type alias (the union of the event classes) used for the
+# next_event() return annotation. It is defined for real in zttp/__init__.py; the
+# extension module has no runtime `Event` attribute, so stubtest sees it as absent.
+zttp._zttp.Event

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Final, Literal, overload
+from typing import Final, Literal, final, overload
+
+from typing_extensions import disjoint_base
 
 SERVER: Final = 1
 CLIENT: Final = 2
@@ -11,6 +13,7 @@ HTTP1: Final = 1
 HTTP2: Final = 2
 HTTP3: Final = 3
 
+@final
 class Request:
     method: bytes
     target: bytes
@@ -21,6 +24,7 @@ class Request:
     stream_id: int
     expect_continue: bool
 
+@final
 class Response:
     status_code: int
     reason: bytes
@@ -28,35 +32,45 @@ class Response:
     headers: list[tuple[bytes, bytes]]
     stream_id: int
 
+@final
 class Data:
     data: bytes
     stream_id: int
 
+@final
 class EndOfMessage:
     trailers: list[tuple[bytes, bytes]]
     stream_id: int
 
+@final
 class RstStream:
     stream_id: int
     error_code: int
 
+@final
 class Goaway:
     last_stream_id: int
     error_code: int
     debug: bytes
 
+@final
 class Settings:
     params: list[tuple[int, int]]
 
+@final
 class Ping:
     ack: bool
     data: bytes
 
+@final
 class WindowUpdate:
     stream_id: int
     increment: int
 
+@final
 class NeedData: ...
+
+@final
 class ConnectionClosed: ...
 
 NEED_DATA: Final[NeedData]
@@ -80,6 +94,7 @@ class ProtocolError(Exception): ...
 class RemoteProtocolError(ProtocolError): ...
 class LocalProtocolError(ProtocolError): ...
 
+@final
 class Stream:
     # A borrowed, re-validated handle to one multiplexed stream - the single send
     # surface for both HTTP/2 and HTTP/3. Obtained via conn.stream(stream_id).
@@ -90,10 +105,11 @@ class Stream:
         self, status: int, headers: list[tuple[bytes, bytes]] | None = ..., end_stream: bool = ...
     ) -> None: ...
     def send_informational(self, status: int, headers: list[tuple[bytes, bytes]] | None = ..., /) -> None: ...
-    def send_data(self, data: bytes) -> None: ...
+    def send_data(self, data: bytes, /) -> None: ...
     def end_message(self, trailers: list[tuple[bytes, bytes]] | None = ..., /) -> None: ...
     def reset(self, error_code: int = ..., /) -> None: ...
 
+@disjoint_base
 class Connection:
     # A factory base: constructing a Connection returns the protocol-specific subtype
     # (H1Connection / H2Connection / H3Connection). Only next_event() is common to
@@ -142,6 +158,7 @@ class Connection:
     def __new__(cls, role: int, protocol: Literal[1] = ...) -> H1Connection: ...
     def next_event(self) -> Event: ...
 
+@final
 class H1Connection(Connection):
     def receive_data(self, data: bytes, /) -> None: ...
     def data_to_send(self) -> bytes: ...
@@ -151,11 +168,12 @@ class H1Connection(Connection):
     ) -> None: ...
     def send_response(self, status: int, headers: list[tuple[bytes, bytes]] | None = ..., /) -> None: ...
     def send_informational(self, status: int, headers: list[tuple[bytes, bytes]] | None = ..., /) -> None: ...
-    def send_data(self, data: bytes) -> None: ...
+    def send_data(self, data: bytes, /) -> None: ...
     def end_message(self, trailers: list[tuple[bytes, bytes]] | None = ...) -> None: ...
     def should_close(self) -> bool: ...
     def upgrade(self) -> bytes | None: ...
 
+@final
 class H2Connection(Connection):
     send_window: int
     def receive_data(self, data: bytes, /) -> None: ...
@@ -175,6 +193,7 @@ class H2Connection(Connection):
     def close(self, error_code: int = ..., last_stream_id: int | None = ..., /) -> None: ...
     def has_pending_send(self) -> bool: ...
 
+@final
 class H3Connection(Connection):
     # Fed by UDP datagrams rather than a byte stream. Server credentials default
     # to an ephemeral local identity; `alpn` defaults to b"h3" (ALPN is mandatory


### PR DESCRIPTION
Adds the stub-drift guard from the API audit.

### Problem
`zttp/_zttp.pyi` is hand-written against the compiled Zig extension and `py.typed` ships, but nothing verified the stub matches the module. A hand-maintained stub silently drifts from the compiled surface (pydantic-core learned this the hard way).

### Change
Add `python -m mypy.stubtest zttp._zttp` to `scripts/check` (the CI check step, which runs after `scripts/install` has built the extension). The one intentional gap - the stub-only `Event` type alias, defined for real in `zttp/__init__.py` - lives in `tests/stubtest_allowlist.txt`; everything else is a hard error.

Fixing what stubtest surfaced, so the allowlist stays tiny:
- `@final` on the non-subclassable extension types (every event class, `Stream`, and the H1/H2/H3 connections);
- `@disjoint_base` on `Connection`;
- the `METH_O` `send_data` is now positional-only in the stub.

### Verification
Locally, `python -m mypy.stubtest zttp._zttp --allowlist tests/stubtest_allowlist.txt` exits 0; `mypy zttp`, `ruff format --check`, `ruff check`, and the full test suite (271 passed) are clean.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)