### PR TITLE
Rename Goaway event to GoAway

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ What differs is each protocol's **event union**, so its surface is exactly as wi
 as its reality. HTTP/1.1 is a single stream and adds nothing. HTTP/2 and HTTP/3
 multiplex many concurrent streams over one connection, so every event carries a
 `stream_id` and they add the control events they actually have (`RstStream`,
-`Goaway`, `Settings`, `Ping`, `WindowUpdate` for H2; `Settings`, `Goaway` for H3).
+`GoAway`, `Settings`, `Ping`, `WindowUpdate` for H2; `Settings`, `GoAway` for H3).
 
 Multiplexing has to reach a flat, single pull. The resolution is a **single,
 arrival-ordered event queue** where every event carries a `stream_id` and the

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -84,7 +84,7 @@ the ones that matter on its own; they're here when you want visibility.
 
 ::: zttp.RstStream
 
-::: zttp.Goaway
+::: zttp.GoAway
 
 The integer ids in a `Settings` event's `params` have names (RFC 9113 6.5.2):
 

--- a/docs/usage/http2.md
+++ b/docs/usage/http2.md
@@ -391,7 +391,7 @@ can observe (and react to) what the peer is doing:
 | `WindowUpdate` | The peer granted flow-control credit. |
 | `Ping` | A keepalive / round-trip probe. |
 | `RstStream` | The peer reset a single stream. |
