### PR TITLE
Reject subclassing the Connection factory with a clear error

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1353,29 +1353,32 @@ fn allocAndBuild(tp: ?*c.PyTypeObject, role: Role, protocol_val: c_long) py.Obje
 }
 
 // Base `Connection` tp_new: a factory. Called as `Connection(role, protocol=...)`
-// it picks the H1/H2 subtype and returns an instance of THAT type, so the runtime
-// type is truthful (isinstance(obj, Connection) still holds via the base). Called
-// on a user subclass of Connection, it builds in place with the requested protocol
-// (the subclass is honoured; no foreign-type substitution).
+// it picks the H1/H2/H3 subtype and returns an instance of THAT type, so the runtime
+// type is truthful (isinstance(obj, Connection) still holds via the base). Connection
+// itself is not a usable instance type - it carries only the shared read API - so
+// subclassing it is rejected rather than yielding a half-built object.
 fn new_base(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv(.c) py.Object {
+    // A user subclass of Connection is none of the concrete subtypes, so it would get
+    // an instance with only next_event() and none of the transport's read/write
+    // surface (receive_data / data_to_send / the send API live on the subtypes).
+    // Reject it with a clear error instead of handing back a broken object.
+    if (@intFromPtr(tp) != @intFromPtr(connection_type)) {
+        return py.raiseType("zttp.Connection is a factory and cannot be subclassed; call zttp.Connection(role, protocol=...) to build an H1/H2/H3Connection");
+    }
     // HTTP/3 carries server-credential kwargs that the (role, protocol) parser would
     // reject, so detect it first by a cheap peek and route the whole call through
     // new_h3, which owns the full parse. The H1/H2 fast path is unchanged.
     if (peekProtocol(args, kwds) == HTTP3) {
-        const target = if (@intFromPtr(tp) == @intFromPtr(connection_type)) @as(?*c.PyTypeObject, @ptrCast(h3_connection_type)) else tp;
-        return new_h3(target, args, kwds);
+        return new_h3(@ptrCast(h3_connection_type), args, kwds);
     }
     var role: Role = .server;
     var protocol_val: c_long = HTTP1;
     if (!parseArgs(args, kwds, &role, &protocol_val, null)) return null;
-    if (@intFromPtr(tp) == @intFromPtr(connection_type)) {
-        const sub: ?*c.PyTypeObject = @ptrCast(switch (protocol_val) {
-            HTTP2 => h2_connection_type,
-            else => h1_connection_type,
-        });
-        return allocAndBuild(sub, role, protocol_val);
-    }
-    return allocAndBuild(tp, role, protocol_val);
+    const sub: ?*c.PyTypeObject = @ptrCast(switch (protocol_val) {
+        HTTP2 => h2_connection_type,
+        else => h1_connection_type,
+    });
+    return allocAndBuild(sub, role, protocol_val);
 }
 
 // Peek the `protocol` argument (2nd positional or the `protocol` kwarg) without the

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -362,6 +362,16 @@ def test_invalid_protocol_rejected() -> None:
         zttp.Connection(zttp.SERVER, protocol=99)
 
 
+def test_connection_factory_cannot_be_subclassed() -> None:
+    # Connection is a factory: it has no usable instance surface of its own, so a
+    # subclass instance would be a half-built object. Constructing one is rejected.
+    class Custom(zttp.Connection):
+        pass
+
+    with pytest.raises(TypeError):
+        Custom(zttp.SERVER)
+
+
 # -- Stream object -------------------------------------------------------------
 
 


### PR DESCRIPTION
Follow-up to #119, addressing its Codex P2 review comment (the `Connection`-subclassing regression).

### Problem
`zttp.Connection` is a factory: constructing it returns the protocol-specific subtype (`H1/H2/H3Connection`), where the read/write surface lives. But `new_base` also *honoured* a user subclass - `class C(zttp.Connection): ...; C(zttp.SERVER)` built an instance of `C`, which inherits only `next_event()` from the base and none of `receive_data` / `data_to_send` / the send API. So the object raised `AttributeError` on first real use. (It was already partly broken before #113 - a subclass never inherited the write methods either - and #113 made it total.)

### Change
Reject subclass construction in `new_base` with a clear `TypeError` that points at the factory call, instead of returning a half-built object:

```python
class C(zttp.Connection): ...
C(zttp.SERVER)
# TypeError: zttp.Connection is a factory and cannot be subclassed;
#            call zttp.Connection(role, protocol=...) to build an H1/H2/H3Connection
```

Normal construction is unchanged (`zttp.Connection(SERVER)` still returns an `H1Connection`, etc.). This also drops the now-dead subclass branches, since the factory always dispatches to a concrete subtype.

### Verification
New test asserts subclass construction raises; `pytest` 281 pass; `mypy --strict`, `ruff`, `mypy.stubtest`, and `zig fmt --check` all clean.

Closes the #119 review finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)