### PR TITLE
Take HTTP/3 credentials and resumption as typed value objects

### DIFF
--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -26,6 +26,25 @@ transport parameters, connection IDs, and handshake entropy are advanced
 overrides for deterministic tests and interoperability work, not the normal user
 API.
 
+The handshake's two same-typed `bytes` pairs - a server's certificate and key,
+and a resumption ticket's identity and PSK - are passed as **value objects** so
+they cannot be transposed. A swap is a type error, not a handshake failure:
+
+```python
+server = zttp.Connection(
+    zttp.SERVER, zttp.HTTP3,
+    credentials=zttp.TlsCredentials(certificate=cert, private_key=key),
+)
+client = zttp.Connection(
+    zttp.CLIENT, zttp.HTTP3,
+    server_name=b"example.com",
+    resumption=zttp.SessionResumption(identity=ticket_id, psk=ticket_psk),
+)
+```
+
+Omit `credentials` and the server uses an ephemeral local identity (development
+only).
+
 !!! warning "Scope"
     HTTP/3 support is still experimental. The public surface is intentionally
     the same event model as HTTP/1.1 and HTTP/2, but the transport underneath is

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1400,30 +1400,48 @@ fn new_h2(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
 fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
     var role_val: c_long = 0;
     var protocol_val: c_long = HTTP3;
-    var cert_obj: ?*c.PyObject = null;
-    var key_obj: ?*c.PyObject = null;
+    var credentials_obj: ?*c.PyObject = null;
     var tp_obj: ?*c.PyObject = null;
     var random_obj: ?*c.PyObject = null;
     var ephemeral_obj: ?*c.PyObject = null;
     var alpn_obj: ?*c.PyObject = null;
     var cid_obj: ?*c.PyObject = null;
     var sni_obj: ?*c.PyObject = null;
-    var resumption_identity_obj: ?*c.PyObject = null;
-    var resumption_psk_obj: ?*c.PyObject = null;
+    var resumption_obj: ?*c.PyObject = null;
     var obfuscated_ticket_age_obj: ?*c.PyObject = null;
     var early_data_obj: ?*c.PyObject = null;
     var remembered_tp_obj: ?*c.PyObject = null;
     var validation_token_obj: ?*c.PyObject = null;
     var kwlist = [_][*c]u8{
-        @constCast("role"),                  @constCast("protocol"),            @constCast("certificate"),
-        @constCast("private_key"),           @constCast("transport_params"),    @constCast("random"),
-        @constCast("ephemeral_seed"),        @constCast("alpn"),                @constCast("connection_id"),
-        @constCast("server_name"),           @constCast("resumption_identity"), @constCast("resumption_psk"),
-        @constCast("obfuscated_ticket_age"), @constCast("early_data"),          @constCast("remembered_transport_params"),
-        @constCast("validation_token"),      null,
+        @constCast("role"),                        @constCast("protocol"),              @constCast("credentials"),
+        @constCast("transport_params"),            @constCast("random"),                @constCast("ephemeral_seed"),
+        @constCast("alpn"),                        @constCast("connection_id"),         @constCast("server_name"),
+        @constCast("resumption"),                  @constCast("obfuscated_ticket_age"), @constCast("early_data"),
+        @constCast("remembered_transport_params"), @constCast("validation_token"),      null,
     };
-    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l$OOOOOOOOOOOOOO", @ptrCast(&kwlist), &role_val, &protocol_val, &cert_obj, &key_obj, &tp_obj, &random_obj, &ephemeral_obj, &alpn_obj, &cid_obj, &sni_obj, &resumption_identity_obj, &resumption_psk_obj, &obfuscated_ticket_age_obj, &early_data_obj, &remembered_tp_obj, &validation_token_obj) == 0) return null;
+    if (c.PyArg_ParseTupleAndKeywords(args, kwds, "l|l$OOOOOOOOOOOO", @ptrCast(&kwlist), &role_val, &protocol_val, &credentials_obj, &tp_obj, &random_obj, &ephemeral_obj, &alpn_obj, &cid_obj, &sni_obj, &resumption_obj, &obfuscated_ticket_age_obj, &early_data_obj, &remembered_tp_obj, &validation_token_obj) == 0) return null;
     if (protocol_val != HTTP3) return py.raiseValue("protocol does not match this Connection subclass; construct zttp.Connection to choose by protocol");
+
+    // Unpack the credential / resumption value objects into the raw byte objects the
+    // builders consume. TlsCredentials(certificate, private_key) and
+    // SessionResumption(identity, psk) name the same-typed byte pairs so a caller
+    // cannot transpose them. The GetAttr results are owned refs; free them on return.
+    var cert_obj: ?*c.PyObject = null;
+    var key_obj: ?*c.PyObject = null;
+    var resumption_identity_obj: ?*c.PyObject = null;
+    var resumption_psk_obj: ?*c.PyObject = null;
+    defer py.xdecref(cert_obj);
+    defer py.xdecref(key_obj);
+    defer py.xdecref(resumption_identity_obj);
+    defer py.xdecref(resumption_psk_obj);
+    if (credentials_obj != null and !py.isNone(credentials_obj)) {
+        cert_obj = c.PyObject_GetAttrString(credentials_obj, "certificate") orelse return null;
+        key_obj = c.PyObject_GetAttrString(credentials_obj, "private_key") orelse return null;
+    }
+    if (resumption_obj != null and !py.isNone(resumption_obj)) {
+        resumption_identity_obj = c.PyObject_GetAttrString(resumption_obj, "identity") orelse return null;
+        resumption_psk_obj = c.PyObject_GetAttrString(resumption_obj, "psk") orelse return null;
+    }
 
     const alloc = tp.?.tp_alloc.?;
     const obj = alloc(tp, 0);

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import zttp
+
+
+def test_value_objects_are_frozen() -> None:
+    creds = zttp.TlsCredentials(certificate=b"CERT", private_key=b"KEY")
+    resumption = zttp.SessionResumption(identity=b"id", psk=b"\x00" * 32)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        creds.certificate = b"other"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        resumption.psk = b"other"  # type: ignore[misc]
+
+
+def test_credentials_and_resumption_need_both_halves() -> None:
+    # Naming both fields is the whole point: neither can be built half-formed, so a
+    # certificate/key (or identity/psk) swap has nowhere to hide.
+    with pytest.raises(TypeError):
+        zttp.TlsCredentials(certificate=b"CERT")  # type: ignore[call-arg]
+    with pytest.raises(TypeError):
+        zttp.SessionResumption(identity=b"id")  # type: ignore[call-arg]
+
+
+def test_h3_constructor_takes_value_objects() -> None:
+    client = zttp.Connection(
+        zttp.CLIENT,
+        zttp.HTTP3,
+        server_name=b"example.com",
+        resumption=zttp.SessionResumption(identity=b"ticket", psk=b"\x00" * 32),
+    )
+    assert isinstance(client, zttp.H3Connection)
+
+
+def test_h3_constructor_rejects_the_old_raw_kwargs() -> None:
+    for bad in (
+        {"certificate": b"c", "private_key": b"k"},
+        {"resumption_identity": b"i", "resumption_psk": b"\x00" * 32},
+    ):
+        with pytest.raises(TypeError):
+            zttp.Connection(zttp.SERVER, zttp.HTTP3, **bad)  # type: ignore[call-overload]

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -14,8 +14,7 @@ SERVER_PUBLIC_KEY = bytes.fromhex(
     "89c6c886572fd6dad9d01e0b98c5fec3276e9a2e4b89705140f564f7eb65016b95"
 )
 SERVER_CONFIG = {
-    "certificate": SERVER_PUBLIC_KEY,
-    "private_key": b"\x42" * 32,
+    "credentials": zttp.TlsCredentials(certificate=SERVER_PUBLIC_KEY, private_key=b"\x42" * 32),
     "transport_params": (
         b"\x04\x04\x80\x10\x00\x00"  # initial_max_data = 1048576
         b"\x08\x01\x08"  # initial_max_streams_bidi = 8
@@ -171,7 +170,7 @@ def test_http3_default_client_and_server_exchange_request() -> None:
 
 def test_http3_client_rejects_unverifiable_server_certificate() -> None:
     config = dict(SERVER_CONFIG)
-    config["certificate"] = b"\xcc" * 48
+    config["credentials"] = zttp.TlsCredentials(certificate=b"\xcc" * 48, private_key=b"\x42" * 32)
     client = make_client()
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
 
@@ -291,8 +290,7 @@ def test_http3_received_session_ticket_psk_resumes_later_connection() -> None:
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x47",
-            "resumption_identity": identity,
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=identity, psk=psk),
             "obfuscated_ticket_age": obfuscated_ticket_age(age_add, 3000, 6000),
         }
     )