-| `Goaway` | The peer is shutting the connection down. |
+| `GoAway` | The peer is shutting the connection down. |
 
 They flow out of `next_event` like any other event. Most applications can ignore
 them, since zttp acts on the ones that matter (crediting windows, releasing

--- a/scripts/interop_aioquic.py
+++ b/scripts/interop_aioquic.py
@@ -335,7 +335,7 @@ def assert_zttp_client_to_aioquic_server(tmp: Path) -> None:
         if event is zttp.NEED_DATA:
             break
         goaway_events.append(event)
-    goaways = [event for event in goaway_events if event.__class__.__name__ == "Goaway"]
+    goaways = [event for event in goaway_events if event.__class__.__name__ == "GoAway"]
     if not goaways or goaways[-1].last_stream_id != 8 or client.goaway_received() != 8:
         raise SystemExit(f"zttp did not receive aioquic's GOAWAY: {goaway_events!r}")
 

--- a/src/core/events.zig
+++ b/src/core/events.zig
@@ -85,7 +85,7 @@ pub const StreamReset = struct {
 /// The peer is shutting the connection down: HTTP/2 GOAWAY (RFC 9113 6.8) or
 /// HTTP/3 GOAWAY (RFC 9114 5.2). `last_stream_id` is u64 to hold the HTTP/3
 /// 62-bit id losslessly; HTTP/2's 31-bit id fits the same field.
-pub const Goaway = struct {
+pub const GoAway = struct {
     last_stream_id: u64,
     error_code: u32,
     debug: []const u8 = &.{},
@@ -138,7 +138,7 @@ pub const H2Event = union(enum) {
     end_of_message: EndOfMessage,
     need_data,
     rst_stream: RstStream,
-    goaway: Goaway,
+    goaway: GoAway,
     settings: SettingsEvent,
     ping: Ping,
     window_update: WindowUpdate,
@@ -158,7 +158,7 @@ pub const H3Event = union(enum) {
     connection_closed,
     need_data,
     settings: SettingsEvent,
-    goaway: Goaway,
+    goaway: GoAway,
     rst_stream: StreamReset,
 };
 

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -156,7 +156,7 @@ pub const Connection = struct {
     failed_with: H2Error = error.ProtocolError,
     /// Set to the GOAWAY error code on the FIRST transition to .failed, so the
     /// integrator can serialize one GOAWAY before closing (RFC 9113 5.4.1).
-    /// Consumed by takeGoawayOwed; re-raising the latched error does not re-set it.
+    /// Consumed by takeGoAwayOwed; re-raising the latched error does not re-set it.
     goaway_owed: ?constants.ErrorCode = null,
     eof_seen: bool = false,
 
@@ -214,7 +214,7 @@ pub const Connection = struct {
     /// Produce the next event, or `.need_data`. A connection error poisons the
     /// engine: it is latched and re-raised on every later call (as H1 does). The
     /// first failure records the GOAWAY code in goaway_owed (RFC 9113 5.4.1); the
-    /// integrator drains it via takeGoawayOwed and serializes one GOAWAY.
+    /// integrator drains it via takeGoAwayOwed and serializes one GOAWAY.
     pub fn nextEvent(self: *Connection) H2Error!Event {
         if (self.phase == .failed) return self.failed_with;
         return self.dispatch() catch |e| self.fail(e);
@@ -222,7 +222,7 @@ pub const Connection = struct {
 
     /// The GOAWAY error code owed after a connection-fatal error, or null. Returns
     /// it at most once so the integrator sends exactly one GOAWAY.
-    pub fn takeGoawayOwed(self: *Connection) ?constants.ErrorCode {
+    pub fn takeGoAwayOwed(self: *Connection) ?constants.ErrorCode {
         const owed = self.goaway_owed;
         self.goaway_owed = null;
         return owed;
@@ -319,7 +319,7 @@ pub const Connection = struct {
         switch (ftype) {
             .settings => try self.handleSettings(f),
             .ping => try self.handlePing(f),
-            .goaway => try self.handleGoaway(f),
+            .goaway => try self.handleGoAway(f),
             .window_update => try self.handleWindowUpdate(f),
             .data => try self.handleData(f),
             .rst_stream => try self.handleRstStream(f),
@@ -368,7 +368,7 @@ pub const Connection = struct {
         self.push(.{ .ping = .{ .ack = Flags.has(f.header.flags, Flags.ack), .opaque_data = data } });
     }
 
-    fn handleGoaway(self: *Connection, f: frame_mod.Frame) H2Error!void {
+    fn handleGoAway(self: *Connection, f: frame_mod.Frame) H2Error!void {
         if (f.header.stream_id != 0) return error.ProtocolError;
         const last_id = std.mem.readInt(u32, f.payload[0..4], .big) & 0x7FFF_FFFF;
         const code = std.mem.readInt(u32, f.payload[4..8], .big);
@@ -1440,11 +1440,11 @@ test "a connection-fatal error owes one GOAWAY with the mapped code" {
     try handshook(&c, hdr.items);
     try testing.expectError(error.ProtocolError, c.nextEvent());
     // The owed GOAWAY carries PROTOCOL_ERROR and is reported exactly once.
-    try testing.expectEqual(@as(?ErrorCode, .protocol_error), c.takeGoawayOwed());
-    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+    try testing.expectEqual(@as(?ErrorCode, .protocol_error), c.takeGoAwayOwed());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoAwayOwed());
     // Re-raising the latched error does not re-arm a GOAWAY.
     try testing.expectError(error.ProtocolError, c.nextEvent());
-    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoAwayOwed());
 }
 
 test "a fatal feed (max_buffer breach) poisons the connection and owes a GOAWAY" {
@@ -1453,11 +1453,11 @@ test "a fatal feed (max_buffer breach) poisons the connection and owes a GOAWAY"
     c.limits.max_buffer = 8;
     try testing.expectError(error.MessageTooLong, c.feed("123456789")); // 9 > 8
     // The breach owes ENHANCE_YOUR_CALM and poisons the connection.
-    try testing.expectEqual(@as(?ErrorCode, .enhance_your_calm), c.takeGoawayOwed());
+    try testing.expectEqual(@as(?ErrorCode, .enhance_your_calm), c.takeGoAwayOwed());
     try testing.expectError(error.MessageTooLong, c.nextEvent()); // latched
     // A later feed re-raises the latched error without re-arming a GOAWAY.
     try testing.expectError(error.MessageTooLong, c.feed("more"));
-    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoawayOwed());
+    try testing.expectEqual(@as(?ErrorCode, null), c.takeGoAwayOwed());
 }
 
 test "localSettingsParams advertises the enforced limits" {

--- a/src/core/h2/writer.zig
+++ b/src/core/h2/writer.zig
@@ -99,7 +99,7 @@ pub const Writer = struct {
         try self.writeFrame(.rst_stream, 0, stream_id, &p);
     }
 
-    pub fn sendGoaway(self: *Writer, last_stream_id: u32, code: ErrorCode, debug: []const u8) WriteError!void {
+    pub fn sendGoAway(self: *Writer, last_stream_id: u32, code: ErrorCode, debug: []const u8) WriteError!void {
         var head: [8]u8 = undefined;
         std.mem.writeInt(u32, head[0..4], last_stream_id & 0x7FFF_FFFF, .big);
         std.mem.writeInt(u32, head[4..8], @intFromEnum(code), .big);

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -383,7 +383,7 @@ const H2Engine = struct {
     fn goaway(self: *H2Engine, code: u32, last_stream_id: ?u32) py.Object {
         if (!self.ensureHandshake()) return null;
         const last = last_stream_id orelse self.conn.lastPeerStreamId();
-        self.writer.sendGoaway(last, @enumFromInt(code), &.{}) catch |e| return h2RaiseWrite(e);
+        self.writer.sendGoAway(last, @enumFromInt(code), &.{}) catch |e| return h2RaiseWrite(e);
         return py.none();
     }
 
@@ -417,13 +417,13 @@ const H2Engine = struct {
     /// Serialize the GOAWAY owed after a connection-fatal error (RFC 9113 5.4.1),
     /// so data_to_send carries it before the integrator closes. Best-effort: if
     /// the writer itself OOMs there is nothing useful to do but close.
-    fn emitGoawayIfOwed(self: *H2Engine) void {
-        if (self.conn.takeGoawayOwed()) |code| {
+    fn emitGoAwayIfOwed(self: *H2Engine) void {
+        if (self.conn.takeGoAwayOwed()) |code| {
             if (!self.handshake_sent) {
                 self.sendOurPreface() catch return;
                 self.handshake_sent = true;
             }
-            self.writer.sendGoaway(self.conn.lastPeerStreamId(), code, &.{}) catch {};
+            self.writer.sendGoAway(self.conn.lastPeerStreamId(), code, &.{}) catch {};
         }
     }
 
@@ -1800,7 +1800,7 @@ fn receive_data(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Objec
     switch (engine.*) {
         .h2 => |*e| {
             e.conn.feed(bytes) catch |err| {
-                e.emitGoawayIfOwed(); // a fatal feed (e.g. max_buffer flood) still owes a GOAWAY
+                e.emitGoAwayIfOwed(); // a fatal feed (e.g. max_buffer flood) still owes a GOAWAY
                 return exceptions.raiseH2(err);
             };
             return py.none();
@@ -1834,7 +1834,7 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
         .h3 => |*e| return e.nextEvent(),
         .h2 => |*e| {
             const ev = e.conn.nextEvent() catch |err| {
-                e.emitGoawayIfOwed(); // queue one GOAWAY for the next data_to_send
+                e.emitGoAwayIfOwed(); // queue one GOAWAY for the next data_to_send
                 return exceptions.raiseH2(err);
             };
             e.autoRespond(ev) catch |err| return h2RaiseWrite(err);

--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -55,7 +55,7 @@ const RstStreamObject = extern struct {
     error_code: py.Object,
 };
 
-const GoawayObject = extern struct {
+const GoAwayObject = extern struct {
     ob_base: c.PyObject,
     last_stream_id: py.Object,
     error_code: py.Object,
@@ -137,9 +137,9 @@ var rst_stream_members = [_]py.MemberDef{
     .{ .name = null, .type = 0, .offset = 0, .flags = 0, .doc = null },
 };
 var goaway_members = [_]py.MemberDef{
-    member("last_stream_id", @offsetOf(GoawayObject, "last_stream_id")),
-    member("error_code", @offsetOf(GoawayObject, "error_code")),
-    member("debug", @offsetOf(GoawayObject, "debug")),
+    member("last_stream_id", @offsetOf(GoAwayObject, "last_stream_id")),
+    member("error_code", @offsetOf(GoAwayObject, "error_code")),
+    member("debug", @offsetOf(GoAwayObject, "debug")),
     .{ .name = null, .type = 0, .offset = 0, .flags = 0, .doc = null },
 };
 var settings_members = [_]py.MemberDef{
@@ -234,7 +234,7 @@ const response_gc = gcOps(ResponseObject);
 const data_gc = gcOps(DataObject);
 const eom_gc = gcOps(EndOfMessageObject);
 const rst_stream_gc = gcOps(RstStreamObject);
-const goaway_gc = gcOps(GoawayObject);
+const goaway_gc = gcOps(GoAwayObject);
 const settings_gc = gcOps(SettingsEventObject);
 const ping_gc = gcOps(PingObject);
 const window_update_gc = gcOps(WindowUpdateObject);
@@ -337,9 +337,9 @@ const rst_stream_fields = .{
     FieldInfo(RstStreamObject){ .name = "error_code", .field = "error_code" },
 };
 const goaway_fields = .{
-    FieldInfo(GoawayObject){ .name = "last_stream_id", .field = "last_stream_id" },
-    FieldInfo(GoawayObject){ .name = "error_code", .field = "error_code" },
-    FieldInfo(GoawayObject){ .name = "debug", .field = "debug" },
+    FieldInfo(GoAwayObject){ .name = "last_stream_id", .field = "last_stream_id" },
+    FieldInfo(GoAwayObject){ .name = "error_code", .field = "error_code" },
+    FieldInfo(GoAwayObject){ .name = "debug", .field = "debug" },
 };
 const settings_fields = .{FieldInfo(SettingsEventObject){ .name = "params", .field = "params" }};
 const ping_fields = .{
@@ -356,7 +356,7 @@ const reprResponse = reprFields(ResponseObject, "Response", response_fields);
 const reprData = reprFields(DataObject, "Data", data_fields);
 const reprEom = reprFields(EndOfMessageObject, "EndOfMessage", eom_fields);
 const reprRstStream = reprFields(RstStreamObject, "RstStream", rst_stream_fields);
-const reprGoaway = reprFields(GoawayObject, "Goaway", goaway_fields);
+const reprGoAway = reprFields(GoAwayObject, "GoAway", goaway_fields);
 const reprSettings = reprFields(SettingsEventObject, "Settings", settings_fields);
 const reprPing = reprFields(PingObject, "Ping", ping_fields);
 const reprWindowUpdate = reprFields(WindowUpdateObject, "WindowUpdate", window_update_fields);
@@ -366,7 +366,7 @@ const cmpResponse = richcompareFields(ResponseObject, response_fields);
 const cmpData = richcompareFields(DataObject, data_fields);
 const cmpEom = richcompareFields(EndOfMessageObject, eom_fields);
 const cmpRstStream = richcompareFields(RstStreamObject, rst_stream_fields);
-const cmpGoaway = richcompareFields(GoawayObject, goaway_fields);
+const cmpGoAway = richcompareFields(GoAwayObject, goaway_fields);
 const cmpSettings = richcompareFields(SettingsEventObject, settings_fields);
 const cmpPing = richcompareFields(PingObject, ping_fields);
 const cmpWindowUpdate = richcompareFields(WindowUpdateObject, window_update_fields);
@@ -390,7 +390,7 @@ var response_slots = slots(response_gc.dealloc, &response_members, response_gc.t
 var data_slots = slots(data_gc.dealloc, &data_members, data_gc.traverse, data_gc.clear, reprData, cmpData);
 var eom_slots = slots(eom_gc.dealloc, &eom_members, eom_gc.traverse, eom_gc.clear, reprEom, cmpEom);
 var rst_stream_slots = slots(rst_stream_gc.dealloc, &rst_stream_members, rst_stream_gc.traverse, rst_stream_gc.clear, reprRstStream, cmpRstStream);
-var goaway_slots = slots(goaway_gc.dealloc, &goaway_members, goaway_gc.traverse, goaway_gc.clear, reprGoaway, cmpGoaway);
+var goaway_slots = slots(goaway_gc.dealloc, &goaway_members, goaway_gc.traverse, goaway_gc.clear, reprGoAway, cmpGoAway);
 var settings_slots = slots(settings_gc.dealloc, &settings_members, settings_gc.traverse, settings_gc.clear, reprSettings, cmpSettings);
 var ping_slots = slots(ping_gc.dealloc, &ping_members, ping_gc.traverse, ping_gc.clear, reprPing, cmpPing);
 var window_update_slots = slots(window_update_gc.dealloc, &window_update_members, window_update_gc.traverse, window_update_gc.clear, reprWindowUpdate, cmpWindowUpdate);
@@ -410,7 +410,7 @@ var response_spec = spec("zttp.Response", @sizeOf(ResponseObject), &response_slo
 var data_spec = spec("zttp.Data", @sizeOf(DataObject), &data_slots);
 var eom_spec = spec("zttp.EndOfMessage", @sizeOf(EndOfMessageObject), &eom_slots);
 var rst_stream_spec = spec("zttp.RstStream", @sizeOf(RstStreamObject), &rst_stream_slots);
-var goaway_spec = spec("zttp.Goaway", @sizeOf(GoawayObject), &goaway_slots);
+var goaway_spec = spec("zttp.GoAway", @sizeOf(GoAwayObject), &goaway_slots);
 var settings_spec = spec("zttp.Settings", @sizeOf(SettingsEventObject), &settings_slots);
 var ping_spec = spec("zttp.Ping", @sizeOf(PingObject), &ping_slots);
 var window_update_spec = spec("zttp.WindowUpdate", @sizeOf(WindowUpdateObject), &window_update_slots);
@@ -630,7 +630,7 @@ pub fn fromH2Event(ev: events.H2Event) py.Object {
         .end_of_message => |e| makeEom(e),
         .need_data => py.newRef(need_data),
         .rst_stream => |r| makeRstStream(r),
-        .goaway => |g| makeGoaway(g),
+        .goaway => |g| makeGoAway(g),
         .settings => |s| makeSettings(s),
         .ping => |p| makePing(p),
         .window_update => |w| makeWindowUpdate(w),
@@ -646,7 +646,7 @@ pub fn fromH3Event(ev: events.H3Event) py.Object {
         .connection_closed => py.newRef(connection_closed),
         .need_data => py.newRef(need_data),
         .settings => |s| makeSettings(s),
-        .goaway => |g| makeGoaway(g),
+        .goaway => |g| makeGoAway(g),
         .rst_stream => |r| makeH3RstStream(r),
     };
 }
@@ -750,10 +750,10 @@ fn makeRstStream(r: events.RstStream) py.Object {
     return o;
 }
 
-fn makeGoaway(g: events.Goaway) py.Object {
+fn makeGoAway(g: events.GoAway) py.Object {
     const o = py.allocInstance(goaway_type);
     if (o == null) return null;
-    const s: *GoawayObject = @ptrCast(o);
+    const s: *GoAwayObject = @ptrCast(o);
     s.last_stream_id = c.PyLong_FromUnsignedLongLong(g.last_stream_id);
     s.error_code = u32Obj(g.error_code);
     s.debug = py.fromBytes(g.debug);
@@ -855,7 +855,7 @@ pub fn register(module: py.Object) bool {
     _ = c.PyModule_AddObjectRef(module, "Data", data_type);
     _ = c.PyModule_AddObjectRef(module, "EndOfMessage", end_of_message_type);
     _ = c.PyModule_AddObjectRef(module, "RstStream", rst_stream_type);
-    _ = c.PyModule_AddObjectRef(module, "Goaway", goaway_type);
+    _ = c.PyModule_AddObjectRef(module, "GoAway", goaway_type);
     _ = c.PyModule_AddObjectRef(module, "Settings", settings_type);
     _ = c.PyModule_AddObjectRef(module, "Ping", ping_type);
     _ = c.PyModule_AddObjectRef(module, "WindowUpdate", window_update_type);

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -1330,7 +1330,7 @@ def test_http3_goaway_event_preserves_large_stream_id() -> None:
     events = []
     while (ev := client.next_event()) is not zttp.NEED_DATA:
         events.append(ev)
-    goaways = [ev for ev in events if isinstance(ev, zttp.Goaway)]
+    goaways = [ev for ev in events if isinstance(ev, zttp.GoAway)]
     assert len(goaways) == 1
     assert goaways[0].last_stream_id == big_id
     assert client.goaway_received() == big_id

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -12,7 +12,7 @@ from zttp._zttp import (
     ConnectionClosed,
     Data,
     EndOfMessage,
-    Goaway,
+    GoAway,
     H1Connection,
     H2Connection,
     H3Connection,
@@ -39,7 +39,7 @@ Event = (
     | Data
     | EndOfMessage
     | RstStream
-    | Goaway
+    | GoAway
     | Settings
     | Ping
     | WindowUpdate
@@ -62,7 +62,7 @@ __all__ = [
     "DatagramHeader",
     "EndOfMessage",
     "Event",
-    "Goaway",
+    "GoAway",
     "H2Settings",
     "H1Connection",
     "H2Connection",

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -116,7 +116,7 @@ class RstStream:
     error_code: int
 
 @final
-class Goaway:
+class GoAway:
     """An HTTP/2 `GOAWAY`: the peer is shutting the connection down.
 
     Attributes:
@@ -181,7 +181,7 @@ Event = (
     | Data
     | EndOfMessage
     | RstStream
-    | Goaway
+    | GoAway
     | Settings
     | Ping
     | WindowUpdate


### PR DESCRIPTION
## Summary
- Rename the public `Goaway` event/type to `GoAway` in the Zig core and Python extension.
- Update Python stubs, package exports, tests, docs, and interop checks for the new name.

## Tests
- `zig build test`
- `zig fmt --check src build.zig tools fuzz`
- `uv run python -m pytest`
- `uv run python -m mypy zttp`