### PR TITLE
Fix the benchmark summary ratio and single-repeat stdev

### DIFF
--- a/benchmarks/http1.py
+++ b/benchmarks/http1.py
@@ -461,8 +461,8 @@ def timed(fn: Runner, n: int) -> float:
         gc.enable()
 
 
-# The ratio's p25-p75 per workload, filled by bench() and shown in the summary.
-dispersion: dict[str, tuple[float, float]] = {}
+# The paired-ratio median and p25-p75 per workload, filled by bench() for the summary.
+dispersion: dict[str, tuple[float, float, float]] = {}  # workload -> (ratio median, p25, p75)
 
 
 def _quartiles(values: list[float]) -> tuple[float, float, float]:
@@ -492,7 +492,7 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
     rates: dict[str, float] = {}
     for label, values in per_batch.items():
         p25, median, p75 = _quartiles(values)
-        stdev = statistics.stdev(values)
+        stdev = statistics.stdev(values) if len(values) > 1 else 0.0
         rates[label] = median
         print(
             f"  {label:>10}: {median:12,.0f} msg/s  "
@@ -500,10 +500,11 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
         )
 
     # The ratio's own dispersion: pair the interleaved zttp/httptools batches and
-    # take each batch's ratio, so the headline number comes with error bars.
+    # take each batch's ratio, so the headline number comes with error bars. Store the
+    # paired-ratio median (not median/median) so the summary is consistent with its band.
     ratios = [z / h for z, h in zip(per_batch["zttp"], per_batch["httptools"], strict=True)]
     r25, rmed, r75 = _quartiles(ratios)
-    dispersion[w.name] = (r25, r75)
+    dispersion[w.name] = (rmed, r25, r75)
     line = f"  -> zttp is {rmed:.2f}x httptools (p25-p75 {r25:.2f}-{r75:.2f})"
     if "h11" in rates:
         line += f", {rates['zttp'] / rates['h11']:.2f}x h11"
@@ -527,11 +528,10 @@ def main() -> None:
 
     print(f"\n{'workload':<32} {'zttp':>12} {'httptools':>12} {'ratio':>7} {'p25-p75':>13}")
     for name, rates in results.items():
-        ratio = rates["zttp"] / rates["httptools"]
-        r25, r75 = dispersion[name]
+        rmed, r25, r75 = dispersion[name]
         print(
             f"{name:<32} {rates['zttp']:>12,.0f} {rates['httptools']:>12,.0f} "
-            f"{ratio:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}"
+            f"{rmed:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}"
         )
 
 

--- a/benchmarks/http2.py
+++ b/benchmarks/http2.py
@@ -408,8 +408,8 @@ def timed(fn: Runner, n: int) -> float:
         gc.enable()
 
 
-# The ratio's p25-p75 per workload, filled by bench() and shown in the summary.
-dispersion: dict[str, tuple[float, float]] = {}
+# The paired-ratio median and p25-p75 per workload, filled by bench() for the summary.
+dispersion: dict[str, tuple[float, float, float]] = {}  # workload -> (ratio median, p25, p75)
 
 
 def _quartiles(values: list[float]) -> tuple[float, float, float]:
@@ -439,7 +439,7 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
     rates: dict[str, float] = {}
     for label, values in per_batch.items():
         p25, median, p75 = _quartiles(values)
-        stdev = statistics.stdev(values)
+        stdev = statistics.stdev(values) if len(values) > 1 else 0.0
         rates[label] = median
         print(
             f"  {label:>10}: {median:14,.0f} msg/s  "
@@ -447,10 +447,11 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
         )
 
     # The ratio's own dispersion: pair the interleaved zttp/h2 batches and take
-    # each batch's ratio, so the headline number comes with error bars.
+    # each batch's ratio, so the headline number comes with error bars. Store the
+    # paired-ratio median (not median/median) so the summary is consistent with its band.
     ratios = [z / h for z, h in zip(per_batch["zttp"], per_batch["h2"], strict=True)]
     r25, rmed, r75 = _quartiles(ratios)
-    dispersion[w.name] = (r25, r75)
+    dispersion[w.name] = (rmed, r25, r75)
     print(f"  -> zttp is {rmed:.2f}x h2 (p25-p75 {r25:.2f}-{r75:.2f})")
     return rates
 
@@ -469,9 +470,8 @@ def main() -> None:
 
     print(f"\n{'workload':<36} {'zttp':>14} {'h2':>14} {'ratio':>7} {'p25-p75':>13}")
     for name, rates in results.items():
-        ratio = rates["zttp"] / rates["h2"]
-        r25, r75 = dispersion[name]
-        print(f"{name:<36} {rates['zttp']:>14,.0f} {rates['h2']:>14,.0f} {ratio:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}")
+        rmed, r25, r75 = dispersion[name]
+        print(f"{name:<36} {rates['zttp']:>14,.0f} {rates['h2']:>14,.0f} {rmed:>6.2f}x {f'{r25:.2f}-{r75:.2f}':>13}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #124, addressing the two Codex P2 review comments on it (which merged before I could fold these in).

### Summary ratio was a different statistic than its band
The summary table printed `median(zttp) / median(httptools)` as the ratio, but showed the **paired** per-batch p25-p75 band next to it. Those are different statistics, so the ratio could fall outside its own band (e.g. a workload showing `1.34x` next to `1.23-1.35`). Now the summary prints the **paired-ratio median** stored from `bench()`, so the headline matches the band it's shown with.

### Single-repeat runs crashed
`statistics.stdev(values)` raises `StatisticsError` with one sample, so `scripts/bench http1 --repeats 1` (a common smoke run) blew up - the old spread math handled a single batch. Guarded to `0.0` for one sample.

Both applied to `benchmarks/http1.py` and `benchmarks/http2.py`.

### Verification
`ruff check` / `ruff format --check` clean; `--repeats 1` now runs (stdev 0.0%), and a normal run's summary ratio matches the per-workload paired-ratio line and its band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)