### PR TITLE
Expose a QUIC datagram header parser for connection demultiplexing

### DIFF
--- a/src/core/quic/packet.zig
+++ b/src/core/quic/packet.zig
@@ -82,12 +82,15 @@ pub const DatagramHeader = struct {
 pub fn parseDatagramHeader(buf: []const u8) Error!DatagramHeader {
     if (buf.len < 1) return error.Truncated;
     if (!isLong(buf[0])) {
+        // A short header still carries the QUIC fixed bit; a clear one is malformed.
+        if ((buf[0] & constants.FIXED_BIT) == 0) return error.Malformed;
         return .{ .long = false, .initial = false, .version = 0, .dcid = &.{}, .scid = &.{} };
     }
     const prefix = try parseLongPrefix(buf);
-    // The long-header type bits are only meaningful for a version we speak; a
-    // Version Negotiation packet (version 0) is never an Initial.
-    const initial = prefix.version != 0 and
+    // The long-header type bits are version-specific, so only trust them for QUIC v1;
+    // an unsupported version (or a Version Negotiation packet, version 0) is never an
+    // Initial we would open a connection for.
+    const initial = prefix.version == constants.VERSION_1 and
         @as(LongType, @enumFromInt(@as(u2, @truncate(buf[0] >> 4)))) == .initial;
     return .{ .long = true, .initial = initial, .version = prefix.version, .dcid = prefix.dcid, .scid = prefix.scid };
 }
@@ -403,11 +406,16 @@ test "parseDatagramHeader routes a long-header Initial" {
 }
 
 test "parseDatagramHeader reports a short header without connection ids" {
-    var pkt = [_]u8{ 0x40, 0xAA, 0xBB, 0xCC }; // form bit clear = short header
+    var pkt = [_]u8{ 0x40, 0xAA, 0xBB, 0xCC }; // form bit clear, fixed bit set = short header
     const h = try parseDatagramHeader(&pkt);
     try std.testing.expect(!h.long);
     try std.testing.expect(!h.initial);
     try std.testing.expectEqual(@as(usize, 0), h.dcid.len);
+}
+
+test "parseDatagramHeader rejects a short header with the fixed bit clear" {
+    var pkt = [_]u8{ 0x00, 0xAA, 0xBB }; // form bit clear AND fixed bit clear = malformed
+    try std.testing.expectError(error.Malformed, parseDatagramHeader(&pkt));
 }
 
 test "parseDatagramHeader does not flag Version Negotiation as Initial" {
@@ -417,6 +425,16 @@ test "parseDatagramHeader does not flag Version Negotiation as Initial" {
     try std.testing.expect(h.long);
     try std.testing.expect(!h.initial);
     try std.testing.expectEqual(@as(u32, 0), h.version);
+}
+
+test "parseDatagramHeader does not flag an unsupported version as Initial" {
+    // Type bits 00 look like Initial, but they are only v1 semantics; a nonzero
+    // unsupported version must not be reported as an Initial.
+    var pkt = [_]u8{ 0xC0, 0x0A, 0x0A, 0x0A, 0x0A, 0x03, 'd', 's', 't', 0x00 };
+    const h = try parseDatagramHeader(&pkt);
+    try std.testing.expect(h.long);
+    try std.testing.expect(!h.initial);
+    try std.testing.expectEqual(@as(u32, 0x0A0A_0A0A), h.version);
 }
 
 test "parseDatagramHeader rejects an empty datagram" {

--- a/src/core/quic/packet.zig
+++ b/src/core/quic/packet.zig
@@ -61,6 +61,37 @@ pub fn isLong(first: u8) bool {
     return (first & constants.HEADER_FORM_LONG) != 0;
 }
 
+/// A routing view of a received datagram's first packet, for demultiplexing a
+/// shared socket onto per-connection state. A long header carries both connection
+/// ids and their lengths on the wire; a short (1-RTT) header does not encode the
+/// dcid length, so `dcid`/`scid` are empty for one and the receiver must match it
+/// against connection ids it already knows.
+pub const DatagramHeader = struct {
+    long: bool,
+    initial: bool,
+    version: u32,
+    dcid: []const u8,
+    scid: []const u8,
+};
+
+/// Parse just the routable prefix of a received datagram (RFC 9000 17), without
+/// decrypting. Zero-copy: the connection-id slices point into `buf`. A short-header
+/// packet returns `long = false` with empty ids; the caller demuxes it by its own
+/// connection ids. This does no version dispatch, so it also routes unsupported
+/// versions and Version Negotiation packets (neither is ever `initial`).
+pub fn parseDatagramHeader(buf: []const u8) Error!DatagramHeader {
+    if (buf.len < 1) return error.Truncated;
+    if (!isLong(buf[0])) {
+        return .{ .long = false, .initial = false, .version = 0, .dcid = &.{}, .scid = &.{} };
+    }
+    const prefix = try parseLongPrefix(buf);
+    // The long-header type bits are only meaningful for a version we speak; a
+    // Version Negotiation packet (version 0) is never an Initial.
+    const initial = prefix.version != 0 and
+        @as(LongType, @enumFromInt(@as(u2, @truncate(buf[0] >> 4)))) == .initial;
+    return .{ .long = true, .initial = initial, .version = prefix.version, .dcid = prefix.dcid, .scid = prefix.scid };
+}
+
 /// Parse only the invariant long-header prefix: form/fixed bits, version, and
 /// connection IDs. This works before version dispatch, so the connection layer can
 /// generate Version Negotiation for unsupported versions.
@@ -358,6 +389,38 @@ test "parseLongPrefix reads connection ids before version dispatch" {
     try std.testing.expectEqualStrings("dst", p.dcid);
     try std.testing.expectEqualStrings("src", p.scid);
     try std.testing.expectEqual(@as(usize, pkt.len), p.header_len);
+}
+
+test "parseDatagramHeader routes a long-header Initial" {
+    // 0xC0: long form + fixed bit + type bits 00 (Initial); version 1; dcid "dst", scid "src".
+    var pkt = [_]u8{ 0xC0, 0x00, 0x00, 0x00, 0x01, 0x03, 'd', 's', 't', 0x03, 's', 'r', 'c' };
+    const h = try parseDatagramHeader(&pkt);
+    try std.testing.expect(h.long);
+    try std.testing.expect(h.initial);
+    try std.testing.expectEqual(@as(u32, 1), h.version);
+    try std.testing.expectEqualStrings("dst", h.dcid);
+    try std.testing.expectEqualStrings("src", h.scid);
+}
+
+test "parseDatagramHeader reports a short header without connection ids" {
+    var pkt = [_]u8{ 0x40, 0xAA, 0xBB, 0xCC }; // form bit clear = short header
+    const h = try parseDatagramHeader(&pkt);
+    try std.testing.expect(!h.long);
+    try std.testing.expect(!h.initial);
+    try std.testing.expectEqual(@as(usize, 0), h.dcid.len);
+}
+
+test "parseDatagramHeader does not flag Version Negotiation as Initial" {
+    // Version 0 is a Version Negotiation packet; its type bits are meaningless.
+    var pkt = [_]u8{ 0xC0, 0x00, 0x00, 0x00, 0x00, 0x03, 'd', 's', 't', 0x00 };
+    const h = try parseDatagramHeader(&pkt);
+    try std.testing.expect(h.long);
+    try std.testing.expect(!h.initial);
+    try std.testing.expectEqual(@as(u32, 0), h.version);
+}
+
+test "parseDatagramHeader rejects an empty datagram" {
+    try std.testing.expectError(error.Truncated, parseDatagramHeader(&[_]u8{}));
 }
 
 test "parseLong reads a Retry packet and validates its integrity tag" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1037,6 +1037,46 @@ var stream_type: py.Object = null;
 // the extension's own init would race the package __init__). Cached for the process.
 var session_ticket_type: py.Object = null;
 var close_info_type: py.Object = null;
+var datagram_header_type: py.Object = null;
+
+/// Module-level `parse_datagram_header(datagram) -> DatagramHeader`: the routable
+/// prefix of a received QUIC datagram, for demultiplexing a shared UDP socket onto
+/// per-connection state without constructing a connection.
+fn parse_datagram_header(_: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
+    const data = py.asBytes(arg) orelse return null;
+    const hdr = core.quic.packet.parseDatagramHeader(data) catch
+        return py.raise(exceptions.RemoteProtocolError, "malformed QUIC packet header");
+    const dh_type = resultType(&datagram_header_type, "DatagramHeader") orelse return null;
+    const tuple = py.tupleNew(5);
+    if (tuple == null) return null;
+    const dcid = py.fromBytes(hdr.dcid);
+    const scid = py.fromBytes(hdr.scid);
+    const version = c.PyLong_FromUnsignedLong(hdr.version);
+    const long = py.boolean(hdr.long);
+    const initial = py.boolean(hdr.initial);
+    if (dcid == null or scid == null or version == null or long == null or initial == null) {
+        py.xdecref(dcid);
+        py.xdecref(scid);
+        py.xdecref(version);
+        py.xdecref(long);
+        py.xdecref(initial);
+        py.decref(tuple);
+        return null;
+    }
+    py.tupleSet(tuple, 0, dcid);
+    py.tupleSet(tuple, 1, scid);
+    py.tupleSet(tuple, 2, version);
+    py.tupleSet(tuple, 3, long);
+    py.tupleSet(tuple, 4, initial);
+    const row = c.PyObject_CallObject(dh_type, tuple);
+    py.decref(tuple);
+    return row;
+}
+
+pub var module_methods = [_]c.PyMethodDef{
+    .{ .ml_name = "parse_datagram_header", .ml_meth = parse_datagram_header, .ml_flags = c.METH_O, .ml_doc = "Parse the routable prefix of a received QUIC datagram: parse_datagram_header(datagram) -> DatagramHeader. Reads no connection state; for demultiplexing a shared UDP socket by connection id." },
+    .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
+};
 
 // Return the zttp.results dataclass named `name`, importing and caching it once.
 fn resultType(cache: *py.Object, name: [*c]const u8) py.Object {

--- a/src/python/module.zig
+++ b/src/python/module.zig
@@ -13,7 +13,7 @@ var module_def = c.PyModuleDef{
     .m_name = "_zttp",
     .m_doc = "zttp: a sans-IO HTTP parser with a Zig core.",
     .m_size = -1,
-    .m_methods = null,
+    .m_methods = &connection.module_methods,
 };
 
 fn PyInit__zttp() callconv(.c) ?*c.PyObject {

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -111,6 +111,40 @@ def test_http3_constant_exists() -> None:
     assert zttp.HTTP3 not in (zttp.HTTP1, zttp.HTTP2)
 
 
+def test_parse_datagram_header_routes_a_client_initial() -> None:
+    client = zttp.Connection(
+        zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"localhost", connection_id=b"\xaa\xbb\xcc\xdd"
+    )
+    initial = client.data_to_send()[0]
+    header = zttp.parse_datagram_header(initial)
+    assert isinstance(header, zttp.DatagramHeader)
+    assert header.is_long_header
+    assert header.is_initial
+    assert header.version == 1
+    assert header.destination_connection_id == b"\xaa\xbb\xcc\xdd"
+
+
+def test_parse_datagram_header_reports_a_short_header() -> None:
+    header = zttp.parse_datagram_header(b"\x40\x01\x02\x03")  # form bit clear = short header
+    assert not header.is_long_header
+    assert not header.is_initial
+    assert header.destination_connection_id == b""
+    assert header.source_connection_id == b""
+
+
+def test_parse_datagram_header_rejects_a_malformed_datagram() -> None:
+    with pytest.raises(zttp.RemoteProtocolError):
+        zttp.parse_datagram_header(b"")
+    with pytest.raises(zttp.RemoteProtocolError):
+        zttp.parse_datagram_header(b"\xc0\x00")  # long header truncated mid-prefix
+
+
+def test_parse_datagram_header_result_is_frozen() -> None:
+    header = zttp.parse_datagram_header(b"\x40\x00")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        header.version = 9  # type: ignore[misc]
+
+
 def test_http3_client_construction_emits_an_initial() -> None:
     conn = make_client()
     assert type(conn) is zttp.H3Connection

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -137,6 +137,17 @@ def test_parse_datagram_header_rejects_a_malformed_datagram() -> None:
         zttp.parse_datagram_header(b"")
     with pytest.raises(zttp.RemoteProtocolError):
         zttp.parse_datagram_header(b"\xc0\x00")  # long header truncated mid-prefix
+    with pytest.raises(zttp.RemoteProtocolError):
+        zttp.parse_datagram_header(b"\x00\xaa\xbb")  # short header with the fixed bit clear
+
+
+def test_parse_datagram_header_does_not_trust_an_unsupported_version() -> None:
+    # Type bits 00 resemble an Initial, but only under QUIC v1; an unsupported
+    # version must not be reported as one.
+    header = zttp.parse_datagram_header(b"\xc0\x0a\x0a\x0a\x0a\x03dst\x00")
+    assert header.is_long_header
+    assert not header.is_initial
+    assert header.version == 0x0A0A0A0A
 
 
 def test_parse_datagram_header_result_is_frozen() -> None:

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -27,9 +27,10 @@ from zttp._zttp import (
     Settings,
     Stream,
     WindowUpdate,
+    parse_datagram_header,
 )
 from zttp.config import SessionResumption, TlsCredentials
-from zttp.results import CloseInfo, SessionTicket
+from zttp.results import CloseInfo, DatagramHeader, SessionTicket
 from zttp.settings import H2Settings
 
 Event = (
@@ -58,6 +59,7 @@ __all__ = [
     "Connection",
     "ConnectionClosed",
     "Data",
+    "DatagramHeader",
     "EndOfMessage",
     "Event",
     "Goaway",
@@ -79,4 +81,5 @@ __all__ = [
     "Stream",
     "TlsCredentials",
     "WindowUpdate",
+    "parse_datagram_header",
 ]

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -7,7 +7,7 @@ from typing import Final, Literal, final, overload
 from typing_extensions import disjoint_base
 
 from zttp.config import SessionResumption, TlsCredentials
-from zttp.results import CloseInfo, SessionTicket
+from zttp.results import CloseInfo, DatagramHeader, SessionTicket
 
 SERVER: Final = 1
 CLIENT: Final = 2
@@ -15,6 +15,17 @@ CLIENT: Final = 2
 HTTP1: Final = 1
 HTTP2: Final = 2
 HTTP3: Final = 3
+
+def parse_datagram_header(datagram: bytes, /) -> DatagramHeader:
+    """Parse the routable prefix of a received QUIC datagram (RFC 9000 17).
+
+    Reads no connection state and does not decrypt - it just exposes the form bit,
+    version, and connection ids so a server sharing one UDP socket can demultiplex
+    datagrams onto per-connection state by destination connection id. A short (1-RTT)
+    header does not encode the destination id's length, so `is_long_header` is `False`
+    and the ids are empty; match those against the connection ids you already track.
+    Raises `RemoteProtocolError` on a truncated or malformed header.
+    """
 
 @final
 class Request:

--- a/zttp/results.py
+++ b/zttp/results.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 __all__ = [
     "CloseInfo",
+    "DatagramHeader",
     "SessionTicket",
 ]
 
@@ -35,3 +36,21 @@ class CloseInfo:
     error_code: int
     reason: bytes
     is_application: bool
+
+
+@dataclass(frozen=True)
+class DatagramHeader:
+    """The routable prefix of a received QUIC datagram (RFC 9000 17).
+
+    Returned by [`parse_datagram_header`][zttp.parse_datagram_header] to demultiplex a
+    shared UDP socket onto per-connection state. A long header carries the connection
+    ids and their lengths on the wire; a short (1-RTT) header does not encode the
+    destination id's length, so `destination_connection_id` is empty for one and the
+    receiver must match it against connection ids it already tracks.
+    """
+
+    destination_connection_id: bytes
+    source_connection_id: bytes
+    version: int
+    is_long_header: bool
+    is_initial: bool


### PR DESCRIPTION
## What

Adds a module-level `parse_datagram_header(datagram: bytes) -> DatagramHeader`.

A server fronting many HTTP/3 connections on a single UDP socket must demultiplex each incoming datagram to the right connection by its **destination connection id**. Until now the only way to inspect a datagram was to feed it to an `H3Connection` - so a shared-socket server had to construct a full connection (QUIC + TLS state) just to discover a datagram was stray or misrouted. This exposes the routable prefix directly.

`DatagramHeader` is a frozen dataclass in `zttp.results` (alongside `CloseInfo`/`SessionTicket`):

```python
header = zttp.parse_datagram_header(datagram)
# header.destination_connection_id / .source_connection_id: bytes
# header.version: int
# header.is_long_header / .is_initial: bool
```

- Reads no connection state and does not decrypt - it just parses the RFC 9000 §17 invariant prefix, reusing the existing `packet` codec (`parseLongPrefix` + the form/type bits).
- A short (1-RTT) header does not encode the destination id's length on the wire, so it reports `is_long_header=False` with empty ids; the caller matches those against the connection ids it already tracks.
- Raises `RemoteProtocolError` on a truncated/malformed header.

## Why

This is the primitive uvicorn's experimental HTTP/3 server needs to demux by connection id instead of by UDP peer address - which removes its connection-migration limitation and lets it drop stray datagrams before allocating any per-connection state.

## Tests

- Zig: `parseDatagramHeader` routes a long Initial, reports short headers without ids, never flags Version Negotiation as Initial, rejects empty input.
- Python: routes a real client Initial by its DCID, reports short headers, rejects malformed input, result is frozen.
- `zig build test`, full `pytest` (288), `mypy`, `stubtest`, and `ruff` all green.