### PR TITLE
Harden the release pipeline and fix dev-version resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # hatch-vcs derives the version from git tags; the default shallow
+          # checkout fetches none, so it would stamp a fallback (0.0.1.dev1) onto
+          # the wheels and sdist. Fetch the full history + tags for the real version.
+          fetch-depth: 0
 
       # cibuildwheel's build[uv] frontend needs uv on PATH; the manylinux
       # containers ship it, the macOS runner does not.
@@ -54,6 +58,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # hatch-vcs derives the version from git tags; the default shallow
+          # checkout fetches none, so it would stamp a fallback (0.0.1.dev1) onto
+          # the wheels and sdist. Fetch the full history + tags for the real version.
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -90,7 +98,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
           # main is pushed repeatedly with the same dev version; don't fail when
@@ -119,7 +127,10 @@ jobs:
           merge-multiple: true
 
       - name: Publish to PyPI
-        # Pinned by release tag, not bare SHA: this is a Docker action and the
-        # runner resolves its published image by the release ref. A SHA pin makes
-        # it look up ghcr.io/...:<sha>, which has no manifest ("manifest unknown").
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # SHA-pinned like every other action: this step runs with id-token: write
+        # (OIDC trusted publishing to real PyPI), so a mutable ref is the highest-
+        # value supply-chain target in the repo. Current release/v1 is a composite
+        # action that builds its own container at run time - it does not resolve a
+        # per-ref image - so SHA pinning works (no "manifest unknown"). Bump with the
+        # release tag when updating.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,12 @@
 # hatch-vcs over uv-dynamic-versioning: the latter drags in jinja2 -> markupsafe,
 # whose missing-wheel source build breaks cross-compiled macOS wheels on new
 # CPythons. The hatch-vcs chain is pure Python.
-requires = ["hatchling", "hatch-vcs", "hatch-ziglang>=0.2", "ziglang==0.16.0"]
+#
+# hatch-ziglang is exactly pinned: it runs during the isolated wheel build and
+# invokes the native compiler, so a future version resolved from a lower bound
+# could execute unreviewed code into the wheels the publish job trusts. The
+# compiler (ziglang) is likewise pinned. Bump both deliberately.
+requires = ["hatchling", "hatch-vcs", "hatch-ziglang==0.2.0", "ziglang==0.16.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Three release-pipeline findings from the security review, plus a version bug I hit while verifying the Publish run:

- **SHA-pin `pypa/gh-action-pypi-publish`** (both TestPyPI and PyPI steps). It runs with `id-token: write` for OIDC trusted publishing, so a mutable `@release/v1` ref is the highest-value supply-chain target in the repo - and it was the *only* unpinned action. The in-file comment claiming a SHA pin breaks the Docker image lookup is outdated: `release/v1` is now a composite action that builds its own container at run time, so SHA pinning works (verified against the action's current `action.yml`).
- **Exactly pin `hatch-ziglang`** (was `>=0.2`). It runs in the isolated wheel build and drives the native compiler; a future version resolved from a lower bound could inject code into the wheels the publish job trusts. `ziglang` was already pinned.
- **`fetch-depth: 0` in the wheel + sdist checkouts.** hatch-vcs derives the version from git tags; the default shallow checkout has none, so it stamped a fallback `0.0.1.dev1` onto every artifact. That's the [TestPyPI failure on the last Publish run](https://github.com/Kludex/zttp/actions/runs/29587109576) (the stale `0.0.1.dev1` release aged past the 14-day upload window) - and it would have shipped mis-versioned wheels to real PyPI on the next tag. Verified locally: the version now resolves to `0.0.17.dev2`.

Not included: the review's finding about publishing beta-ABI `cp315` wheels to PyPI before 3.15.0rc1 (medium, conditional). The clean fix is to gate `cp315`/`cp315t` out of the wheel build until rc1, but that trades directly against the 3.15 support just added, and only bites if a release is tagged during the beta - so I left it for you to decide. Happy to do it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)