### PR TITLE
Pass fuzz-docker arguments as positional parameters

### DIFF
--- a/scripts/fuzz-docker
+++ b/scripts/fuzz-docker
@@ -28,4 +28,4 @@ docker run --rm --platform linux/amd64 \
     -e FUZZING_LANGUAGE=c++ \
     -v "$ROOT":/src/zttp \
     -v "$ROOT/.oss-fuzz/build.sh":/src/build.sh \
-    "$IMAGE" bash -c "cd /src/zttp && rm -rf zig-out .zig-cache && compile && /out/zttp_fuzz_reader $*"
+    "$IMAGE" bash -c 'cd /src/zttp && rm -rf zig-out .zig-cache && compile && /out/zttp_fuzz_reader "$@"' _ "$@"


### PR DESCRIPTION
`scripts/fuzz-docker` interpolated `$*` directly into the double-quoted `bash -c` string executed inside the container, so shell metacharacters in a developer-supplied argument were re-parsed by the container's bash. With the working tree bind-mounted read-write at `/src/zttp`, an injected command could read or modify the source tree. Passing the args as positional parameters (`bash -c '... "$@"' _ "$@"`) makes them reach the fuzzer literally.

Verified: `sh -n` clean; `; echo INJECTED` now arrives as a literal argv entry instead of executing. The zero-arg default (`-max_total_time=60`) is preserved.

Local-dev tooling only - not used by CI or the runtime parser. Found in a security review (low severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)