### PR TITLE
Lowercase header names in the HTTP/2 roundtrip fuzz oracle

### DIFF
--- a/fuzz/roundtrip_h2.py
+++ b/fuzz/roundtrip_h2.py
@@ -22,8 +22,10 @@ def roundtrip_h2(data: bytes) -> None:
     method, target, headers, body = draw_request(data, safe=True)
     # The client derives :authority from a host header; keep exactly one so the
     # roundtrip is deterministic (a request with no host still works - :authority
-    # is just absent).
-    sent_headers = [(k, v) for k, v in headers if k.lower() != b"host"]
+    # is just absent). Lowercase every name: HTTP/2 forbids uppercase field names
+    # and the writer rejects them, so the safe corpus (HTTP/1-style capitalized)
+    # would otherwise make send_request raise and skip the differential entirely.
+    sent_headers = [(k.lower(), v) for k, v in headers if k.lower() != b"host"]
     sent_headers.append((b"host", b"example.com"))
 
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)


### PR DESCRIPTION
`fuzz/roundtrip_h2.py` forwarded the safe corpus's HTTP/1-style capitalized header names (`X-Fuzz`, `User-Agent`, `Accept`, `X-A`, `X-B`) into the HTTP/2 client. HTTP/2 forbids uppercase field names, so the writer raised `LocalProtocolError`, which the oracle catches as a skip - meaning any drawn request carrying a non-host header was dropped before the encode/decode differential ever ran. The H2 roundtrip therefore almost never exercised ordinary request headers.

Lowercasing the forwarded names (the equality checks at the bottom already compare case-insensitively) lets those requests through, restoring the intended differential coverage. Not a product bug - the writer is correctly enforcing RFC 9113 lowercase names; this is a fuzzing-assurance gap flagged in a security review (informational).

Verified: 2000 roundtrip_h2 iterations run clean, a lowercased `x-fuzz` header now survives `send_request`, and the full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)