### PR TITLE
Report benchmark dispersion and document the write-API asymmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ identical data, median of 15 interleaved batches:
 | Simple GET        | ~1.24M req/s | ~1.07M req/s | **~1.16x**        |
 | POST + JSON body  | ~1.42M req/s | ~1.25M req/s | **~1.14x**        |
 
+These ratios are medians; a single-digit-percent edge is close enough that
+run-to-run noise matters, so `scripts/bench` reports each workload's p25-p75
+quartiles and standard deviation alongside the median, and prints the ratio's own
+p25-p75 so you can see whether an edge is real or within the spread. On the
+closest workloads that band can straddle 1.0.
+
 zttp beats a C parser on 13 of the benchmark suite's 14 workloads while staying
 sans-IO and event-based, and is roughly 15x faster than the pure-Python
 alternative. Run it yourself: `./scripts/bench`.

--- a/benchmarks/http1.py
+++ b/benchmarks/http1.py
@@ -6,8 +6,9 @@ so the comparison reflects real work, not just feed_data overhead.
 
 Methodology: every parser runs many short batches, interleaved round-robin so
 thermal drift and scheduler placement hit all parsers equally, with the GC
-disabled while a batch is timed. The headline number is the median batch, with
-the spread reported so noise is visible instead of hidden.
+disabled while a batch is timed. The headline number is the median batch,
+reported with its p25-p75 quartiles and stdev so run-to-run noise is visible
+instead of hidden.
 
 The workloads are drawn from the parser-benchmark literature wherever one
 exists (picohttpparser/llhttp/httparse fixtures, the wrk and TechEmpower
@@ -460,6 +461,19 @@ def timed(fn: Runner, n: int) -> float:
         gc.enable()
 
 
+# The ratio's p25-p75 per workload, filled by bench() and shown in the summary.
+dispersion: dict[str, tuple[float, float]] = {}
+
+
+def _quartiles(values: list[float]) -> tuple[float, float, float]:
+    """Return (p25, median, p75). statistics.quantiles needs at least two points."""
+    if len(values) < 2:
+        v = values[0]
+        return (v, v, v)
+    q1, median, q3 = statistics.quantiles(values, n=4)
+    return (q1, median, q3)
+
+
 def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
     verify(w)
     batch = max(1, int(batch * w.scale))
@@ -474,15 +488,23 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
         for label, fn in parsers:
             samples[label].append(timed(fn, batch))
 
+    per_batch = {label: [batch / dt for dt in batches] for label, batches in samples.items()}
     rates: dict[str, float] = {}
-    for label, batches in samples.items():
-        per_batch = [batch / dt for dt in batches]
-        median = statistics.median(per_batch)
-        spread = (max(per_batch) - min(per_batch)) / median * 100
+    for label, values in per_batch.items():
+        p25, median, p75 = _quartiles(values)
+        stdev = statistics.stdev(values)
         rates[label] = median
-        print(f"  {label:>10}: {median:12,.0f} msg/s  (median of {repeats}, spread {spread:4.1f}%)")
+        print(
+            f"  {label:>10}: {median:12,.0f} msg/s  "
+            f"(median of {repeats}, p25-p75 {p25:,.0f}-{p75:,.0f}, stdev {stdev / median * 100:4.1f}%)"
+        )
 
-    line = f"  -> zttp is {rates['zttp'] / rates['httptools']:.2f}x httptools"
+    # The ratio's own dispersion: pair the interleaved zttp/httptools batches and
+    # take each batch's ratio, so the headline number comes with error bars.
+    ratios = [z / h for z, h in zip(per_batch["zttp"], per_batch["httptools"], strict=True)]
+    r25, rmed, r75 = _quartiles(ratios)
+    dispersion[w.name] = (r25, r75)
+    line = f"  -> zttp is {rmed:.2f}x httptools (p25-p75 {r25:.2f}-{r75:.2f})"
     if "h11" in rates:
         line += f", {rates['zttp'] / rates['h11']:.2f}x h11"
     print(line)
@@ -503,10 +525,14 @@ def main() -> None:
     selected = [w for w in WORKLOADS if args.only is None or args.only.lower() in w.name.lower()]
     results = {w.name: bench(w, args.batch, args.repeats) for w in selected}
 
-    print(f"\n{'workload':<32} {'zttp':>12} {'httptools':>12} {'ratio':>7}")
+    print(f"\n{'workload':<32} {'zttp':>12} {'httptools':>12} {'ratio':>7} {'p25-p75':>13}")
     for name, rates in results.items():
         ratio = rates["zttp"] / rates["httptools"]
-        print(f"{name:<32} {rates['zttp']:>12,.0f} {rates['httptools']:>12,.0f} {ratio:>6.2f}x")
+        r25, r75 = dispersion[name]
+        print(
+            f"{name:<32} {rates['zttp']:>12,.0f} {rates['httptools']:>12,.0f} "
+            f"{ratio:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}"
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/http2.py
+++ b/benchmarks/http2.py
@@ -13,9 +13,9 @@ or status, headers, body), verified equal before timing.
 
 Methodology mirrors http1.py: many short batches interleaved round-robin so
 thermal drift hits both parsers equally, GC disabled while a batch is timed, and
-the median batch reported with its spread so noise is visible. msg/s counts
-HTTP/2 *messages* (requests or responses), so a 16-stream workload that decodes
-in one pass still counts as 16.
+the median batch reported with its p25-p75 quartiles and stdev so noise is
+visible. msg/s counts HTTP/2 *messages* (requests or responses), so a 16-stream
+workload that decodes in one pass still counts as 16.
 """
 
 from __future__ import annotations
@@ -408,6 +408,19 @@ def timed(fn: Runner, n: int) -> float:
         gc.enable()
 
 
+# The ratio's p25-p75 per workload, filled by bench() and shown in the summary.
+dispersion: dict[str, tuple[float, float]] = {}
+
+
+def _quartiles(values: list[float]) -> tuple[float, float, float]:
+    """Return (p25, median, p75). statistics.quantiles needs at least two points."""
+    if len(values) < 2:
+        v = values[0]
+        return (v, v, v)
+    q1, median, q3 = statistics.quantiles(values, n=4)
+    return (q1, median, q3)
+
+
 def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
     verify(w)
     batch = max(1, int(batch * w.scale))
@@ -422,15 +435,23 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
         for label, fn in parsers:
             samples[label].append(timed(fn, batch))
 
+    per_batch = {label: [batch * w.messages / dt for dt in batches] for label, batches in samples.items()}
     rates: dict[str, float] = {}
-    for label, batches in samples.items():
-        per_batch = [batch * w.messages / dt for dt in batches]
-        median = statistics.median(per_batch)
-        spread = (max(per_batch) - min(per_batch)) / median * 100
+    for label, values in per_batch.items():
+        p25, median, p75 = _quartiles(values)
+        stdev = statistics.stdev(values)
         rates[label] = median
-        print(f"  {label:>10}: {median:14,.0f} msg/s  (median of {repeats}, spread {spread:4.1f}%)")
+        print(
+            f"  {label:>10}: {median:14,.0f} msg/s  "
+            f"(median of {repeats}, p25-p75 {p25:,.0f}-{p75:,.0f}, stdev {stdev / median * 100:4.1f}%)"
+        )
 
-    print(f"  -> zttp is {rates['zttp'] / rates['h2']:.2f}x h2")
+    # The ratio's own dispersion: pair the interleaved zttp/h2 batches and take
+    # each batch's ratio, so the headline number comes with error bars.
+    ratios = [z / h for z, h in zip(per_batch["zttp"], per_batch["h2"], strict=True)]
+    r25, rmed, r75 = _quartiles(ratios)
+    dispersion[w.name] = (r25, r75)
+    print(f"  -> zttp is {rmed:.2f}x h2 (p25-p75 {r25:.2f}-{r75:.2f})")
     return rates
 
 
@@ -446,10 +467,11 @@ def main() -> None:
     workloads = [Workload(w.name, w.streams, w.kind, w.scale, wire=_encode(w)) for w in selected]
     results = {w.name: bench(w, args.batch, args.repeats) for w in workloads}
 
-    print(f"\n{'workload':<36} {'zttp':>14} {'h2':>14} {'ratio':>7}")
+    print(f"\n{'workload':<36} {'zttp':>14} {'h2':>14} {'ratio':>7} {'p25-p75':>13}")
     for name, rates in results.items():
         ratio = rates["zttp"] / rates["h2"]
-        print(f"{name:<36} {rates['zttp']:>14,.0f} {rates['h2']:>14,.0f} {ratio:>6.2f}x")
+        r25, r75 = dispersion[name]
+        print(f"{name:<36} {rates['zttp']:>14,.0f} {rates['h2']:>14,.0f} {ratio:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}")
 
 
 if __name__ == "__main__":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,36 @@ The sans-IO discipline is unchanged: the core never touches a socket. The bounda
 just moved from "decrypted byte stream" (TCP) down to "UDP datagram" (QUIC); the
 event side - bytes in, events out, no I/O in the core - is identical.
 
+## Why the write API is imperative, not symmetric with the read API
+
+h11 is symmetric: you read with `conn.next_event()` and write with
+`conn.send(h11.Response(...))` - the same event objects flow both ways. zttp is
+deliberately **not** symmetric. The read side yields `Request` / `Response` /
+`Data` events; the write side is imperative methods (`send_response(status,
+headers)`, `send_data(...)`, `end_message(...)`), so the event objects are
+read-only outputs and are never constructed by the caller.
+
+This is a considered trade-off:
+
+- **The engine owns framing.** Content-Length vs chunked, HTTP/2 flow-control
+  parking, HTTP/3 packetisation against the current clock - the writer decides all
+  of it from the connection state. An imperative call passes the minimum the engine
+  cannot infer; a symmetric `send(Response(...))` would invite callers to set
+  framing fields the engine must then validate or override.
+- **Read and write payloads are not the same type.** A parsed `Request` carries a
+  synthesized `host` header, `expect_continue`, the decoded `path`/`query`, and a
+  `stream_id` the engine assigned. A caller building a request does not supply
+  those. Reusing one class for both directions would mean a type whose fields are
+  half input, half output.
+- **The event objects stay cheap.** They are read-only views over the parse buffer
+  with no constructor to validate, which is part of why the read path is fast.
+
+The cost is that a `Response` cannot be built as a value, passed around, and sent
+later - the pattern h11 proxies lean on. If a future need makes that compelling,
+an additive `stream.send(event)` overload could accept an event object without
+removing the imperative methods. Recording the decision here so the asymmetry
+reads as intentional, not accidental.
+
 ## Memory safety
 
 Because the core is Python-agnostic, every slice it hands out points into a buffer


### PR DESCRIPTION
The two smaller rigor items from the API audit.

### Benchmark dispersion
The headline "~1.16x" was a bare median with no spread, so a single-digit-percent edge couldn't be told from run-to-run noise. `benchmarks/http1.py` and `http2.py` now:
- report each parser's **p25-p75 quartiles and standard deviation** per workload (replacing the crude `(max-min)/median`);
- compute the **ratio's own p25-p75** from the interleaved per-batch pairs, and show it in both the per-workload line and the summary table.

On the closest workloads that band straddles 1.0 - i.e. the edge is within noise - which is now visible instead of hidden. Example from a local run:

```
workload                             zttp    httptools   ratio   p25-p75
wrk default GET                 1,415,950    1,107,725   1.28x   1.16-1.32
k8s ingress proxied GET           389,595      390,531   1.00x   0.91-1.21
```

The README explains that the ratios are medians and points at the per-workload dispersion output. (I left the README's measured macOS-arm64 numbers as-is - I can't re-measure on that hardware; the numbers above are an illustrative local run.)

### Write-API asymmetry (design note)
h11 is symmetric (`next_event()` to read, `conn.send(Response(...))` to write); zttp's write side is imperative (`send_response(...)`) and the event objects are read-only. `docs/architecture.md` now records **why** this is deliberate - the engine owns framing, read vs write payloads are genuinely different types, and the event objects stay allocation-cheap - and notes that an additive `stream.send(event)` overload stays open if a value-style write path is ever wanted. This is the "decide deliberately" half of the issue; the decision is yours to ratify, the doc just makes the asymmetry intentional rather than accidental.

### Verification
`ruff check` / `ruff format --check` on the benchmarks are clean; the benchmark ran end-to-end with the new output; the test suite is unaffected (271 passed).

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)