@@ -339,8 +337,7 @@ def test_http3_ticket_age_mismatch_does_not_accept_zero_rtt() -> None:
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x48",
-            "resumption_identity": identity,
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=identity, psk=psk),
             "obfuscated_ticket_age": 0,
             "early_data": True,
             "remembered_transport_params": SERVER_CONFIG["transport_params"],
@@ -382,8 +379,7 @@ def test_http3_expired_ticket_does_not_accept_zero_rtt() -> None:
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x49",
-            "resumption_identity": identity,
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=identity, psk=psk),
             "obfuscated_ticket_age": obfuscated_ticket_age(age_add, 3000, resume_at),
             "early_data": True,
             "remembered_transport_params": SERVER_CONFIG["transport_params"],
@@ -425,8 +421,7 @@ def test_http3_ticket_without_early_data_extension_does_not_accept_zero_rtt() ->
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x4a",
-            "resumption_identity": identity,
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=identity, psk=psk),
             "obfuscated_ticket_age": obfuscated_ticket_age(age_add, 3000, 6000),
             "early_data": True,
             "remembered_transport_params": SERVER_CONFIG["transport_params"],
@@ -468,8 +463,7 @@ def test_http3_zero_rtt_ticket_is_single_use() -> None:
         client_config.update(
             {
                 "connection_id": connection_id,
-                "resumption_identity": identity,
-                "resumption_psk": psk,
+                "resumption": zttp.SessionResumption(identity=identity, psk=psk),
                 "obfuscated_ticket_age": obfuscated_ticket_age(age_add, 3000, now),
                 "early_data": True,
                 "remembered_transport_params": SERVER_CONFIG["transport_params"],
@@ -502,16 +496,14 @@ def test_http3_client_server_resumed_handshake() -> None:
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x45",
-            "resumption_identity": b"ticket-identity",
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
             "obfuscated_ticket_age": 0x01020304,
         }
     )
     server_config = dict(SERVER_CONFIG)
     server_config.update(
         {
-            "resumption_identity": b"ticket-identity",
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
         }
     )
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **client_config)
@@ -539,8 +531,7 @@ def test_http3_static_resumption_credentials_do_not_accept_zero_rtt() -> None:
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x46",
-            "resumption_identity": b"ticket-identity",
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
             "obfuscated_ticket_age": 0x01020304,
             "early_data": True,
             "remembered_transport_params": SERVER_CONFIG["transport_params"],
