### PR TITLE
Clear the remembered request method when a parse fails

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1838,6 +1838,13 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             while (true) {
                 const ev = e.reader.nextEvent() catch |err| {
                     e.dropPending();
+                    // A parse failure means there is no valid current request, but
+                    // req_method survives start_next_cycle by design. Clear it so an
+                    // error response the app sends next (e.g. send_response(400,
+                    // content-length: ...)) is framed on its own headers - not on a
+                    // stale HEAD/CONNECT method, which would wrongly make it bodyless
+                    // and turn remote input into a LocalProtocolError.
+                    e.req_method_len = 0;
                     return exceptions.raiseParse(err);
                 };
                 if (ev == .need_data and e.pending_obj != null) {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -137,6 +137,11 @@ const H1Engine = struct {
     /// response is serialized (see next_message).
     req_method: [16]u8 = undefined,
     req_method_len: usize = 0,
+    /// Whether the remembered method belongs to a request already surfaced (server)
+    /// or sent (client) in the current read cycle. Reset by start_next_cycle. Used
+    /// to decide, on a parse failure, whether the method is stale (fresh-head
+    /// failure -> clear) or still owed a response (mid-body failure -> keep).
+    request_surfaced: bool = false,
     /// Connection signals for the last parsed request, captured at event time so
     /// they outlive the head buffer. `upgrade_obj` is held Python bytes (or null).
     should_close: bool = false,
@@ -155,6 +160,7 @@ const H1Engine = struct {
         }
         @memcpy(self.req_method[0..m.len], m);
         self.req_method_len = m.len;
+        self.request_surfaced = true;
     }
 
     fn method(self: *const H1Engine) []const u8 {
@@ -1838,13 +1844,15 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
             while (true) {
                 const ev = e.reader.nextEvent() catch |err| {
                     e.dropPending();
-                    // A parse failure means there is no valid current request, but
-                    // req_method survives start_next_cycle by design. Clear it so an
-                    // error response the app sends next (e.g. send_response(400,
-                    // content-length: ...)) is framed on its own headers - not on a
-                    // stale HEAD/CONNECT method, which would wrongly make it bodyless
-                    // and turn remote input into a LocalProtocolError.
-                    e.req_method_len = 0;
+                    // req_method survives start_next_cycle by design. Clear it ONLY
+                    // when the failure is on a fresh request head (no request
+                    // surfaced this cycle): otherwise an error response the app sends
+                    // (e.g. send_response(400, content-length: ...)) would be framed
+                    // on a stale HEAD/CONNECT method and wrongly forced bodyless. But
+                    // if a request WAS already surfaced and its body then fails, the
+                    // response to THAT request (a HEAD stays bodyless regardless of
+                    // headers) still needs the method - keep it.
+                    if (!e.request_surfaced) e.req_method_len = 0;
                     return exceptions.raiseParse(err);
                 };
                 if (ev == .need_data and e.pending_obj != null) {
@@ -2229,6 +2237,10 @@ fn next_message(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const e = h1(self) orelse return null;
     e.reader.reset();
+    // A new read cycle: the remembered method now belongs to the previous request,
+    // no longer one surfaced this cycle (so a parse failure on the next head clears
+    // it - see next_event).
+    e.request_surfaced = false;
     // req_method is intentionally NOT cleared: a caller may call start_next_cycle()
     // before serializing the previous response (e.g. pipelined keep-alive reads),
     // and send_response reads it to frame HEAD / CONNECT responses as bodyless. It

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -161,6 +161,25 @@ def test_error_response_keeps_its_body_after_a_head_then_malformed_request() -> 
     assert conn.data_to_send() == b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\nbad request"
 
 
+def test_head_body_parse_error_keeps_bodyless_framing() -> None:
+    # A HEAD request whose (chunked) body then fails to parse must keep HEAD framing
+    # for its error response: a response to HEAD is bodyless regardless of headers,
+    # so the method must NOT be cleared mid-request - unlike a failure on a fresh
+    # next-request head (see the test above), which does clear it.
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"HEAD / HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n")
+    assert any(isinstance(e, zttp.Request) for e in drain(conn))
+    conn.receive_data(b"zz\r\n")  # invalid chunk size -> body parse error
+    with pytest.raises(zttp.RemoteProtocolError):
+        list(drain(conn))
+    # The error response to the HEAD stays bodyless: sending a body is rejected.
+    conn.send_response(400, [(b"Content-Length", b"11")])
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_data(b"bad request")
+    conn.end_message()
+    assert conn.data_to_send() == b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\n"
+
+
 def test_status_code_formatting() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(404, [])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -135,6 +135,32 @@ def test_head_response_bodyless_after_early_start_next_cycle() -> None:
     assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n"
 
 
+def test_error_response_keeps_its_body_after_a_head_then_malformed_request() -> None:
+    # A HEAD request leaves the remembered method = HEAD, which survives
+    # start_next_cycle by design. If the next pipelined request fails to parse, no
+    # new Request replaces the method, so an error response the app sends must NOT
+    # be framed as bodyless off the stale HEAD - that would turn remote input into a
+    # LocalProtocolError in common error-handling code.
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"HEAD / HTTP/1.1\r\nHost: x\r\n\r\n")
+    list(drain(conn))
+    conn.send_response(200, [])
+    conn.end_message()
+    conn.data_to_send()
+    conn.start_next_cycle()
+
+    conn.receive_data(b"GET / HTTP/1.1\r\nBad Header\r\n\r\n")  # malformed head
+    with pytest.raises(zttp.RemoteProtocolError):
+        list(drain(conn))
+
+    # The 400 carries a body; before the fix the stale HEAD made it bodyless and
+    # send_data raised LocalProtocolError.
+    conn.send_response(400, [(b"Content-Length", b"11")])
+    conn.send_data(b"bad request")
+    conn.end_message()
+    assert conn.data_to_send() == b"HTTP/1.1 400 Bad Request\r\nContent-Length: 11\r\n\r\nbad request"
+
+
 def test_status_code_formatting() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(404, [])


### PR DESCRIPTION
`send_response` derives bodyless framing from the remembered request method, which is intentionally preserved across `start_next_cycle` (so a late HEAD response frames correctly). But when the **next** pipelined request fails to parse, no Request event fires, so a stale `HEAD`/`CONNECT` method lingers into the error path: an app handling `RemoteProtocolError` with `send_response(400, content-length: N)` hits `req_method == HEAD`, the 400 is classified bodyless, and `send_data` raises `LocalProtocolError` - turning malformed remote input into a local failure in ordinary error-handling code.

Fix: clear the remembered method in the parse-failure branch (the exact point the gap opens), preserving the deliberate survives-`start_next_cycle` behavior on the success path (existing HEAD-after-early-cycle tests still pass).

Regression test added (HEAD → respond → `start_next_cycle` → malformed request → the 400 keeps its body). Flagged in a security review; note the related finding about `start_next_cycle` clearing the method was a false positive (current code deliberately preserves it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)