### PR TITLE
Reject forbidden HTTP/1 trailer fields

### DIFF
--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -93,9 +93,8 @@ fn parseVersion(tok: []const u8) ParseError![]const u8 {
     return num;
 }
 
-/// Parse one header field-line into a (name, value) pair. The name is the raw
-/// token (case preserved); the value has surrounding OWS stripped. A line with
-/// leading whitespace is obs-fold (RFC 9112 5.2) and is rejected.
+/// Whether a field-name is allowed in a chunked trailer section. Trailers cannot
+/// carry message framing, connection routing, or payload-processing metadata.
 pub fn trailerFieldAllowed(name: []const u8) bool {
     inline for (.{
         // Message framing / connection routing fields.
@@ -116,6 +115,9 @@ pub fn trailerFieldAllowed(name: []const u8) bool {
     return true;
 }
 
+/// Parse one header field-line into a (name, value) pair. The name is the raw
+/// token (case preserved); the value has surrounding OWS stripped. A line with
+/// leading whitespace is obs-fold (RFC 9112 5.2) and is rejected.
 pub fn parseHeaderLine(line: []const u8) ParseError!Header {
     if (line.len == 0) return error.InvalidHeader;
     if (line[0] == ' ' or line[0] == '\t') return error.InvalidHeader; // obs-fold

--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -97,7 +97,20 @@ fn parseVersion(tok: []const u8) ParseError![]const u8 {
 /// token (case preserved); the value has surrounding OWS stripped. A line with
 /// leading whitespace is obs-fold (RFC 9112 5.2) and is rejected.
 pub fn trailerFieldAllowed(name: []const u8) bool {
-    inline for (.{ "content-length", "transfer-encoding", "host", "connection", "upgrade", "te" }) |forbidden| {
+    inline for (.{
+        // Message framing / connection routing fields.
+        "content-length",
+        "transfer-encoding",
+        "trailer",
+        "host",
+        "connection",
+        "upgrade",
+        "te",
+        // Payload-processing metadata that RFC 9110 forbids in trailers.
+        "content-encoding",
+        "content-type",
+        "content-range",
+    }) |forbidden| {
         if (ascii.eqIgnoreCase(name, forbidden)) return false;
     }
     return true;
@@ -207,9 +220,13 @@ test "parseHeaderLine rejects control chars in value" {
     try std.testing.expectError(error.InvalidHeader, parseHeaderLine("X: a\x00b"));
 }
 
-test "trailerFieldAllowed rejects framing fields" {
+test "trailerFieldAllowed rejects prohibited fields" {
     try std.testing.expect(!trailerFieldAllowed("Content-Length"));
     try std.testing.expect(!trailerFieldAllowed("Transfer-Encoding"));
+    try std.testing.expect(!trailerFieldAllowed("Trailer"));
     try std.testing.expect(!trailerFieldAllowed("Connection"));
+    try std.testing.expect(!trailerFieldAllowed("Content-Encoding"));
+    try std.testing.expect(!trailerFieldAllowed("Content-Type"));
+    try std.testing.expect(!trailerFieldAllowed("Content-Range"));
     try std.testing.expect(trailerFieldAllowed("X-Checksum"));
 }

--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const tables = @import("../tables.zig");
+const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 const scanner = @import("../scanner.zig");
 const Scanner = scanner.Scanner;
@@ -95,6 +96,13 @@ fn parseVersion(tok: []const u8) ParseError![]const u8 {
 /// Parse one header field-line into a (name, value) pair. The name is the raw
 /// token (case preserved); the value has surrounding OWS stripped. A line with
 /// leading whitespace is obs-fold (RFC 9112 5.2) and is rejected.
+pub fn trailerFieldAllowed(name: []const u8) bool {
+    inline for (.{ "content-length", "transfer-encoding", "host", "connection", "upgrade", "te" }) |forbidden| {
+        if (ascii.eqIgnoreCase(name, forbidden)) return false;
+    }
+    return true;
+}
+
 pub fn parseHeaderLine(line: []const u8) ParseError!Header {
     if (line.len == 0) return error.InvalidHeader;
     if (line[0] == ' ' or line[0] == '\t') return error.InvalidHeader; // obs-fold
@@ -197,4 +205,11 @@ test "parseHeaderLine rejects obs-fold and bad names" {
 
 test "parseHeaderLine rejects control chars in value" {
     try std.testing.expectError(error.InvalidHeader, parseHeaderLine("X: a\x00b"));
+}
+
+test "trailerFieldAllowed rejects framing fields" {
+    try std.testing.expect(!trailerFieldAllowed("Content-Length"));
+    try std.testing.expect(!trailerFieldAllowed("Transfer-Encoding"));
+    try std.testing.expect(!trailerFieldAllowed("Connection"));
+    try std.testing.expect(trailerFieldAllowed("X-Checksum"));
 }

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -690,12 +690,14 @@ test "H-4: trailer byte cap rejected" {
     try t.expectError(error.MessageTooLong, r.nextEvent());
 }
 
-test "framing trailers are rejected" {
-    var r = Reader.init(t.allocator, .server);
-    defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nContent-Length: 0\r\n\r\n");
-    try expectTag(.request, try r.nextEvent());
-    try t.expectError(error.InvalidHeader, r.nextEvent());
+test "prohibited trailers are rejected" {
+    inline for (.{ "Content-Length: 0", "Trailer: Content-Length", "Content-Type: text/plain" }) |trailer| {
+        var r = Reader.init(t.allocator, .server);
+        defer r.deinit();
+        try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n" ++ trailer ++ "\r\n\r\n");
+        try expectTag(.request, try r.nextEvent());
+        try t.expectError(error.InvalidHeader, r.nextEvent());
+    }
 }
 
 test "M-1: oversized complete head rejected before full copy" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -389,7 +389,8 @@ pub const Reader = struct {
         self.trailer_store.appendSlice(self.gpa, line) catch return error.MessageTooLong;
         // Validate now (cheap, surfaces errors early) but record only the range;
         // the borrowed slice would dangle if trailer_store reallocs on a later line.
-        _ = try headers_mod.parseHeaderLine(self.trailer_store.items[start..]);
+        const h = try headers_mod.parseHeaderLine(self.trailer_store.items[start..]);
+        if (!headers_mod.trailerFieldAllowed(h.name)) return error.InvalidHeader;
         self.trailers.append(self.gpa, .{ .name = "", .value = "" }) catch return error.MessageTooLong;
         self.trailer_ranges.append(self.gpa, .{ .off = start, .len = line.len }) catch return error.MessageTooLong;
     }
@@ -687,6 +688,14 @@ test "H-4: trailer byte cap rejected" {
     _ = try r.nextEvent();
     try r.feed("X-Long-Trailer-Header: aaaaaaaaaaaaaaaaaaaaaaaaa\r\n");
     try t.expectError(error.MessageTooLong, r.nextEvent());
+}
+
+test "framing trailers are rejected" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nContent-Length: 0\r\n\r\n");
+    try expectTag(.request, try r.nextEvent());
+    try t.expectError(error.InvalidHeader, r.nextEvent());
 }
 
 test "M-1: oversized complete head rejected before full copy" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -599,13 +599,15 @@ test "send-path injection: CRLF in trailer rejected" {
     try t.expectError(error.InvalidField, wr.endMessage(&trailers));
 }
 
-test "send rejects framing trailers" {
-    var wr = Writer.init(t.allocator);
-    defer wr.deinit();
-    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
-    try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
-    const trailers = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
-    try t.expectError(error.InvalidField, wr.endMessage(&trailers));
+test "send rejects prohibited trailers" {
+    inline for (.{ "Transfer-Encoding", "Trailer", "Content-Type" }) |name| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+        try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
+        const trailers = [_]Header{.{ .name = name, .value = "x" }};
+        try t.expectError(error.InvalidField, wr.endMessage(&trailers));
+    }
 }
 
 test "send rejects ambiguous framing (TE + CL)" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -9,6 +9,7 @@ const tables = @import("../tables.zig");
 const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 const framing = @import("framing.zig");
+const headers_mod = @import("headers.zig");
 
 const Header = events.Header;
 const responseIsBodyless = framing.responseIsBodyless;
@@ -336,6 +337,9 @@ pub const Writer = struct {
         switch (self.state) {
             .body_chunked => {
                 try validateHeaders(trailers);
+                for (trailers) |tr| {
+                    if (!headers_mod.trailerFieldAllowed(tr.name)) return error.InvalidField;
+                }
                 try self.w("0\r\n");
                 for (trailers) |tr| {
                     try self.w(tr.name);
@@ -592,6 +596,15 @@ test "send-path injection: CRLF in trailer rejected" {
     const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
     try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
     const trailers = [_]Header{.{ .name = "X", .value = "v\r\nInjected: 1" }};
+    try t.expectError(error.InvalidField, wr.endMessage(&trailers));
+}
+
+test "send rejects framing trailers" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
+    const trailers = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
     try t.expectError(error.InvalidField, wr.endMessage(&trailers));
 }
 


### PR DESCRIPTION
## Summary
- Add a shared H1 trailer field allow-list check for framing/connection fields.
- Reject forbidden trailer fields on both receive and send paths.
- Cover `Content-Length`/`Transfer-Encoding` trailer regressions.

## Tests
- `zig build test`
