### PR TITLE
Enable Mergify merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,9 @@ queue_rules:
   - name: default
     merge_method: squash
     update_method: merge
+    queue_conditions:
+      - '#approved-reviews-by>=1'
+      - '#changes-requested-reviews-by=0'
     merge_conditions:
       - check-success=All green
       - check-success=Run zizmor

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,18 @@
+queue_rules:
+  - name: default
+    merge_method: squash
+    update_method: merge
+    merge_conditions:
+      - check-success=All green
+      - check-success=Run zizmor
+
+pull_request_rules:
+  - name: Queue approved pull requests
+    conditions:
+      - base=main
+      - '-draft'
+      - '#approved-reviews-by>=1'
+      - '#changes-requested-reviews-by=0'
+    actions:
+      queue:
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,19 +3,17 @@ queue_rules:
     merge_method: squash
     update_method: merge
     queue_conditions:
-      - '#approved-reviews-by>=1'
-      - '#changes-requested-reviews-by=0'
+      - base=main
+      - '-draft'
     merge_conditions:
       - check-success=All green
       - check-success=Run zizmor
 
 pull_request_rules:
-  - name: Queue approved pull requests
+  - name: Queue pull requests
     conditions:
       - base=main
       - '-draft'
-      - '#approved-reviews-by>=1'
-      - '#changes-requested-reviews-by=0'
     actions:
       queue:
         name: default


### PR DESCRIPTION
## Summary
- add Mergify configuration with a default queue
- queue non-draft PRs targeting main
- require the aggregate CI and zizmor checks before merge

## Testing
- parsed .mergify.yml as YAML
