### PR TITLE
Set the canonical site_url for the docs

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -2,7 +2,7 @@
 site_name = "zttp"
 site_description = "A sans-IO HTTP/1.1, HTTP/2, and HTTP/3 parser for Python with a Zig core."
 site_author = "Marcelo Trylesinski"
-#site_url = "https://zttp.dev/"
+site_url = "https://zttp.marcelotryle.com/"
 repo_url = "https://github.com/Kludex/zttp"
 repo_name = "Kludex/zttp"
 copyright = """


### PR DESCRIPTION
Follow-up from the docs audit.

`site_url` was commented out in `zensical.toml` (and the commented value pointed at the wrong domain, `zttp.dev`), so the built site had **no canonical URLs and no `sitemap.xml`** - which weakens search indexing and social/link previews.

Point it at the production custom domain the worker actually serves - `zttp.marcelotryle.com` (per `wrangler.toml`'s `[[routes]]`).

### Verified by building the site
- `site/sitemap.xml` is now generated: `<loc>https://zttp.marcelotryle.com/…</loc>`.
- Pages carry `<link rel="canonical" href="https://zttp.marcelotryle.com/…">`.
- No stale `zttp.dev` anywhere in the output.
- `python -m zensical build` → "No issues found".