@@ -549,8 +540,7 @@ def test_http3_static_resumption_credentials_do_not_accept_zero_rtt() -> None:
     server_config = dict(SERVER_CONFIG)
     server_config.update(
         {
-            "resumption_identity": b"ticket-identity",
-            "resumption_psk": psk,
+            "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
         }
     )
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **client_config)
@@ -721,10 +711,11 @@ def test_http3_server_defaults_transport_settings_and_credentials() -> None:
 
 
 def test_http3_server_custom_credentials_must_be_a_pair() -> None:
+    # TlsCredentials names both halves, so a lone certificate or key cannot be built.
     with pytest.raises(TypeError):
-        zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, certificate=b"\xcc" * 48)
+        zttp.TlsCredentials(certificate=b"\xcc" * 48)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
-        zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, private_key=b"\x42" * 32)
+        zttp.TlsCredentials(private_key=b"\x42" * 32)  # type: ignore[call-arg]
 
 
 def test_http3_rejects_a_wrong_size_key() -> None:
@@ -732,8 +723,7 @@ def test_http3_rejects_a_wrong_size_key() -> None:
         zttp.Connection(
             zttp.SERVER,
             protocol=zttp.HTTP3,
-            certificate=b"\xcc" * 48,
-            private_key=b"\x42" * 16,
+            credentials=zttp.TlsCredentials(certificate=b"\xcc" * 48, private_key=b"\x42" * 16),
             transport_params=b"\x00\x01",
             random=b"\xab" * 32,
             ephemeral_seed=b"\x33" * 32,

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -28,6 +28,7 @@ from zttp._zttp import (
     Stream,
     WindowUpdate,
 )
+from zttp.config import SessionResumption, TlsCredentials
 
 Event = (
     Request
@@ -68,7 +69,9 @@ __all__ = [
     "Request",
     "Response",
     "RstStream",
+    "SessionResumption",
     "Settings",
     "Stream",
+    "TlsCredentials",
     "WindowUpdate",
 ]

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -6,6 +6,8 @@ from typing import Final, Literal, final, overload
 
 from typing_extensions import disjoint_base
 
+from zttp.config import SessionResumption, TlsCredentials
+
 SERVER: Final = 1
 CLIENT: Final = 2
 # Literal-typed so Connection(role, HTTP2) selects the H2Connection __new__ overload.
@@ -124,14 +126,12 @@ class Connection:
         role: Literal[1],
         protocol: Literal[3],
         *,
-        certificate: bytes | None = ...,
-        private_key: bytes | None = ...,
+        credentials: TlsCredentials | None = ...,
         transport_params: bytes | None = ...,
         random: bytes | None = ...,
         ephemeral_seed: bytes | None = ...,
         alpn: bytes | None = ...,
-        resumption_identity: bytes | None = ...,
-        resumption_psk: bytes | None = ...,
+        resumption: SessionResumption | None = ...,
     ) -> H3Connection: ...
     @overload
     def __new__(
@@ -145,8 +145,7 @@ class Connection:
         connection_id: bytes | None = ...,
         alpn: bytes | None = ...,
         server_name: bytes | None = ...,
-        resumption_identity: bytes | None = ...,
-        resumption_psk: bytes | None = ...,
+        resumption: SessionResumption | None = ...,
         obfuscated_ticket_age: int = ...,
         early_data: bool = ...,
         remembered_transport_params: bytes | None = ...,

--- a/zttp/config.py
+++ b/zttp/config.py
@@ -1,0 +1,33 @@
+"""Typed value objects for the HTTP/3 constructor.
+
+The HTTP/3 handshake needs two pairs of same-typed `bytes` - a certificate and its
+private key, and a resumption ticket identity and its PSK. Passed as bare keyword
+arguments they can be silently transposed. These frozen value objects name each
+half, so `Connection(SERVER, HTTP3, credentials=TlsCredentials(...))` makes a swap
+a type error rather than a handshake failure.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "SessionResumption",
+    "TlsCredentials",
+]
+
+
+@dataclass(frozen=True)
+class TlsCredentials:
+    """An HTTP/3 server's TLS identity: the certificate and its private key."""
+
+    certificate: bytes
+    private_key: bytes
+
+
+@dataclass(frozen=True)
+class SessionResumption:
+    """A TLS-PSK resumption secret: the ticket identity and its pre-shared key."""
+
+    identity: bytes
+    psk: bytes


### PR DESCRIPTION
Fresh take on issue #115 (the bytes-blob H3 constructor), replacing the closed #121 factory approach - no factory functions, construction still goes through `zttp.Connection(role, HTTP3, ...)`.

### Problem
The H3 constructor took the certificate + private key, and the resumption identity + PSK, as four bare `bytes` keyword arguments. Each pair is the **same type**, so a caller could transpose them and only find out at the handshake.

### Change
Replace those four kwargs with two frozen value objects passed to the same constructor:

```python
server = zttp.Connection(
    zttp.SERVER, zttp.HTTP3,
    credentials=zttp.TlsCredentials(certificate=cert, private_key=key),
)
client = zttp.Connection(
    zttp.CLIENT, zttp.HTTP3,
    server_name=b"example.com",
    resumption=zttp.SessionResumption(identity=tid, psk=tpsk),
)
```

Naming each half makes a swap a type error. Only the two genuinely-swappable same-typed pairs are grouped; the individually-named scalars (`server_name`, `alpn`, `connection_id`, `early_data`, …) stay as they were. The Zig `__new__` reads `.certificate`/`.private_key` and `.identity`/`.psk` off the objects; the rest of the handshake path is untouched. The four old raw kwargs are **removed** (the API is experimental, and keeping them would re-expose the swap).

### Verification
- New `tests/test_config.py`: value objects are frozen, require both halves, drive a real `H3Connection`, and the old raw kwargs now raise `TypeError`.
- Existing H3 tests migrated to the value objects (82 pass).
- Full suite: 275 passed, 2 skipped. `ruff format --check`, `ruff check`, `mypy` (strict), `mypy.stubtest` (matches #122's guard), and `zig fmt --check` all clean.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)