### PR TITLE
Replace uv-dynamic-versioning with hatch-vcs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling", "hatch-ziglang>=0.2", "uv-dynamic-versioning>=0.8.0", "ziglang==0.16.0"]
+# hatch-vcs over uv-dynamic-versioning: the latter drags in jinja2 -> markupsafe,
+# whose missing-wheel source build breaks cross-compiled macOS wheels on new
+# CPythons. The hatch-vcs chain is pure Python.
+requires = ["hatchling", "hatch-vcs", "hatch-ziglang>=0.2", "ziglang==0.16.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -76,14 +79,15 @@ cache-keys = [
 ]
 
 [tool.hatch.version]
-source = "uv-dynamic-versioning"
+source = "vcs"
 
-[tool.uv-dynamic-versioning]
-vcs = "git"
-style = "pep440"
-bump = true
-metadata = false  # drop the +<hash> local segment; PyPI rejects it on uploads
-fallback-version = "0.0.0"
+[tool.hatch.version.raw-options]
+# guess-next-dev matches the old uv-dynamic-versioning bump=true behavior
+# (tag 0.0.16 + N commits -> 0.0.17.devN); no-local-version drops the +<hash>
+# local segment, which PyPI rejects on uploads.
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
+fallback_version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["zttp"]


### PR DESCRIPTION
Drops jinja2/markupsafe from the isolated build env - markupsafe has no cp315 wheels yet and its source build breaks the cross-compiled `cp315-macosx_x86_64` leg (x86_64-tagged wheel, arm64 build interpreter), which is why [the macOS Publish job failed](https://github.com/Kludex/zttp/actions/runs/29580377909/job/87890530737). The hatch-vcs chain is pure Python, so nothing in the build env compiles anymore.

Verified: sdist version identical before/after (`0.0.17.dev1`), 289 tests pass, `guess-next-dev` + `no-local-version` reproduce the old `bump = true` + `metadata = false` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)