### PR TITLE
Build portable wheels with the baseline CPU

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,11 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
+    // Wheels must run on CPUs other than the machine that built them. Keep a
+    // conservative default while still allowing an explicit -Dcpu override.
+    const target = b.standardTargetOptions(.{
+        .default_target = .{ .cpu_model = .baseline },
+    });
     const optimize = b.standardOptimizeOption(.{});
     // DWARF debug info is ~3 MB per extension (vs ~450 KB of code); shipped
     // wheels don't need it. Keep it for Debug builds.


### PR DESCRIPTION
## Summary

- default native Zig builds to the conservative baseline CPU model
- preserve explicit `-Dcpu` overrides for local or specialized builds

## Context

The Windows wheels were compiled for the GitHub runner's native CPU. On a different Windows runner, constructing `zttp.Connection(zttp.SERVER)` from zttp 0.0.15 terminated Python with `0xc000001d` (`Illegal instruction`). This also blocked the Windows jobs on Kludex/uvicorn#2979.

Resolving the default target with Zig's baseline CPU model makes release wheels portable across supported machines instead of inheriting build-host CPU features.

## Verification

- `zig build test`
- `zig build --verbose test` (compiler invocation includes `-mcpu baseline`)
- `scripts/check`
- Python suite: 288 passed, 2 optional interop tests skipped
- extension build and `zttp.Connection(zttp.SERVER)` import smoke test
- documentation build
