### PR TITLE
Make HTTP/1 reader EOF terminal

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -120,6 +120,7 @@ pub const Reader = struct {
             self.eof_seen = true;
             return;
         }
+        if (self.eof_seen) return error.ProtocolError;
         if (self.limits.max_buffer != 0) {
             const unconsumed = self.buf.items.len - self.consumed;
             if (unconsumed + data.len > self.limits.max_buffer) return error.MessageTooLong;
@@ -708,6 +709,13 @@ test "feed rejects input past max_buffer" {
     defer r.deinit();
     const big = "Z" ** 2048;
     try t.expectError(error.MessageTooLong, r.feed(big));
+}
+
+test "feed rejects data after EOF" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("");
+    try t.expectError(error.ProtocolError, r.feed("GET / HTTP/1.1\r\n\r\n"));
 }
 
 test "M-2: bare LF request rejected when strict" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -170,6 +170,12 @@ pub const Reader = struct {
         return self.buf.items.len == self.consumed;
     }
 
+    /// True once EOF has been signalled on this read side; non-empty input after
+    /// this point is a protocol/API error.
+    pub fn eofSeen(self: *const Reader) bool {
+        return self.eof_seen;
+    }
+
     /// True when the reader is waiting for the head of a new message.
     pub fn atMessageStart(self: *const Reader) bool {
         return self.state == .head;

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -211,6 +211,7 @@ const H1Engine = struct {
 
     fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
         if (!self.flushPending()) return null;
+        if (data.len > 0 and self.reader.eofSeen()) return exceptions.raiseParse(error.ProtocolError);
         if (data.len > 0 and self.reader.backlogEmpty()) {
             if (self.reader.bodyLengthRemaining() != null) {
                 self.stash(obj, data);

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -126,6 +126,16 @@ def test_eof_on_empty_connection_yields_closed() -> None:
     assert conn.next_event() is zttp.CONNECTION_CLOSED
 
 
+def test_data_after_eof_rejected_before_body_fast_path() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+    assert conn.next_event() is zttp.NEED_DATA
+    conn.receive_data(b"")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(b"hello")
+
+
 @pytest.mark.parametrize(
     "bad",
     [

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -193,7 +193,7 @@ class ProtocolError(Exception):
     """Base class for the two protocol errors. Catch this to handle both."""
 
 class RemoteProtocolError(ProtocolError):
-    """The peer sent something malformed. Raised from `next_event()`."""
+    """The peer sent something malformed. Raised by the read API."""
 
 class LocalProtocolError(ProtocolError):
     """You used the send API in a way that cannot produce a valid message."""


### PR DESCRIPTION
## Summary
- Reject non-empty feed data after an EOF marker.
- Add a regression test for the terminal close state.

## Tests
- `zig build test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rejects additional data received after an HTTP connection has reached EOF.
  * Raises a protocol error instead of attempting to parse invalid post-EOF input.
  * Improves handling when request body data arrives after an unexpected connection close.
* **Tests**
  * Added coverage verifying that data received after EOF is consistently rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->