### PR TITLE
Validate HTTP/1 Transfer-Encoding on send

### DIFF
--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -53,6 +53,30 @@ fn validValue(value: []const u8) WriteError!void {
     }
 }
 
+/// Send-side mirror of the reader's Transfer-Encoding framing guard: if the
+/// caller supplies TE, it must be an ordered comma-list that ends in exactly one
+/// `chunked` coding. Anything else would make the bytes we serialize ambiguous
+/// to downstream HTTP/1 parsers.
+const TransferEncoding = struct {
+    saw_chunked: bool = false,
+    coding_after_chunked: bool = false,
+
+    fn add(self: *TransferEncoding, value: []const u8) void {
+        var it = std.mem.splitScalar(u8, value, ',');
+        while (it.next()) |raw| {
+            const coding = trimOws(raw);
+            if (coding.len == 0) continue;
+            if (self.saw_chunked) self.coding_after_chunked = true;
+            if (eqIgnoreCase(coding, "chunked")) self.saw_chunked = true;
+        }
+    }
+
+    fn validate(self: TransferEncoding) WriteError!void {
+        if (!self.saw_chunked) return error.InvalidField;
+        if (self.coding_after_chunked) return error.InvalidField;
+    }
+};
+
 /// Normalize a caller-supplied HTTP version into the bare number (e.g. "1.1"),
 /// accepting both "1.1" and "HTTP/1.1" so a value round-tripped from the read
 /// side (which yields the bare "1.1") cannot double-prefix into "HTTP/HTTP/1.1".
@@ -168,11 +192,13 @@ fn validateHeaders(hdrs: []const Header) WriteError!void {
 /// Content-Length, or conflicting duplicate Content-Lengths, would let a
 /// downstream parser disagree about message boundaries (response splitting).
 fn validateFraming(hdrs: []const Header) WriteError!void {
+    var te = TransferEncoding{};
     var has_te = false;
     var content_length: ?[]const u8 = null;
     for (hdrs) |h| {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
             has_te = true;
+            te.add(h.value);
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
             if (v.len > 0 and ascii.parseDecimal(u64, v) == null) return error.InvalidField; // digits, no overflow
@@ -182,6 +208,7 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
             content_length = v;
         }
     }
+    if (has_te) try te.validate();
     if (has_te and content_length != null) return error.InvalidField; // TE + CL
 }
 
@@ -593,6 +620,37 @@ test "send-path injection: CRLF in trailer rejected" {
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
     const trailers = [_]Header{.{ .name = "X", .value = "v\r\nInjected: 1" }};
     try t.expectError(error.InvalidField, wr.endMessage(&trailers));
+}
+
+test "send rejects non-chunked transfer-encoding" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip" }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send rejects non-final transfer-encoding chunked" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked, gzip" }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send rejects duplicate transfer-encoding chunked" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked, chunked" }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send accepts transfer-encoding with chunked final" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
+    try wr.sendResponse("1.1", 200, "OK", &h, "GET");
+    try wr.sendData("abc");
+    try wr.endMessage(&.{});
+    try t.expectEqualStrings("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n3\r\nabc\r\n0\r\n\r\n", wr.pending());
 }
 
 test "send rejects ambiguous framing (TE + CL)" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -53,13 +53,6 @@ fn validValue(value: []const u8) WriteError!void {
     }
 }
 
-/// Send-side Transfer-Encoding policy follows h11: zttp only knows how to emit
-/// `chunked`, so any caller-supplied TE must be one field whose value is exactly
-/// that coding. We do not serialize unsupported codings as metadata-only hints.
-fn validateTransferEncoding(value: []const u8) WriteError!void {
-    if (!eqIgnoreCase(trimOws(value), "chunked")) return error.InvalidField;
-}
-
 /// Normalize a caller-supplied HTTP version into the bare number (e.g. "1.1"),
 /// accepting both "1.1" and "HTTP/1.1" so a value round-tripped from the read
 /// side (which yields the bare "1.1") cannot double-prefix into "HTTP/HTTP/1.1".
