### PR TITLE
Add a verify=<callable> hook for caller-decided certificate trust

### DIFF
--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -73,7 +73,27 @@ der_certs = b"".join(ssl.create_default_context().get_ca_certs(binary_form=True)
 client = zttp.Connection(zttp.CLIENT, zttp.HTTP3, server_name=b"example.com", trust=der_certs)
 ```
 
-Two escape hatches:
+Other ways to decide trust:
+
+- **Your own verifier.** Pass a callable as `verify=` and zttp hands it the
+  certificate chain to judge - the sans-IO way to use the OS-native verifier, or
+  [`truststore`][truststore], or any policy. It runs during the handshake and
+  returns `True` to accept; a `False` or a raised exception rejects (and your
+  exception propagates). Any I/O it needs happens in *your* code, so zttp stays
+  sans-IO. This also sidesteps the ECDSA-only limit below, since zttp does not do
+  the checking:
+
+    ```python
+    import truststore
+
+    ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+    def verify(certificates: list[bytes], server_name: bytes | None) -> bool:
+        # certificates is the DER chain, leaf first; decide with your own tooling
+        return my_policy_ok(certificates, server_name)
+
+    client = zttp.Connection(zttp.CLIENT, zttp.HTTP3, server_name=b"example.com", verify=verify)
+    ```
 
 - **Pinning.** Pass the exact server certificate as `trust=` - handy for a
   self-signed dev server. `zttp.generate_self_signed(dns_name, private_key,
@@ -82,10 +102,13 @@ Two escape hatches:
 - **Opt out.** `verify=False` disables authentication entirely. It is explicit
   and dangerous - only for local testing over a trusted link.
 
-!!! note "ECDSA only"
-    zttp verifies ECDSA P-256/P-384 chains (the schemes it speaks). An RSA
-    certificate fails verification. This is a parser limitation, not a security
-    fallback - it never trusts what it cannot check.
+!!! note "ECDSA only (built-in `trust=` verification)"
+    zttp's own chain verification handles ECDSA P-256/P-384 (the schemes it
+    speaks); an RSA chain fails - it never trusts what it cannot check. This is a
+    limitation of the `trust=` path only; a `verify=` callback does its own
+    checking and has no such limit.
+
+  [truststore]: https://truststore.readthedocs.io/
 
 !!! warning "Scope"
     HTTP/3 support is still experimental. The public surface is intentionally

--- a/src/core/quic/tls/verify.zig
+++ b/src/core/quic/tls/verify.zig
@@ -22,7 +22,20 @@ const EcdsaP384 = std.crypto.sign.ecdsa.EcdsaP384Sha384;
 pub const Trust = union(enum) {
     insecure,
     anchors: *const AnchorSet,
+    /// Trust is decided by an injected callback (e.g. the OS-native verifier, via
+    /// the integrator's I/O layer). The core still does no I/O - it hands the raw
+    /// chain to `call` and honors the verdict, like rustls's ServerCertVerifier.
+    verifier: Verifier,
 };
+
+pub const Verifier = struct {
+    ctx: *anyopaque,
+    call: *const fn (ctx: *anyopaque, chain: []const []const u8, host: ?[]const u8, now_sec: i64) bool,
+};
+
+/// Certificate chains longer than this are refused before the callback runs; real
+/// chains are a handful of certificates and this bounds the on-stack chain array.
+pub const MAX_CHAIN = 12;
 
 pub const Options = struct {
     trust: Trust,
@@ -385,6 +398,19 @@ pub fn verifyCertificateMessage(body: []const u8, opts: Options) Error!void {
 
     switch (opts.trust) {
         .insecure => return,
+        .verifier => |v| {
+            // Hand the raw chain to the caller's verifier and honor its verdict.
+            var chain: [MAX_CHAIN][]const u8 = undefined;
+            var n: usize = 0;
+            while (list.remaining() != 0) {
+                if (n >= MAX_CHAIN) return error.BadCertificate;
+                chain[n] = (list.vector(3) catch return error.BadCertificate).buf;
+                _ = list.vector(2) catch return error.BadCertificate; // entry extensions
+                n += 1;
+            }
+            if (v.call(v.ctx, chain[0..n], opts.host, opts.now_sec)) return;
+            return error.ChainUntrusted;
+        },
         .anchors => |anchors| {
             var prev: Cert = undefined;
             var index: usize = 0;
@@ -547,6 +573,36 @@ test "insecure trust skips verification but still requires a leaf" {
     const empty_msg = try certMessage(gpa, &.{});
     defer gpa.free(empty_msg);
     try testing.expectError(error.EmptyChain, verifyCertificateMessage(empty_msg, .{ .trust = .insecure, .host = null, .now_sec = NOW }));
+}
+
+test "a verifier callback decides trust and receives the chain" {
+    const gpa = testing.allocator;
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(gpa);
+    const der = try selfSigned(gpa, &buf, [_]u8{0x42} ** 32, "example.com", NOT_AFTER);
+    const msg = try certMessage(gpa, &.{der});
+    defer gpa.free(msg);
+
+    const Ctx = struct {
+        seen_certs: usize = 0,
+        seen_host_len: usize = 0,
+        accept: bool,
+        fn call(ctx: *anyopaque, chain: []const []const u8, host: ?[]const u8, now_sec: i64) bool {
+            _ = now_sec;
+            const self: *@This() = @ptrCast(@alignCast(ctx));
+            self.seen_certs = chain.len;
+            self.seen_host_len = if (host) |h| h.len else 0;
+            return self.accept;
+        }
+    };
+    var ctx = Ctx{ .accept = true };
+    const trust: Trust = .{ .verifier = .{ .ctx = &ctx, .call = Ctx.call } };
+    try verifyCertificateMessage(msg, .{ .trust = trust, .host = "example.com", .now_sec = NOW });
+    try testing.expectEqual(@as(usize, 1), ctx.seen_certs); // the callback saw the leaf
+    try testing.expectEqual(@as(usize, 11), ctx.seen_host_len); // and the host "example.com"
+
+    ctx.accept = false;
+    try testing.expectError(error.ChainUntrusted, verifyCertificateMessage(msg, .{ .trust = trust, .host = "example.com", .now_sec = NOW }));
 }
 
 test "malformed certificates are rejected, never panic" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -509,6 +509,9 @@ const H3Engine = struct {
     /// Client trust anchors, heap-owned so the tls client's borrowed pointer stays
     /// valid for the connection's life. null on servers and insecure clients.
     trust_bundle: ?*AnchorSet = null,
+    /// Held Python callable when verify=<callable>; the tls client's verifier ctx
+    /// borrows it, so it must outlive the connection. null otherwise.
+    verify_callable: ?*c.PyObject = null,
     /// The integrator's clock at the last receive_datagram / handle_timeout. A Stream
     /// send does not carry its own `now` (the API matches H2's, which has no clock),
     /// so it packetises against the most recent time the caller gave us.
@@ -547,9 +550,17 @@ const H3Engine = struct {
         }
 
         if (peer_address) |addr| {
-            self.qc.?.receiveDatagramFrom(dgram, now, addr) catch |e| return exceptions.raiseQuic(e);
+            self.qc.?.receiveDatagramFrom(dgram, now, addr) catch |e| {
+                // A verify callback that raised left its exception set; propagate it
+                // rather than masking it with a generic QUIC protocol error.
+                if (c.PyErr_Occurred() != null) return null;
+                return exceptions.raiseQuic(e);
+            };
         } else {
-            self.qc.?.receiveDatagram(dgram, now) catch |e| return exceptions.raiseQuic(e);
+            self.qc.?.receiveDatagram(dgram, now) catch |e| {
+                if (c.PyErr_Occurred() != null) return null;
+                return exceptions.raiseQuic(e);
+            };
         }
         self.h3.?.pumpAll() catch |e| return exceptions.raiseH3(e);
         return py.none();
@@ -961,11 +972,12 @@ const H3Engine = struct {
             gpa.destroy(q);
         }
         if (self.config) |*cfg| cfg.deinit();
-        // Freed after qc: the tls client borrowed a pointer into this bundle.
+        // Freed after qc: the tls client borrowed pointers into these.
         if (self.trust_bundle) |b| {
             b.deinit(gpa);
             gpa.destroy(b);
         }
+        if (self.verify_callable) |cb| py.decref(cb);
     }
 };
 
@@ -1657,8 +1669,10 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
 
 const ClientTrust = struct {
     trust: tls_verify.Trust,
-    /// Heap-owned when `.anchors`; freed by H3Engine.deinit. null for `.insecure`.
+    /// Heap-owned when `.anchors`; freed by H3Engine.deinit. null otherwise.
     bundle: ?*AnchorSet,
+    /// Held Python callable when `verify=<callable>`; freed by H3Engine.deinit.
+    callable: ?*c.PyObject,
 };
 
 fn freeTrust(t: ClientTrust) void {
@@ -1666,6 +1680,34 @@ fn freeTrust(t: ClientTrust) void {
         b.deinit(gpa);
         gpa.destroy(b);
     }
+    if (t.callable) |cb| py.decref(cb);
+}
+
+// Bridges the core's certificate verifier to a Python callable, verify(certs, host)
+// -> bool, called synchronously mid-handshake with the GIL held (we are inside a
+// receive_datagram call). A raise or a falsy return is a rejection; on a raise the
+// exception is left set so receive_datagram propagates it rather than masking it
+// with a generic QUIC error. `certs` is the DER chain leaf-first; `host` is
+// server_name or None. Any I/O the verifier needs happens here, in the caller's
+// code - the core stays sans-IO.
+fn verifierTrampoline(ctx: *anyopaque, chain: []const []const u8, host: ?[]const u8, now_sec: i64) bool {
+    _ = now_sec;
+    const callable: py.Object = @ptrCast(@alignCast(ctx));
+    const list = c.PyList_New(@intCast(chain.len));
+    if (list == null) return false;
+    defer py.decref(list);
+    for (chain, 0..) |der, i| {
+        const item = py.fromBytes(der);
+        if (item == null) return false;
+        _ = c.PyList_SetItem(list, @intCast(i), item); // steals the reference
+    }
+    const host_obj = if (host) |h| py.fromBytes(h) else py.none();
+    if (host_obj == null) return false;
+    defer py.decref(host_obj);
+    const result = c.PyObject_CallFunctionObjArgs(callable, list, host_obj, @as(py.Object, null));
+    if (result == null) return false; // the callback raised; the error stays set
+    defer py.decref(result);
+    return c.PyObject_IsTrue(result) == 1;
 }
 
 /// Resolve the client's certificate-verification policy. Sans-IO: the library
@@ -1676,7 +1718,24 @@ fn freeTrust(t: ClientTrust) void {
 /// silent bypass. On failure sets a Python error and returns null.
 fn resolveClientTrust(trust_obj: ?*c.PyObject, verify_obj: ?*c.PyObject, now_sec: i64) ?ClientTrust {
     const has_trust = trust_obj != null and !py.isNone(trust_obj);
-    const verify = if (verify_obj != null and !py.isNone(verify_obj)) blk: {
+    const has_verify = verify_obj != null and !py.isNone(verify_obj);
+
+    // verify=<callable>: the caller decides trust from the chain (e.g. via truststore
+    // or the OS verifier). zttp surfaces the certificates and honors the verdict.
+    if (has_verify and c.PyCallable_Check(verify_obj) != 0) {
+        if (has_trust) {
+            _ = py.raiseValue("trust= cannot be combined with a verify callback; the callback receives the chain and decides");
+            return null;
+        }
+        py.incref(verify_obj.?);
+        return .{
+            .trust = .{ .verifier = .{ .ctx = @ptrCast(verify_obj.?), .call = verifierTrampoline } },
+            .bundle = null,
+            .callable = verify_obj,
+        };
+    }
+
+    const verify = if (has_verify) blk: {
         const t = c.PyObject_IsTrue(verify_obj);
         if (t < 0) return null;
         break :blk t != 0;
@@ -1687,10 +1746,10 @@ fn resolveClientTrust(trust_obj: ?*c.PyObject, verify_obj: ?*c.PyObject, now_sec
             _ = py.raiseValue("trust= cannot be combined with verify=False");
             return null;
         }
-        return .{ .trust = .insecure, .bundle = null };
+        return .{ .trust = .insecure, .bundle = null, .callable = null };
     }
     if (!has_trust) {
-        _ = py.raiseValue("an HTTP/3 client must be given trust=<CA certificates, PEM or DER> to verify the server, or verify=False to disable verification (sans-IO: zttp does not read the system trust store; load it yourself, e.g. ssl.create_default_context().get_ca_certs())");
+        _ = py.raiseValue("an HTTP/3 client must be given trust=<CA certificates, PEM or DER>, a verify=<callable> that decides from the chain, or verify=False to disable verification (sans-IO: zttp does not read the system trust store; load it yourself, e.g. ssl.create_default_context().get_ca_certs())");
         return null;
     }
 
@@ -1705,7 +1764,7 @@ fn resolveClientTrust(trust_obj: ?*c.PyObject, verify_obj: ?*c.PyObject, now_sec
         gpa.destroy(bundle);
         return null;
     }
-    return .{ .trust = .{ .anchors = bundle }, .bundle = bundle };
+    return .{ .trust = .{ .anchors = bundle }, .bundle = bundle, .callable = null };
 }
 
 fn addTrustAnchors(bundle: *AnchorSet, obj: *c.PyObject, now_sec: i64) bool {
@@ -1867,7 +1926,7 @@ fn buildClientH3(
         return null;
     };
     h.* = H3Connection.init(gpa, q);
-    return .{ .qc = q, .h3 = h, .trust_bundle = client_trust.bundle };
+    return .{ .qc = q, .h3 = h, .trust_bundle = client_trust.bundle, .verify_callable = client_trust.callable };
 }
 
 // Copy the integrator's server credentials into an owned ServerConfig, validating

--- a/tests/test_http3_verify.py
+++ b/tests/test_http3_verify.py
@@ -104,6 +104,49 @@ def test_matching_san_wildcard_is_accepted() -> None:
     handshake(client, server)
 
 
+# -- verify=<callable>: the caller decides trust from the chain (truststore, ssl, ...) --
+
+
+def test_verify_callback_receives_the_chain_and_decides() -> None:
+    cert = server_cert(b"example.test")
+    seen: dict[str, object] = {}
+
+    def verifier(certificates: list[bytes], server_name: bytes | None) -> bool:
+        seen["certs"] = certificates
+        seen["host"] = server_name
+        return True  # the caller's own verification would go here
+
+    client, server = make_pair(cert=cert, server_name=b"example.test", verify=verifier)
+    handshake(client, server)  # accepted
+    assert seen["certs"] == [cert]  # got the DER chain, leaf first
+    assert seen["host"] == b"example.test"
+
+
+def test_verify_callback_rejection_fails_the_handshake() -> None:
+    cert = server_cert()
+    client, server = make_pair(cert=cert, server_name=b"localhost", verify=lambda certs, host: False)
+    with pytest.raises(zttp.RemoteProtocolError):
+        handshake(client, server)
+
+
+def test_verify_callback_exception_propagates() -> None:
+    cert = server_cert()
+
+    def verifier(certificates: list[bytes], server_name: bytes | None) -> bool:
+        raise RuntimeError("policy check failed")
+
+    client, server = make_pair(cert=cert, server_name=b"localhost", verify=verifier)
+    with pytest.raises(RuntimeError, match="policy check failed"):
+        handshake(client, server)  # the callback's own exception, not a masked QUIC error
+
+
+def test_verify_callback_conflicts_with_trust() -> None:
+    with pytest.raises(ValueError, match="callback"):
+        zttp.Connection(
+            zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"x", trust=server_cert(), verify=lambda certs, host: True
+        )
+
+
 # -- constructor policy (no handshake needed) ---------------------------------
 
 

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Final, Literal, final, overload
 
 from typing_extensions import disjoint_base
@@ -282,7 +283,7 @@ class Connection:
         remembered_transport_params: bytes | None = ...,
         validation_token: bytes | None = ...,
         trust: bytes | None = ...,
-        verify: bool = ...,
+        verify: bool | Callable[[list[bytes], bytes | None], bool] = ...,
         now_sec: int | None = ...,
     ) -> H3Connection: ...
     @overload


### PR DESCRIPTION
Stacked on #146. Follow-up from that PR's discussion: the built-in `trust=` path is the `certifi` model (verify an ECDSA chain against anchors you pass). This adds the [`truststore`](https://truststore.readthedocs.io/)-style option - delegate the *trust decision* itself to the caller.

`verify=` now also accepts a **callable**: zttp surfaces the DER certificate chain (leaf first) and the expected host, and the callback returns `True` to accept. It runs synchronously during the handshake; a `False` or a raised exception rejects, and **the callback's own exception propagates** (not masked by a QUIC error). This is the sans-IO way to reach the OS-native verifier / truststore / any policy - any I/O the verifier needs happens in *your* code, not zttp's - mirroring rustls's `ServerCertVerifier`. It also sidesteps the built-in path's ECDSA-only limit, since zttp does no checking in this mode.

```python
def verify(certificates: list[bytes], server_name: bytes | None) -> bool:
    return my_policy_ok(certificates, server_name)  # truststore, ssl, OS verifier, ...

client = zttp.Connection(zttp.CLIENT, zttp.HTTP3, server_name=b"example.com", verify=verify)
```

- Core: a `Trust.verifier` variant carries an injected fn pointer; the core hands it the chain and honors the verdict - no I/O, still fuzzed.
- Binding: a trampoline calls the Python callable; `receive_datagram` propagates a pending Python error instead of masking it.

Tested end to end (callback receives the chain + host; accept/reject drive the handshake; a raising callback propagates). 792 core Zig tests, 307 Python tests, ruff/mypy/stubtest/zig-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)