### PR TITLE
Make the HTTP/3 credential value objects keyword-only

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,3 +42,15 @@ def test_h3_constructor_rejects_the_old_raw_kwargs() -> None:
     ):
         with pytest.raises(TypeError):
             zttp.Connection(zttp.SERVER, zttp.HTTP3, **bad)  # type: ignore[call-overload]
+
+
+def test_value_objects_are_keyword_only() -> None:
+    # Positional construction is where a same-typed swap could still hide, so the
+    # fields are keyword-only: TlsCredentials(key, cert) is a TypeError, not a silent
+    # transposition.
+    with pytest.raises(TypeError):
+        zttp.TlsCredentials(b"cert", b"key")  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        zttp.SessionResumption(b"id", b"psk")  # type: ignore[misc]
+    # Keyword construction is unaffected.
+    assert zttp.TlsCredentials(certificate=b"c", private_key=b"k").private_key == b"k"

--- a/zttp/config.py
+++ b/zttp/config.py
@@ -4,7 +4,8 @@ The HTTP/3 handshake needs two pairs of same-typed `bytes` - a certificate and i
 private key, and a resumption ticket identity and its PSK. Passed as bare keyword
 arguments they can be silently transposed. These frozen value objects name each
 half, so `Connection(SERVER, HTTP3, credentials=TlsCredentials(...))` makes a swap
-a type error rather than a handshake failure.
+a type error rather than a handshake failure. They are keyword-only, so even
+positional construction cannot transpose the two same-typed fields.
 """
 
 from __future__ import annotations
@@ -17,7 +18,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TlsCredentials:
     """An HTTP/3 server's TLS identity: the certificate and its private key."""
 
@@ -25,7 +26,7 @@ class TlsCredentials:
     private_key: bytes
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class SessionResumption:
     """A TLS-PSK resumption secret: the ticket identity and its pre-shared key."""
 


### PR DESCRIPTION
Follow-up to #125, addressing its Codex P2 review comment.

`TlsCredentials` and `SessionResumption` group the same-typed `bytes` pairs so a swap is a type error - but a frozen dataclass still generates a **positional** `__init__`, so `TlsCredentials(key, cert)` (and `SessionResumption(psk, identity)`) transposed the fields with no type-checker or runtime error, since both fields are `bytes`, and failed only later as a handshake/validation error.

Marking both `@dataclass(frozen=True, kw_only=True)` forces the field names at the one remaining boundary: positional construction is now a `TypeError`, keyword construction is unchanged. (`kw_only` needs Python 3.10, which is the project floor.)

New test asserts positional construction raises and keyword construction still works. `pytest`, `mypy --strict`, and `ruff` clean.