@@ -184,7 +177,9 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
             if (has_te) return error.InvalidField;
             has_te = true;
-            try validateTransferEncoding(h.value);
+            // h11-style send policy: zttp only emits the `chunked` transfer
+            // coding it implements, never unsupported metadata-only codings.
+            if (!eqIgnoreCase(trimOws(h.value), "chunked")) return error.InvalidField;
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
             if (v.len > 0 and ascii.parseDecimal(u64, v) == null) return error.InvalidField; // digits, no overflow

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -53,29 +53,12 @@ fn validValue(value: []const u8) WriteError!void {
     }
 }
 
-/// Send-side mirror of the reader's Transfer-Encoding framing guard: if the
-/// caller supplies TE, it must be an ordered comma-list that ends in exactly one
-/// `chunked` coding. Anything else would make the bytes we serialize ambiguous
-/// to downstream HTTP/1 parsers.
-const TransferEncoding = struct {
-    saw_chunked: bool = false,
-    coding_after_chunked: bool = false,
-
-    fn add(self: *TransferEncoding, value: []const u8) void {
-        var it = std.mem.splitScalar(u8, value, ',');
-        while (it.next()) |raw| {
-            const coding = trimOws(raw);
-            if (coding.len == 0) continue;
-            if (self.saw_chunked) self.coding_after_chunked = true;
-            if (eqIgnoreCase(coding, "chunked")) self.saw_chunked = true;
-        }
-    }
-
-    fn validate(self: TransferEncoding) WriteError!void {
-        if (!self.saw_chunked) return error.InvalidField;
-        if (self.coding_after_chunked) return error.InvalidField;
-    }
-};
+/// Send-side Transfer-Encoding policy follows h11: zttp only knows how to emit
+/// `chunked`, so any caller-supplied TE must be one field whose value is exactly
+/// that coding. We do not serialize unsupported codings as metadata-only hints.
+fn validateTransferEncoding(value: []const u8) WriteError!void {
+    if (!eqIgnoreCase(trimOws(value), "chunked")) return error.InvalidField;
+}
 
 /// Normalize a caller-supplied HTTP version into the bare number (e.g. "1.1"),
 /// accepting both "1.1" and "HTTP/1.1" so a value round-tripped from the read
@@ -181,29 +164,27 @@ pub fn reasonPhrase(status: u16) []const u8 {
     };
 }
 
