### PR TITLE
Reject empty Content-Length on HTTP/1 send

### DIFF
--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -625,6 +625,9 @@ test "send rejects non-digit Content-Length" {
 test "send rejects empty Content-Length" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
-    const h = [_]Header{.{ .name = "Content-Length", .value = "   " }};
-    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+    const empty = [_]Header{.{ .name = "Content-Length", .value = "" }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &empty, "GET"));
+
+    const whitespace = [_]Header{.{ .name = "Content-Length", .value = "   " }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &whitespace, "GET"));
 }

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -175,7 +175,7 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
             has_te = true;
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
-            if (v.len > 0 and ascii.parseDecimal(u64, v) == null) return error.InvalidField; // digits, no overflow
+            if (ascii.parseDecimal(u64, v) == null) return error.InvalidField; // non-empty digits, no overflow
             if (content_length) |prev| {
                 if (!eqIgnoreCase(prev, v)) return error.InvalidField; // conflicting duplicate
             }
@@ -619,5 +619,12 @@ test "send rejects non-digit Content-Length" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     const h = [_]Header{.{ .name = "Content-Length", .value = "5x" }};
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send rejects empty Content-Length" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{.{ .name = "Content-Length", .value = "   " }};
     try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
 }


### PR DESCRIPTION
## Summary
- Require `Content-Length` values to parse as non-empty decimal numbers on send.
- Add a regression for OWS-only `Content-Length`.

## Tests
- `zig build test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for `Content-Length` headers.
  * Values containing only whitespace, or otherwise not representing a valid decimal number, are now correctly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->