### PR TITLE
Stop declaring the extension GIL-free until it is synchronized

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,9 @@ include = ["zttp", "src", "tools", "build.zig"]
 # Zig comes from the `ziglang` build requirement (build isolation), so no system
 # toolchain install is needed. The sans-IO core has no OS dependencies, so it
 # builds for glibc, musl, macOS, and Windows alike. Skip only 32-bit and PyPy.
-# cp314t/cp315t are the free-threaded builds; the extension declares Py_MOD_GIL_NOT_USED.
+# cp314t/cp315t are the free-threaded builds. The extension does NOT yet declare
+# Py_MOD_GIL_NOT_USED (it isn't synchronized - #151), so on these interpreters
+# CPython re-enables the compatibility GIL at import; the wheels still load and run.
 # Windows is skipped for the free-threaded builds: their pyconfig.h doesn't self-define
 # Py_GIL_DISABLED (POSIX does), so translate-c would compile against the GIL ABI and
 # mismatch (still true in 3.15's PC/pyconfig.h).
@@ -136,7 +138,14 @@ archs = ["AMD64"]
 addopts = "-rxXs --strict-config --strict-markers"
 xfail_strict = true
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # Free-threaded builds (3.13t+): the extension deliberately does not declare
+    # Py_MOD_GIL_NOT_USED until it is synchronized (#151), so CPython re-enables the
+    # GIL at import and warns. That is the intended, safe behavior - don't let the
+    # expected warning fail the suite when running under a free-threaded interpreter.
+    "ignore:The global interpreter lock:RuntimeWarning",
+]
 markers = [
     "http3_interop: optional HTTP/3 interop checks that require external protocol stacks",
 ]

--- a/src/python/module.zig
+++ b/src/python/module.zig
@@ -35,6 +35,12 @@ fn PyInit__zttp() callconv(.c) ?*c.PyObject {
         py.decref(m);
         return null;
     }
-    py.declareGilNotUsed(m);
+    // Deliberately NOT declaring Py_MOD_GIL_NOT_USED: the module-global
+    // server_ticket_store (connection_obj.zig) is mutated and read across
+    // connections with no synchronization, so a free-threaded build would race it
+    // (a use-after-free even under the intended one-connection-per-thread usage).
+    // Without the declaration CPython re-enables the compatibility GIL on
+    // free-threaded builds, which serializes these accesses and keeps the cp314t/
+    // cp315t wheels correct. Re-enable once the extension is synchronized (#151).
     return m;
 }


### PR DESCRIPTION
The free-threaded wheels (cp314t/cp315t) declared `Py_MOD_GIL_NOT_USED`, but the extension is not actually safe without the GIL - a security review found real data races:

- **Cross-connection, under *intended* usage**: the module-global `server_ticket_store` is mutated by `rememberServerTicket` (append/remove/free → reallocates its buffer) and read by `ServerConfig.flightConfig`, which hands out `server_ticket_store.items` as a **slice** consumed deep in the QUIC/TLS server handshake. Two HTTP/3 server connections, each correctly owned by its own thread (the intended free-threaded pattern), can realloc the buffer under a reader - a use-after-free with no misuse.
- **Per-connection, under misuse**: unsynchronized Reader/Writer/`upgrade_obj` state; the flag turned a previously-wrong-state bug into interpreter-corrupting UAF when a `Connection` is shared across threads.

Making it genuinely GIL-free requires real synchronization (guard the global so no reader holds a slice across a concurrent mutation, plus per-Connection locking or an enforced single-owner contract) - a rework that can't be responsibly stress-tested in a single change. So retract the premature claim: without `Py_MOD_GIL_NOT_USED`, CPython re-enables the compatibility GIL on free-threaded builds and serializes these accesses. The cp314t/cp315t wheels still load and run; they just use the GIL until the work in **#151** lands.

Verified: `sys._is_gil_enabled()` is now `True` on 3.15t, and the suite passes under both 3.15t (288, with a scoped ignore for CPython's expected re-enable warning) and a normal GIL build (289).

🤖 Generated with [Claude Code](https://claude.com/claude-code)