-fn validateHeaders(hdrs: []const Header, require_te_chunked: bool) WriteError!void {
+fn validateHeaders(hdrs: []const Header) WriteError!void {
     for (hdrs) |h| {
         try validName(h.name);
         try validValue(h.value);
     }
-    try validateFraming(hdrs, require_te_chunked);
+    try validateFraming(hdrs);
 }
 
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
 /// smuggling guards. A message carrying both Transfer-Encoding and
-/// Content-Length, or conflicting duplicate Content-Lengths, would let a
-/// downstream parser disagree about message boundaries (response splitting).
-/// Bodyless responses may carry metadata-only Transfer-Encoding values (e.g.
-/// HEAD/304 describing the representation), so `require_te_chunked` only applies
-/// when the message actually needs TE to delimit a body.
-fn validateFraming(hdrs: []const Header, require_te_chunked: bool) WriteError!void {
-    var te = TransferEncoding{};
+/// Content-Length, multiple Transfer-Encoding fields, unsupported TE codings, or
+/// conflicting duplicate Content-Lengths would let a downstream parser disagree
+/// about message boundaries (response splitting).
+fn validateFraming(hdrs: []const Header) WriteError!void {
     var has_te = false;
     var content_length: ?[]const u8 = null;
     for (hdrs) |h| {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
+            if (has_te) return error.InvalidField;
             has_te = true;
-            te.add(h.value);
+            try validateTransferEncoding(h.value);
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
             if (v.len > 0 and ascii.parseDecimal(u64, v) == null) return error.InvalidField; // digits, no overflow
@@ -213,7 +194,6 @@ fn validateFraming(hdrs: []const Header, require_te_chunked: bool) WriteError!vo
             content_length = v;
         }
     }
-    if (require_te_chunked and has_te) try te.validate();
     if (has_te and content_length != null) return error.InvalidField; // TE + CL
 }
 
@@ -270,7 +250,7 @@ pub const Writer = struct {
         try validLineToken(method, false);
         try validLineToken(target, false);
         const ver = try normalizeVersion(version);
-        try validateHeaders(hdrs, true);
+        try validateHeaders(hdrs);
         try self.w(method);
         try self.w(" ");
         try self.w(target);
@@ -288,9 +268,8 @@ pub const Writer = struct {
     /// is bodyless (RFC 9112 6.3), so the caller never tracks framing by hand.
     pub fn sendResponse(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, request_method: []const u8) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
-        const bodyless = responseIsBodyless(request_method, status);
-        try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs, !bodyless);
-        if (bodyless) {
+        try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs);
+        if (responseIsBodyless(request_method, status)) {
             self.state = .body_none;
             self.body_remaining = 0;
         } else {
@@ -310,12 +289,12 @@ pub const Writer = struct {
     pub fn sendInformational(self: *Writer, status: u16, hdrs: []const Header) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
         if (status / 100 != 1 or status == 101) return error.InvalidField;
-        try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs, false);
+        try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs);
     }
 
-    fn writeStatusLine(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, require_te_chunked: bool) WriteError!void {
+    fn writeStatusLine(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header) WriteError!void {
         try validLineToken(reason, true); // reason-phrase may contain SP/HTAB
-        try validateHeaders(hdrs, require_te_chunked);
+        try validateHeaders(hdrs);
         try self.w("HTTP/");
         try self.w(version);
         try self.w(" ");
@@ -368,7 +347,7 @@ pub const Writer = struct {
     pub fn endMessage(self: *Writer, trailers: []const Header) WriteError!void {
         switch (self.state) {
             .body_chunked => {
-                try validateHeaders(trailers, true);
+                try validateHeaders(trailers);
                 try self.w("0\r\n");
                 for (trailers) |tr| {
                     try self.w(tr.name);
@@ -515,14 +494,11 @@ test "HEAD response is bodyless despite Content-Length" {
     try t.expectEqualStrings("HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n", wr.pending());
 }
 
-test "bodyless response allows metadata-only transfer-encoding" {
+test "bodyless response rejects unsupported transfer-encoding" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip" }};
-    try wr.sendResponse("1.1", 304, "Not Modified", &hdrs, "GET");
-    try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
-    try wr.endMessage(&.{});
-    try t.expectEqualStrings("HTTP/1.1 304 Not Modified\r\nTransfer-Encoding: gzip\r\n\r\n", wr.pending());
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 304, "Not Modified", &hdrs, "GET"));
 }
 
 test "data before head is rejected" {
@@ -666,14 +642,21 @@ test "send rejects duplicate transfer-encoding chunked" {
     try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
 }
 
-test "send accepts transfer-encoding with chunked final" {
+test "send rejects unsupported transfer-encoding comma list" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
-    try wr.sendResponse("1.1", 200, "OK", &h, "GET");
-    try wr.sendData("abc");
-    try wr.endMessage(&.{});
-    try t.expectEqualStrings("HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n3\r\nabc\r\n0\r\n\r\n", wr.pending());
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send rejects multiple transfer-encoding fields" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{
+        .{ .name = "Transfer-Encoding", .value = "gzip" },
+        .{ .name = "Transfer-Encoding", .value = "chunked" },
+    };
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
 }
 
 test "send rejects ambiguous framing (TE + CL)" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -179,19 +179,22 @@ pub fn reasonPhrase(status: u16) []const u8 {
     };
 }
 
-fn validateHeaders(hdrs: []const Header) WriteError!void {
+fn validateHeaders(hdrs: []const Header, require_te_chunked: bool) WriteError!void {
     for (hdrs) |h| {
         try validName(h.name);
         try validValue(h.value);
     }
-    try validateFraming(hdrs);
+    try validateFraming(hdrs, require_te_chunked);
 }
 
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
 /// smuggling guards. A message carrying both Transfer-Encoding and
 /// Content-Length, or conflicting duplicate Content-Lengths, would let a
 /// downstream parser disagree about message boundaries (response splitting).
-fn validateFraming(hdrs: []const Header) WriteError!void {
+/// Bodyless responses may carry metadata-only Transfer-Encoding values (e.g.
+/// HEAD/304 describing the representation), so `require_te_chunked` only applies
+/// when the message actually needs TE to delimit a body.
+fn validateFraming(hdrs: []const Header, require_te_chunked: bool) WriteError!void {
     var te = TransferEncoding{};
     var has_te = false;
     var content_length: ?[]const u8 = null;
@@ -208,7 +211,7 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
             content_length = v;
         }
     }
-    if (has_te) try te.validate();
+    if (require_te_chunked and has_te) try te.validate();
     if (has_te and content_length != null) return error.InvalidField; // TE + CL
 }
 
@@ -265,7 +268,7 @@ pub const Writer = struct {
         try validLineToken(method, false);
         try validLineToken(target, false);
         const ver = try normalizeVersion(version);
-        try validateHeaders(hdrs);
+        try validateHeaders(hdrs, true);
         try self.w(method);
         try self.w(" ");
         try self.w(target);
@@ -283,8 +286,9 @@ pub const Writer = struct {
     /// is bodyless (RFC 9112 6.3), so the caller never tracks framing by hand.
     pub fn sendResponse(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, request_method: []const u8) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
-        try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs);
-        if (responseIsBodyless(request_method, status)) {
+        const bodyless = responseIsBodyless(request_method, status);
+        try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs, !bodyless);
+        if (bodyless) {
             self.state = .body_none;
             self.body_remaining = 0;
         } else {
@@ -304,12 +308,12 @@ pub const Writer = struct {
     pub fn sendInformational(self: *Writer, status: u16, hdrs: []const Header) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
         if (status / 100 != 1 or status == 101) return error.InvalidField;
-        try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs);
+        try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs, false);
     }
 
-    fn writeStatusLine(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header) WriteError!void {
+    fn writeStatusLine(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, require_te_chunked: bool) WriteError!void {
         try validLineToken(reason, true); // reason-phrase may contain SP/HTAB
-        try validateHeaders(hdrs);
+        try validateHeaders(hdrs, require_te_chunked);
         try self.w("HTTP/");
         try self.w(version);
         try self.w(" ");
@@ -362,7 +366,7 @@ pub const Writer = struct {
     pub fn endMessage(self: *Writer, trailers: []const Header) WriteError!void {
         switch (self.state) {
             .body_chunked => {
-                try validateHeaders(trailers);
+                try validateHeaders(trailers, true);
                 try self.w("0\r\n");
                 for (trailers) |tr| {
                     try self.w(tr.name);
@@ -500,6 +504,16 @@ test "HEAD response is bodyless despite Content-Length" {
     try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
     try wr.endMessage(&.{});
     try t.expectEqualStrings("HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n", wr.pending());
+}
+
+test "bodyless response allows metadata-only transfer-encoding" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip" }};
+    try wr.sendResponse("1.1", 304, "Not Modified", &hdrs, "GET");
+    try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
+    try wr.endMessage(&.{});
+    try t.expectEqualStrings("HTTP/1.1 304 Not Modified\r\nTransfer-Encoding: gzip\r\n\r\n", wr.pending());
 }
 
 test "data before head is rejected" {


### PR DESCRIPTION
## Summary
- Add h11-style send-side `Transfer-Encoding` validation.
- Only allow one `Transfer-Encoding` field with the supported `chunked` coding.
- Reject unsupported codings, comma-list codings, duplicate TE fields, and TE+CL on send.

## Tests
- `zig build test`
