### PR TITLE
Review and fix the README and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,79 @@
-# zttp
-
 <p align="center">
   <img src="https://github.com/Kludex/zttp/blob/main/docs/assets/logo.png?raw=true" alt="zttp" width="400">
 </p>
 
+<p align="center">
+  <em>A sans-IO HTTP parser for Python with a Zig core! ⚡</em>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Kludex/zttp/actions/workflows/main.yml" target="_blank">
+    <img src="https://github.com/Kludex/zttp/actions/workflows/main.yml/badge.svg?event=push&branch=main" alt="Test">
+  </a>
+  <a href="https://pypi.org/project/zttp" target="_blank">
+    <img src="https://img.shields.io/pypi/v/zttp?color=%2334D058&label=pypi%20package" alt="Package version">
+  </a>
+  <a href="https://pypi.org/project/zttp" target="_blank">
+    <img src="https://img.shields.io/pypi/pyversions/zttp.svg?color=%2334D058" alt="Supported Python versions">
+  </a>
+  <a href="https://github.com/Kludex/zttp/blob/main/LICENSE" target="_blank">
+    <img src="https://img.shields.io/pypi/l/zttp.svg?color=%2334D058" alt="License">
+  </a>
+</p>
+
+---
+
+**Documentation**: <a href="https://zttp.marcelotryle.com" target="_blank">https://zttp.marcelotryle.com</a>
+
+**Source Code**: <a href="https://github.com/Kludex/zttp" target="_blank">https://github.com/Kludex/zttp</a>
+
+---
+
 > [!WARNING]
 > **zttp** is experimental. The API and behaviour may change at any time, and it is not yet ready for production use.
 
