### PR TITLE
Continue through HTTP/1 informational responses

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -10,6 +10,7 @@
 
 const std = @import("std");
 const events = @import("../events.zig");
+const ascii = @import("../ascii.zig");
 const headers_mod = @import("headers.zig");
 const framing_mod = @import("framing.zig");
 const connection_mod = @import("connection.zig");
@@ -316,10 +317,14 @@ pub const Reader = struct {
         if (st.status_code / 100 == 1 and st.status_code != 101) {
             // Informational responses are not the final response to the request:
             // surface the head, then keep reading the final response without
-            // requiring reset() or clearing the remembered request method. Still
-            // validate framing fields with bodyless semantics before continuing,
-            // so malformed CL/TE cannot be surfaced as a trusted interim head.
-            _ = try framing_mod.determine(self.headers.items, .{ .bodyless = true, .until_close_default = true });
+            // requiring reset() or clearing the remembered request method. 1xx
+            // responses cannot carry body framing fields; reject them before the
+            // interim head is surfaced as trusted metadata.
+            for (self.headers.items) |h| {
+                if (ascii.eqIgnoreCase(h.name, "content-length") or ascii.eqIgnoreCase(h.name, "transfer-encoding")) {
+                    return error.InvalidFraming;
+                }
+            }
             self.state = .head;
             return .{ .response = .{
                 .status_code = st.status_code,
@@ -652,12 +657,14 @@ test "informational response preserves HEAD method for final response" {
     try expectTag(.end_of_message, try r.nextEvent());
 }
 
-test "informational response validates framing headers" {
-    var r = Reader.init(t.allocator, .client);
-    defer r.deinit();
-    r.setRequestMethod("GET");
-    try r.feed("HTTP/1.1 100 Continue\r\nContent-Length: x\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
-    try t.expectError(error.InvalidFraming, r.nextEvent());
+test "informational response rejects framing headers" {
+    inline for (.{ "Content-Length: 0", "Transfer-Encoding: chunked" }) |header| {
+        var r = Reader.init(t.allocator, .client);
+        defer r.deinit();
+        r.setRequestMethod("GET");
+        try r.feed("HTTP/1.1 100 Continue\r\n" ++ header ++ "\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        try t.expectError(error.InvalidFraming, r.nextEvent());
+    }
 }
 
 test "client still frames a normal GET response body" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -306,6 +306,18 @@ pub const Reader = struct {
         }
 
         const st = try headers_mod.parseStatusLine(first);
+        if (st.status_code / 100 == 1 and st.status_code != 101) {
+            // Informational responses are not the final response to the request:
+            // surface the head, then keep reading the final response without
+            // requiring reset() or clearing the remembered request method.
+            self.state = .head;
+            return .{ .response = .{
+                .status_code = st.status_code,
+                .reason = st.reason,
+                .http_version = st.http_version,
+                .headers = self.headers.items,
+            } };
+        }
         const method = self.request_method[0..self.request_method_len];
         try self.frameBody(.{
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
@@ -593,6 +605,28 @@ test "client auto-frames 304 response as bodyless" {
     r.setRequestMethod("GET");
     try r.feed("HTTP/1.1 304 Not Modified\r\nContent-Length: 100\r\n\r\n");
     try expectTag(.response, try r.nextEvent());
+    try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "client continues through informational response" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    r.setRequestMethod("GET");
+    try r.feed("HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    const info = try r.nextEvent();
+    try t.expectEqual(@as(u16, 100), info.response.status_code);
+    const final = try r.nextEvent();
+    try t.expectEqual(@as(u16, 200), final.response.status_code);
+    try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "informational response preserves HEAD method for final response" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    r.setRequestMethod("HEAD");
+    try r.feed("HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 123\r\n\r\n");
+    try t.expectEqual(@as(u16, 100), (try r.nextEvent()).response.status_code);
+    try t.expectEqual(@as(u16, 200), (try r.nextEvent()).response.status_code);
     try expectTag(.end_of_message, try r.nextEvent());
 }
 

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -309,7 +309,10 @@ pub const Reader = struct {
         if (st.status_code / 100 == 1 and st.status_code != 101) {
             // Informational responses are not the final response to the request:
             // surface the head, then keep reading the final response without
-            // requiring reset() or clearing the remembered request method.
+            // requiring reset() or clearing the remembered request method. Still
+            // validate framing fields with bodyless semantics before continuing,
+            // so malformed CL/TE cannot be surfaced as a trusted interim head.
+            _ = try framing_mod.determine(self.headers.items, .{ .bodyless = true, .until_close_default = true });
             self.state = .head;
             return .{ .response = .{
                 .status_code = st.status_code,
@@ -628,6 +631,14 @@ test "informational response preserves HEAD method for final response" {
     try t.expectEqual(@as(u16, 100), (try r.nextEvent()).response.status_code);
     try t.expectEqual(@as(u16, 200), (try r.nextEvent()).response.status_code);
     try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "informational response validates framing headers" {
+    var r = Reader.init(t.allocator, .client);
+    defer r.deinit();
+    r.setRequestMethod("GET");
+    try r.feed("HTTP/1.1 100 Continue\r\nContent-Length: x\r\n\r\nHTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+    try t.expectError(error.InvalidFraming, r.nextEvent());
 }
 
 test "client still frames a normal GET response body" {

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -302,12 +302,11 @@ def test_informational_round_trips_to_reader() -> None:
     interim = client.next_event()
     assert isinstance(interim, zttp.Response)
     assert interim.status_code == 100
-    assert isinstance(client.next_event(), zttp.EndOfMessage)
 
-    client.start_next_cycle()
     final = client.next_event()
     assert isinstance(final, zttp.Response)
     assert final.status_code == 200
+    assert isinstance(client.next_event(), zttp.EndOfMessage)
 
 
 def test_send_response_default_reason() -> None:


### PR DESCRIPTION
## Summary
- Surface non-101 1xx responses without ending the message cycle.
- Keep reading the final response without requiring `reset()`.
- Preserve the remembered request method across informational responses.

## Tests
- `zig build test`
