### PR TITLE
Validate HTTP/1 request-line fields on send

### DIFF
--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -79,14 +79,13 @@ fn validTarget(target: []const u8) WriteError!void {
     }
 }
 
-/// Status-line tokens such as the reason phrase must not carry CR/LF or
-/// controls. Reason allows SP/HTAB.
-fn validLineToken(s: []const u8, allow_sp: bool) WriteError!void {
-    for (s) |ch| {
+/// Reason phrases may contain SP/HTAB, but not CR/LF, NUL, DEL, or other
+/// controls.
+fn validReasonPhrase(reason: []const u8) WriteError!void {
+    for (reason) |ch| {
         if (ch == '\r' or ch == '\n' or ch == 0) return error.InvalidField;
-        if (ch < 0x20 and !(allow_sp and ch == '\t')) return error.InvalidField;
+        if (ch < 0x20 and ch != '\t') return error.InvalidField;
         if (ch == 0x7F) return error.InvalidField;
-        if (!allow_sp and ch == ' ') return error.InvalidField;
     }
 }
 
@@ -294,7 +293,7 @@ pub const Writer = struct {
     }
 
     fn writeStatusLine(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header) WriteError!void {
-        try validLineToken(reason, true); // reason-phrase may contain SP/HTAB
+        try validReasonPhrase(reason);
         try validateHeaders(hdrs);
         try self.w("HTTP/");
         try self.w(version);

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -65,9 +65,22 @@ fn normalizeVersion(version: []const u8) WriteError![]const u8 {
     return v;
 }
 
-/// Request-line / status-line tokens (method, target, version, reason) must not
-/// carry CR/LF or controls. Reason allows SP; the others should not contain SP,
-/// but we only guard against the injection-relevant controls here.
+/// Methods are tokens on the wire, same grammar as field names.
+fn validMethod(method: []const u8) WriteError!void {
+    try validName(method);
+}
+
+/// Request targets use the same permissive-but-bounded class as the parser:
+/// no controls, SP, DEL, or DQUOTE, and not empty.
+fn validTarget(target: []const u8) WriteError!void {
+    if (target.len == 0) return error.InvalidField;
+    for (target) |ch| {
+        if (!tables.is_target_char[ch]) return error.InvalidField;
+    }
+}
+
+/// Status-line tokens such as the reason phrase must not carry CR/LF or
+/// controls. Reason allows SP/HTAB.
 fn validLineToken(s: []const u8, allow_sp: bool) WriteError!void {
     for (s) |ch| {
         if (ch == '\r' or ch == '\n' or ch == 0) return error.InvalidField;
@@ -235,8 +248,8 @@ pub const Writer = struct {
     /// Serialize a request-line + headers. `framing` decides body handling.
     pub fn sendRequest(self: *Writer, method: []const u8, target: []const u8, version: []const u8, hdrs: []const Header) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
-        try validLineToken(method, false);
-        try validLineToken(target, false);
+        try validMethod(method);
+        try validTarget(target);
         const ver = try normalizeVersion(version);
         try validateHeaders(hdrs);
         try self.w(method);
@@ -584,6 +597,16 @@ test "send-path injection: CRLF in target rejected" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     try t.expectError(error.InvalidField, wr.sendRequest("GET", "/ HTTP/1.1\r\nX: y", "1.1", &.{}));
+}
+
+test "send rejects malformed request-line fields" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    try t.expectError(error.InvalidField, wr.sendRequest("", "/", "1.1", &.{}));
+    try t.expectError(error.InvalidField, wr.sendRequest("GE:T", "/", "1.1", &.{}));
+    try t.expectError(error.InvalidField, wr.sendRequest("GET", "", "1.1", &.{}));
+    try t.expectError(error.InvalidField, wr.sendRequest("GET", "\"bad\"", "1.1", &.{}));
+    try t.expectEqualStrings("", wr.pending());
 }
 
 test "send-path injection: CRLF in trailer rejected" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -629,6 +629,21 @@ test "send rejects malformed request-line fields" {
     try t.expectEqualStrings("", wr.pending());
 }
 
+test "send validates reason phrase controls" {
+    inline for (.{ "O\x00K", "O\x07K", "O\x7fK" }) |reason| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, reason, &.{}, "GET"));
+        try t.expectEqualStrings("", wr.pending());
+    }
+
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    try wr.sendResponse("1.1", 200, "O\tK", &.{}, "GET");
+    try wr.endMessage(&.{});
+    try t.expectEqualStrings("HTTP/1.1 200 O\tK\r\n\r\n", wr.pending());
+}
+
 test "send-path injection: CRLF in trailer rejected" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();


### PR DESCRIPTION
## Summary
- Validate methods as HTTP tokens before serializing.
- Validate request targets with the parser's target character class.
- Reject empty/malformed request-line fields before writing bytes.

## Tests
- `zig build test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for HTTP request methods, targets, and status reason phrases.
  * Malformed request-line fields are now rejected more reliably.
  * Prevented invalid data from remaining in the pending output buffer after validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->