-A [sans-IO](https://sans-io.readthedocs.io/) HTTP/1.1, HTTP/2, and HTTP/3 parser
-for Python, with a core written in [Zig](https://ziglang.org). It offers the same
-clean, event-based API as [h11](https://github.com/python-hyper/h11), with a
-hand-written Zig engine underneath that is fast enough to be the HTTP parser in
-[uvicorn](https://github.com/encode/uvicorn). **It has no dependencies.**
+zttp is a [sans-IO](https://sans-io.readthedocs.io/) HTTP parser whose engine is
+written in [Zig](https://ziglang.org). It speaks **HTTP/1.1, HTTP/2, and
+HTTP/3**, and it does **no I/O of its own**: you feed it bytes and pull out
+events, and you ask it for bytes to send. It never touches a socket, so it works
+with any I/O you like.
 
-## Sans-IO
+It's the same idea as [h11](https://github.com/python-hyper/h11), with a
+hand-written Zig engine underneath instead of pure Python.
 
-**zttp** does no I/O. You feed it bytes and pull out events; you ask it for bytes to
-send. It never touches a socket, so it works with any I/O you like:
+The key features are:
+
+* **Sans-IO**: a clean, event-based API. Feed bytes with `receive_data`, pull
+  `Request` / `Data` / `EndOfMessage` events with `next_event`. No callbacks, no
+  sockets, no surprises.
+* **HTTP/1.1, HTTP/2, and HTTP/3**: the *same* event API for all three, selected
+  with one `protocol=` argument.
+* **Fast**: faster than [httptools](https://github.com/MagicStack/httptools) (a C
+  parser) on 13 of 14 benchmark workloads, and roughly 15x the pure-Python
+  alternative.
+* **Safe**: strict by default. It defends against request smuggling, rejects bare
+  `LF` line endings, bounds every buffer, and ships in Zig's safety-checked build.
+* **Typed**: a `py.typed` package with full type hints.
+* **No dependencies**: the wheel ships the compiled engine and nothing else.
+
+## Requirements
+
+zttp needs **CPython 3.10+** and runs on **Linux**, **macOS**, and **Windows**.
+
+## Installation
+
+```console
+$ pip install zttp
+```
+
+Wheels ship the Zig core already compiled, so there is nothing to build and
+nothing else to configure. See
+[Installation](https://zttp.marcelotryle.com/usage/install/) for building from
+source.
+
+## Example
+
+You play the **server**: bytes come in, events come out.
 
 ```python
 import zttp
@@ -40,6 +97,10 @@ The read side yields `Request` / `Response` / `Data` / `EndOfMessage`, or the
 head, body data, and the end of the message, framing the body (Content-Length or
 chunked) for you.
 
+Feed `receive_data` whatever you have — a whole message, a fragment, or a single
+byte — and zttp buffers and resumes. There are **no callbacks**: you *pull*
+events when *you* are ready. That's what sans-IO means.
+
 ## One API, three protocols
 
 The `protocol=` argument selects the wire format; the event API stays the same:
@@ -52,14 +113,10 @@ h2 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)  # HTTP/2
 h3 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)  # HTTP/3
 ```
 
-HTTP/3 support is experimental. The convenience server constructor creates an
-ephemeral TLS identity for local use; it is not production server identity yet.
-
 On **HTTP/2**, one connection multiplexes many requests, so the `Request` /
 `Response` / `Data` / `EndOfMessage` events carry a `stream_id` and you send on
-a `Stream` handle (connection-level control events like `Settings` and `Ping`
-have no stream to name). Outbound flow control is handled for you: `send_data`
-emits what the peer's window allows and parks the rest until credit arrives.
+a `Stream` handle. Outbound flow control is handled for you: `send_data` emits
+what the peer's window allows and parks the rest until credit arrives.
 
 ```python
 stream = h2.stream(request.stream_id)
@@ -72,37 +129,41 @@ h2.data_to_send()  # the HTTP/2 frames to put on the wire
 On **HTTP/3**, the wire is UDP, so you feed whole datagrams with
 `receive_datagram` and pull the same events. The QUIC transport underneath
 (packet protection, loss recovery, congestion control, stream reassembly) is
-written from scratch in the Zig core, with transport defaults supplied by zttp.
-HTTP/3 uses the same stream-scoped send surface as HTTP/2, with `Stream` handles
-for responses, body data, trailers, and per-stream cancellation.
+written from scratch in the Zig core. HTTP/3 uses the same stream-scoped send
+surface as HTTP/2.
 
 ```python
 h3.receive_datagram(datagram)
 h3.next_event()  # the same Request / Data / EndOfMessage, tagged with stream_id
 ```
 
+See [HTTP/2](https://zttp.marcelotryle.com/usage/http2/) and
+[HTTP/3](https://zttp.marcelotryle.com/usage/http3/) for the full story, including
+what each protocol changes and why. HTTP/3 support is experimental: the
+convenience server constructor creates an ephemeral TLS identity for local use,
+not a production server identity.
+
 ## Performance
 
-Against httptools on the same requests (macOS arm64, CPython 3.14, httptools
-0.8.0, the safety-checked `ReleaseSafe` build), both verified to extract
-identical data, median of 15 interleaved batches:
+Against [httptools](https://github.com/MagicStack/httptools) — the C parser
+uvicorn uses — on the same requests, with both verified to extract identical
+data:
 
 | Workload          | zttp         | httptools    | zttp vs httptools |
 | ----------------- | -----------: | -----------: | ----------------: |
 | Simple GET        | ~1.24M req/s | ~1.07M req/s | **~1.16x**        |
 | POST + JSON body  | ~1.42M req/s | ~1.25M req/s | **~1.14x**        |
 
-These ratios are medians; a single-digit-percent edge is close enough that
-run-to-run noise matters, so `scripts/bench` reports each workload's p25-p75
-quartiles and standard deviation alongside the median, and prints the ratio's own
-p25-p75 so you can see whether an edge is real or within the spread. On the
-closest workloads that band can straddle 1.0.
-
-zttp beats a C parser on 13 of the benchmark suite's 14 workloads while staying
+zttp beats httptools on 13 of the benchmark suite's 14 workloads while staying
 sans-IO and event-based, and is roughly 15x faster than the pure-Python
-alternative. Run it yourself: `./scripts/bench`.
+alternative. Run it yourself with `./scripts/bench`.
 
-## Why it is fast
+These are parser microbenchmarks, and single-digit-percent edges are close to
+run-to-run noise — see
+[Performance](https://zttp.marcelotryle.com/reference/performance/) for the full
+14-workload table, the methodology, and the caveats.
+
+### Why it is fast
 
 - A SWAR newline scanner and comptime-built character-class tables in the Zig
   core, so the hot loops are branch-light array lookups.
@@ -119,10 +180,11 @@ and combining multiple `Transfer-Encoding` field-lines into one ordered list so
 `chunked` must be the sole, final coding. Line endings are strict CRLF by default
 (bare LF is rejected), chunk-size is strictly `1*HEXDIG`, and obsolete line
 folding is rejected. Header blocks, trailers, and the receive buffer are all
-bounded (`Limits`) so a malicious peer cannot exhaust memory, and the outbound
-serializer rejects CR/LF/control bytes to prevent response splitting. The build
-defaults to Zig's safety-checked `ReleaseSafe` mode. Malformed input raises
-`RemoteProtocolError`; misusing the send API raises `LocalProtocolError`.
+bounded by conservative built-in limits so a malicious peer cannot exhaust
+memory, and the outbound serializer rejects CR/LF/control bytes to prevent
+response splitting. The build defaults to Zig's safety-checked `ReleaseSafe`
+mode. Malformed input raises `RemoteProtocolError`; misusing the send API raises
+`LocalProtocolError`.
 
 The HTTP/2 layer applies the same posture: the per-stream state machine enforces
 RFC 9113's stream lifecycle, with the exact stream-vs-connection error
@@ -131,9 +193,9 @@ classification the RFC requires.
 The parser has been through two adversarial security audits (a code review and a
 CVE-driven review against real HTTP-parser CVEs across Node, Go, Python, Rust, and
 C servers); `zig build fuzz` runs the adversarial-input net over the core. See
-[THREAT_MODEL.md](THREAT_MODEL.md) for what **zttp** defends against and what the
-integrator is responsible for.
+[THREAT_MODEL.md](THREAT_MODEL.md) for what **zttp** defends against, the exact
+limits it enforces, and what the integrator is responsible for.
 
 ## License
 
-BSD-3-Clause.
+This project is licensed under the terms of the BSD-3-Clause license.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -17,10 +17,9 @@ In scope:
   Content-Length and chunked bodies, trailers).
 - HTTP/2 (RFC 9113): frame codec, HPACK, stream multiplexing and state, flow
   control, and the connection lifecycle, plus h2c upgrade (RFC 7540 3.2).
-- HTTP/3 (RFC 9114) over a QUIC transport (RFC 9000/9001/9002): the server read
-  path - QPACK decode and request-stream framing. The peer control stream and its
-  SETTINGS are **not yet processed** (only bidirectional request streams are
-  pumped), so HTTP/3 settings are neither negotiated nor enforced today.
+- HTTP/3 (RFC 9114) over a QUIC transport (RFC 9000/9001/9002): QPACK, request-
+  stream framing, the peer control stream and its SETTINGS, and the connection
+  lifecycle (GOAWAY, per-stream cancellation), in both roles.
 - The read side (`receive_data` / `next_event`) and the write side
   (`send_*` / `data_to_send`).
 
@@ -204,28 +203,60 @@ boundary (RFC 9113 8):
 
 ## HTTP/3
 
-HTTP/3 (RFC 9114) over QUIC is read-path-first and the **least mature** of the
-three protocols. It reuses the shared field validators on **regular** header
-fields - lowercase token names, no control bytes in values, connection-specific
-fields and a non-`trailers` `TE` rejected, duplicate Content-Length conflict
-rejected (`decodeRequest`, `src/core/h3/connection.zig`). It also enforces the
-pseudo-header structure rules (pseudo before regular, no duplicates, required
-request pseudo-headers).
+HTTP/3 (RFC 9114) over QUIC is the **least mature** of the three protocols - not
+because it enforces less, but because it is the newest code with the least
+adversarial exposure. The defenses below are enforced in `src/core/h3/` and
+covered by tests.
 
-Two gaps a downgrading proxy must NOT rely on yet:
+### Field validation
 
-- **Pseudo-header *values* are not validated.** Unlike the H2 path, `decodeRequest`
-  does not run the value check on `:method`/`:path`/`:authority`/`:scheme`, so a
-  `:authority` carrying CR/LF is currently accepted and synthesized into a `host`
-  header. An h3→h1 downgrade must validate the pseudo-header values itself until
-  this is closed.
-- **The control stream and SETTINGS are not processed** (only request streams are
-  pumped), so HTTP/3 settings are neither negotiated nor enforced.
+It reuses the shared field validators on **regular** header fields - lowercase
+token names, no control bytes in values, connection-specific fields and a
+non-`trailers` `TE` rejected, duplicate Content-Length conflict rejected
+(`decodeRequest`, `src/core/h3/connection.zig`). It enforces the pseudo-header
+structure rules (pseudo before regular, no duplicates, required request
+pseudo-headers, CONNECT's `:authority`-only shape) and validates pseudo-header
+**values** with the same check as regular values, so an `:authority` carrying
+CR/LF cannot be synthesized into a `host` header on an h3→h1 downgrade.
 
-The QUIC transport (RFC 9000/9001/9002) - handshake, packet protection, flow
-control - is in scope and held to the strict-reject bar, but its threat surface
-is broad and has had far less adversarial exposure than the H1/H2 paths. Treat
-HTTP/3 as experimental from a security standpoint.
+### Control stream and SETTINGS
+
+The peer's unidirectional streams are classified and pumped, and the control
+stream is held to RFC 9114 6.2.1:
+
+- A request stream arriving **before** the peer's SETTINGS is rejected; a control
+  stream that does not begin with SETTINGS, or sends a second SETTINGS, is a
+  connection error.
+- A **second** control, QPACK-encoder, or QPACK-decoder stream is a connection
+  error, as is closing any of those critical streams.
+- HTTP/2-only frame types, control frames on a request stream, DATA before
+  HEADERS, and frames not allowed on the control stream are all rejected.
+- GOAWAY and MAX_PUSH_ID are validated for malformed/trailing bytes, wrong role,
+  and monotonicity (a GOAWAY id that increases, or a MAX_PUSH_ID that decreases,
+  is an error); CANCEL_PUSH for an unpromised push is rejected. Server push is
+  disabled, so a client-opened push stream is a connection error.
+
+### QPACK and field-section bounds
+
+| Defense | Limit (default) | Class |
+| --- | --- | --- |
+| Decoded field-section size, checked mid-decode | `MAX_FIELD_SECTION_SIZE` (64 KiB) | QPACK bomb |
+| Dynamic table capacity | `QPACK_MAX_TABLE_CAPACITY` (4 KiB) | encoder-driven memory |
+| Streams blocked on encoder updates | `QPACK_BLOCKED_STREAMS` (16) | blocked-stream pile-up |
+
+As on the H2 path, **what zttp advertises is exactly what it enforces**: these
+three values are sent verbatim in its own SETTINGS, so a conformant peer
+self-limits. Exceeding the blocked-stream cap is `QPACK_DECOMPRESSION_FAILED`;
+an oversized or malformed field section is rejected before the list is
+materialized.
+
+### The transport
+
+The QUIC transport (RFC 9000/9001/9002) - handshake, packet protection,
+amplification limits, loss recovery, and flow control - is in scope and held to
+the strict-reject bar, but its threat surface is broad and has had far less
+adversarial exposure than the H1/H2 paths. Treat HTTP/3 as experimental from a
+security standpoint.
 
 ## Integrator responsibilities
 

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -67,7 +67,7 @@ import zttp
 
 conn = zttp.Connection(zttp.SERVER)
 conn.send_data(b"x")  # no head was sent first
-#> zttp.LocalProtocolError: invalid send for current connection state
+#> zttp.LocalProtocolError: cannot send body data now: send a head first, or this message takes no body
 ```
 
 ```python

--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -289,7 +289,7 @@ import zttp
 conn = zttp.Connection(zttp.SERVER)
 conn.send_response(200, [(b"Content-Length", b"5")])
 conn.send_data(b"too long")
-#> zttp.LocalProtocolError: invalid send for current connection state
+#> zttp.LocalProtocolError: sent more body than the declared Content-Length
 ```
 
 For a body of unknown length, use `Transfer-Encoding: chunked` instead: then

--- a/docs/usage/http2.md
+++ b/docs/usage/http2.md
@@ -254,20 +254,36 @@ are real `Connection` subclasses, so code that only reads (`receive_data` /
 ## The read side
 
 Reading is what you already do. The only addition is `stream_id` on every event,
-because one HTTP/2 connection multiplexes many requests at once:
+because one HTTP/2 connection multiplexes many requests at once.
+
+Every example on this page uses one small helper to pull the events that are
+ready. It's the same `drain` you'd write yourself:
+
+```python title="drain.py"
+import zttp
+
+
+def drain(conn):
+    """Yield every complete event currently available."""
+    while True:
+        event = conn.next_event()
+        if event is zttp.NEED_DATA:
+            return
+        yield event
+```
+
+Now a server reads a request off the wire:
 
 ```python title="server_read.py"
 import zttp
 
 server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
-server.receive_data(incoming_bytes)
+server.receive_data(incoming_bytes)  # whatever you just read off the socket
 
-while True:
-    event = server.next_event()
-    if event is zttp.NEED_DATA:
-        break
+for event in drain(server):
     if isinstance(event, zttp.Request):
         print(event.method, event.target, event.stream_id)
+        #> b'GET' b'/' 1
 ```
 
 `event.stream_id` tells you which stream this `Request` arrived on. On HTTP/1.1
@@ -276,6 +292,14 @@ request carries the same id.
 
 A **client** reads the mirror image (`Response` events instead of `Request`),
 again tagged with the `stream_id` of the request they answer.
+
+!!! note "The connection preface"
+    HTTP/2 opens with a preface (the client's magic string, then each side's
+    `SETTINGS`). zttp emits yours lazily, on the first `data_to_send()`, so you
+    normally don't think about it. Call `initiate_connection()` to send it
+    eagerly - useful for a server that wants its `SETTINGS` on the wire before
+    the first request arrives. That's also why the first event you drain is
+    usually a `Settings` from the peer.
 
 ## Streams
 
@@ -300,10 +324,11 @@ import zttp
 client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
 stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])
 
-stream  #> Stream(stream_id=1)
+print(stream)
+#> Stream(stream_id=1)
 
 stream.end_message()
-print(client.data_to_send())  # the HTTP/2 frames to put on the wire
+request_bytes = client.data_to_send()  # the HTTP/2 frames to put on the wire
 ```
 
 The version arg is ignored (it's always `2`), and `:authority` is derived from
@@ -320,7 +345,7 @@ The server learns a stream's id by **reading** the request off it. Use
 import zttp
 
 server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
-server.receive_data(request_bytes)
+server.receive_data(request_bytes)  # from client.py above
 request = next(e for e in drain(server) if isinstance(e, zttp.Request))
 
 stream = server.stream(request.stream_id)
@@ -328,11 +353,21 @@ stream.send_response(200, [(b"content-type", b"text/plain")])
 stream.send_data(b"Hello, HTTP/2!")
 stream.end_message()
 
-print(server.data_to_send())
+response_bytes = server.data_to_send()
 ```
 
-`drain` is just a loop over `next_event` until `NEED_DATA`: the events carry the
-`stream_id` you need.
+Those two snippets are a complete round-trip: feed `response_bytes` back to the
+`client` and you get the mirror image out.
+
+```python
+client.receive_data(response_bytes)
+for event in drain(client):
+    print(event)
+#> Settings(params=[(3, 128), (6, 65536), (1, 4096), (5, 16384)])
+#> Response(status_code=200, reason=b'', http_version=b'2', headers=[(b'content-type', b'text/plain')])
+#> Data(data=b'Hello, HTTP/2!')
+#> EndOfMessage(trailers=[])
+```
 
 !!! tip "Many streams at once"
     Because each `Stream` names its own id, you can answer requests in **any
@@ -352,18 +387,18 @@ and **parks the rest**. As the peer grants more window (it sends you
 parked bytes automatically on the next `next_event`:
 
 ```python title="flow.py"
-import zttp
-
-stream = server.stream(1)
+stream = server.stream(request.stream_id)
 stream.send_response(200, [(b"content-type", b"text/plain")])
-stream.send_data(b"a very large body ...")
-out = server.data_to_send()                 # only what the window allowed
+stream.send_data(very_large_body)
+out = server.data_to_send()          # only what the window allowed
 
-# ... later, the peer grants more window ...
-server.receive_data(window_update_bytes)
+# ... later, the peer grants more window. Those WINDOW_UPDATE frames are just
+# ordinary inbound bytes off the socket:
+server.receive_data(bytes_from_socket)
 for event in drain(server):
-    ...                                      # a WindowUpdate flows past
-more = server.data_to_send()                 # the parked bytes, now freed
+    ...                              # a WindowUpdate flows past
+
+more = server.data_to_send()         # the parked bytes, now freed
 ```
 
 You hand zttp the whole body in one `send_data` call: it never blocks and never


### PR DESCRIPTION
Reviewed the README and the docs site as a reader would meet them, then fixed
what was wrong. Four changes, in rough order of impact.

## The README wasn't doing its job

It read as a condensed technical brief rather than a front door. It had no link
to the documentation site (declared in `zensical.toml` as
`https://zttp.marcelotryle.com/` and never mentioned), **no installation
instructions at all**, no badges, and no requirements line — while `docs/index.md`
had all of them.

Added the badge block, the **Documentation** / **Source Code** links,
**Requirements**, and **Installation**. Dropped the redundant `# zttp` heading
above the logo and pulled the feature bullets over from `docs/index.md` so the
two intros no longer disagree about what the project is.

Two claims were also walked back:

- "fast enough to be the HTTP parser in uvicorn" read as a statement of fact
  about uvicorn. Now: "faster than httptools (a C parser) on 13 of 14 benchmark
  workloads."
- Buffers were described as bounded by `` `Limits` ``, formatted like a public
  name. It isn't in `__all__`, isn't in `_zttp.pyi`, and isn't importable — only
  `THREAT_MODEL.md` explains it. Now described in prose.

The 2-row perf table stays as a teaser but links to the full 14-row table
instead of implying it's the whole picture.

## Two documented error messages were wrong

Running the examples against the compiled extension:

| File | Documented | Actually raised |
| --- | --- | --- |
| `docs/usage/errors.md` | `invalid send for current connection state` | `cannot send body data now: send a head first, or this message takes no body` |
| `docs/usage/http1.md` | `invalid send for current connection state` | `sent more body than the declared Content-Length` |

The real messages are considerably better — they were improved and the docs
never caught up.

## `THREAT_MODEL.md` understated the HTTP/3 posture

The HTTP/3 section listed "two gaps a downgrading proxy must NOT rely on yet."
Both are closed:

- *"Pseudo-header values are not validated"* — `src/core/h3/connection.zig:1053`
  runs `fields.validValue(h.value)` on them, with a comment specifically about
  the `:authority` CR/LF case.
- *"The control stream and SETTINGS are not processed"* — they are:
  `peer_settings` at `:151`, `:330`, `:673`, plus SETTINGS-first enforcement,
  second-control-stream rejection, GOAWAY/MAX_PUSH_ID monotonicity, and
  blocked-stream caps.

The Scope section said the same thing. Replaced both with the actual posture,
split into field validation / control stream / QPACK bounds, including the real
limits (`MAX_FIELD_SECTION_SIZE` 64 KiB, `QPACK_MAX_TABLE_CAPACITY` 4 KiB,
`QPACK_BLOCKED_STREAMS` 16).

A threat model that understates the implementation is the dangerous kind of
stale — people make trust decisions from it.

## `docs/usage/http2.md` couldn't be run

The page called `drain(server)` three times and never defined it — line 334 said
"`drain` is just a loop over `next_event`", prose where a five-line function
belongs. It also referenced `incoming_bytes`, `request_bytes`, and
`window_update_bytes`, none of which existed.

`drain` is now defined at the top of the read side, and the client/server
snippets form a real round-trip. Every `#>` output in the page is copied from an
actual run:

```
Stream(stream_id=1)
b'GET' b'/' 1
Settings(params=[(3, 128), (6, 65536), (1, 4096), (5, 16384)])
Response(status_code=200, reason=b'', http_version=b'2', headers=[(b'content-type', b'text/plain')])
Data(data=b'Hello, HTTP/2!')
EndOfMessage(trailers=[])
```

Also documented `initiate_connection()` and the lazy preface, which appeared
nowhere and is why the first drained event is usually a `Settings`.

## Verification

- Every code sample touched was executed against the compiled extension.
- `zensical build` succeeds, with only the 3 pre-existing unresolved
  mkdocstrings cross-references (`zttp.Connection`, `zttp.TlsCredentials`,
  `zttp.SessionResumption`) — they fail because `scripts/docs` runs
  `--no-install-project`, so the anchors can't resolve. Unchanged by this PR.

## Follow-ups, not in this PR

1. **Nothing tests the docs.** This is the root cause of the wrong error
   messages. The `#>` markers are already `pytest-examples` syntax — wiring it
   into `scripts/check` would turn each one into an assertion. Worth doing given
   coverage already fails CI under 100%.
2. **HTTP/3 has no send side documented,** and the `next_timeout()` /
   `handle_timeout(now)` timer contract appears nowhere. You can't write a
   working QUIC integration without it. `data_to_send()` also returns
   `list[bytes]` there, not `bytes`.
3. **`THREAT_MODEL.md` isn't in the site nav** — only reachable from GitHub.
4. **Undocumented public API:** `parse_datagram_header`, `DatagramHeader`,
   `Event`, `NeedData`, `ConnectionClosed`, `HTTP1` are in `__all__` but absent
   from `reference/api.md`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Overhauled the README and docs to make `zttp` easier to adopt and accurate. Adds install/docs links and badges, fixes two wrong error messages, updates the HTTP/3 threat model, and makes the HTTP/2 examples runnable.

- **Bug Fixes**
  - Corrected two documented `LocalProtocolError` messages to match runtime: “cannot send body data now: send a head first, or this message takes no body” and “sent more body than the declared Content-Length”.

- **Refactors**
  - README: added badges, documentation/source links, requirements, and installation; aligned intro with docs, softened performance wording, removed the public-looking `Limits` mention, and linked the full performance table.
  - `THREAT_MODEL.md`: replaced the HTTP/3 section with the current posture—pseudo-header value validation, processed control stream/SETTINGS, GOAWAY/MAX_PUSH_ID rules, and explicit QPACK/field-section limits.
  - `docs/usage/http2.md`: defined `drain`, removed placeholders, added a verified client/server round‑trip, and documented the connection preface and `initiate_connection()`.

<sup>Written for commit b492d4859fabf10ba08d4da2adfdc42afea5ebc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

