### PR TITLE
Expose HTTP/1 response close signal to clients

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -291,7 +291,7 @@ pub const Reader = struct {
 
         if (self.role == .server) {
             const rl = try headers_mod.parseRequestLine(first);
-            try self.frameBody(.{ .until_close_default = false });
+            _ = try self.frameBody(.{ .until_close_default = false });
             self.conn_should_close = connection_mod.shouldClose(rl.http_version, self.headers.items);
             self.conn_upgrade = connection_mod.upgrade(self.headers.items);
             return .{ .request = .{
@@ -307,11 +307,11 @@ pub const Reader = struct {
 
         const st = try headers_mod.parseStatusLine(first);
         const method = self.request_method[0..self.request_method_len];
-        try self.frameBody(.{
+        const framing = try self.frameBody(.{
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
             .until_close_default = true,
         });
-        self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items);
+        self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items) or framing == .until_close;
         return .{ .response = .{
             .status_code = st.status_code,
             .reason = st.reason,
@@ -320,8 +320,10 @@ pub const Reader = struct {
         } };
     }
 
-    fn frameBody(self: *Reader, opts: framing_mod.FramingOptions) ParseError!void {
-        self.enterBody(try framing_mod.determine(self.headers.items, opts));
+    fn frameBody(self: *Reader, opts: framing_mod.FramingOptions) ParseError!Framing {
+        const framing = try framing_mod.determine(self.headers.items, opts);
+        self.enterBody(framing);
+        return framing;
     }
 
     fn enterBody(self: *Reader, f: Framing) void {
@@ -620,6 +622,14 @@ test "client treats HTTP/1.0 response as close unless keep-alive" {
     var r = Reader.init(t.allocator, .client);
     defer r.deinit();
     try r.feed("HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n");
+    try expectTag(.response, try r.nextEvent());
+    try t.expect(r.shouldClose());
+}
+
+test "client marks close-delimited response as closing" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    try r.feed("HTTP/1.1 200 OK\r\n\r\nbody");
     try expectTag(.response, try r.nextEvent());
     try t.expect(r.shouldClose());
 }

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -311,6 +311,7 @@ pub const Reader = struct {
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
             .until_close_default = true,
         });
+        self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items);
         return .{ .response = .{
             .status_code = st.status_code,
             .reason = st.reason,
@@ -605,6 +606,22 @@ test "client still frames a normal GET response body" {
     const d = try r.nextEvent();
     try t.expectEqualStrings("hello", d.data.data);
     try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "client exposes response connection close signal" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    try r.feed("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
+    try expectTag(.response, try r.nextEvent());
+    try t.expect(r.shouldClose());
+}
+
+test "client treats HTTP/1.0 response as close unless keep-alive" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    try r.feed("HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n");
+    try expectTag(.response, try r.nextEvent());
+    try t.expect(r.shouldClose());
 }
 
 test "truncated content-length body errors at EOF" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -158,8 +158,9 @@ pub const Reader = struct {
         self.conn_upgrade = null;
     }
 
-    /// Whether the connection must close after the most recently parsed request
-    /// (RFC 9112 9.3). Valid after a Request event, until the next reset.
+    /// Whether the connection must close after the most recently parsed
+    /// request/response (RFC 9112 9.3, plus close-delimited responses). Valid
+    /// after a Request/Response event, until the next reset.
     pub fn shouldClose(self: *const Reader) bool {
         return self.conn_should_close;
     }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -142,8 +142,9 @@ const H1Engine = struct {
     /// to decide, on a parse failure, whether the method is stale (fresh-head
     /// failure -> clear) or still owed a response (mid-body failure -> keep).
     request_surfaced: bool = false,
-    /// Connection signals for the last parsed request, captured at event time so
-    /// they outlive the head buffer. `upgrade_obj` is held Python bytes (or null).
+    /// Connection close signal for the last parsed request/response, captured at
+    /// event time so it outlives the head buffer. `upgrade_obj` remains
+    /// request-only and is held as Python bytes (or null).
     should_close: bool = false,
     upgrade_obj: py.Object = null,
     /// Single-copy body path: when a fed buffer's prefix is a Content-Length
@@ -2475,7 +2476,7 @@ var h1_methods = [_]py.MethodDef{
     .{ .ml_name = "send_informational", .ml_meth = send_informational, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize an interim 1xx response: send_informational(status, headers=None). The real response still follows on the same cycle." },
     .{ .ml_name = "send_data", .ml_meth = send_data, .ml_flags = c.METH_O, .ml_doc = "Serialize a run of body bytes (chunk-framed if the head was chunked)." },
     .{ .ml_name = "end_message", .ml_meth = end_message, .ml_flags = c.METH_VARARGS, .ml_doc = "End the outgoing message: end_message(trailers=None)." },
-    .{ .ml_name = "should_close", .ml_meth = should_close, .ml_flags = c.METH_NOARGS, .ml_doc = "Whether the connection must close after the last request (Connection: close / HTTP/1.0)." },
+    .{ .ml_name = "should_close", .ml_meth = should_close, .ml_flags = c.METH_NOARGS, .ml_doc = "Whether the connection must close after the last request/response (Connection: close / HTTP/1.0 / close-delimited response)." },
     .{ .ml_name = "upgrade", .ml_meth = upgrade, .ml_flags = c.METH_NOARGS, .ml_doc = "The last request's Upgrade value if it asked to upgrade (Connection: upgrade), else None." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1891,6 +1891,8 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
                         e.upgrade_obj = py.fromBytes(u);
                         if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
                     } else e.upgrade_obj = null;
+                } else if (ev == .response) {
+                    e.should_close = e.reader.shouldClose();
                 }
                 return events_obj.fromH1Event(ev);
             }

--- a/tests/test_connection_signals.py
+++ b/tests/test_connection_signals.py
@@ -47,6 +47,20 @@ def test_should_close_resets_after_cycle() -> None:
     assert conn.should_close() is False
 
 
+def test_client_should_close_explicit_response_close() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.receive_data(b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert conn.should_close() is True
+
+
+def test_client_should_close_for_close_delimited_response() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.receive_data(b"HTTP/1.1 200 OK\r\n\r\nbody")
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert conn.should_close() is True
+
+
 def test_upgrade_websocket() -> None:
     conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n")
     assert conn.upgrade() == b"websocket"


### PR DESCRIPTION
## Summary
- Compute `shouldClose` for client-side responses, not only server-side requests.
- Cover `Connection: close` and HTTP/1.0 response defaults.

## Tests
- `zig build test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP client connection lifecycle handling for responses that explicitly request closure.
  - Connections are now correctly marked for closing after HTTP/1.0 responses and responses whose body ends when the connection closes.
  - Updated response event processing so connection-close signals are consistently reported.
  - Added coverage for explicit close headers and close-delimited responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->