### PR TITLE
Test the documented examples, document the HTTP/3 send side, publish the threat model

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ It never reads a socket, never calls you back, never blocks. **You** own the I/O
 and the control flow; zttp owns only the protocol.
 
 ```python
+import zttp
+
 conn = zttp.Connection(zttp.SERVER)
 conn.receive_data(raw)        # bytes from wherever: socket, file, test
 event = conn.next_event()     # pull, when you want it

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,6 +43,7 @@ The key features are:
   allocation (see [Performance](reference/performance.md) for the numbers).
 * **Safe**: strict by default. It defends against request smuggling, rejects bare
   `LF` line endings, bounds every buffer, and ships in Zig's safety-checked build.
+  See [Security](security.md).
 * **Typed**: a `py.typed` package with full type hints. Your editor knows every
   event field.
 * **Tested**: a high-level test suite at **100% coverage**, plus the Zig core's
@@ -146,6 +147,12 @@ That's it. The buffering, the header parsing, the body framing: all Zig. 🎉
     ---
 
     What sans-IO is, and why a parser should do no I/O.
+
+-   :material-shield: **[Security](security.md)**
+
+    ---
+
+    The threat model: what zttp defends against, and what is yours to handle.
 
 -   :material-speedometer: **[Performance](reference/performance.md)**
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -141,17 +141,50 @@ must decide which `H3Connection` a datagram belongs to **before** feeding it to
 one. `parse_datagram_header` reads the routable prefix without decrypting
 anything or touching connection state.
 
+There are four cases, and a server has to handle all of them:
+
 ```python
 import zttp
 
-header = zttp.parse_datagram_header(datagram)
-if header.is_long_header:
-    conn = connections.get(header.destination_connection_id)
-else:
-    # A short (1-RTT) header does not encode the id's length on the wire, so
-    # match the prefix against the connection ids you already track.
-    conn = lookup_by_prefix(datagram)
+connections: dict[bytes, zttp.H3Connection] = {}  # keyed by local connection id
+
+
+def route(datagram: bytes, peer_address: bytes) -> None:
+    try:
+        header = zttp.parse_datagram_header(datagram)
+    except zttp.RemoteProtocolError:
+        return  # not a QUIC datagram we can route: drop it
+
+    if header.is_long_header:
+        conn = connections.get(header.destination_connection_id)
+        if conn is None:
+            if not header.is_initial:
+                # Handshake or 0-RTT for a connection we do not have. We hold no
+                # keys for it and it must not start one: drop it.
+                return
+            # A new connection. The client chose this destination id, so key the
+            # connection on it until it issues ids of its own.
+            conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+            connections[header.destination_connection_id] = conn
+    else:
+        # A short (1-RTT) header does not encode the destination id's length on
+        # the wire, so match its prefix against the ids you already track.
+        conn = lookup_by_prefix(datagram)
+        if conn is None:
+            return  # unknown connection: drop, or send a stateless reset
+
+    conn.receive_datagram(datagram, now_us(), peer_address)
 ```
+
+!!! warning "Only an Initial may create a connection"
+    Routing an unknown *non*-Initial long-header packet into a fresh connection
+    lets any peer allocate state with one spoofed datagram. Drop it - the keys to
+    decrypt it do not exist. Same for an unmatched short header, though there you
+    may instead send a stateless reset (RFC 9000 10.3), so a peer holding a dead
+    connection learns to give up rather than retrying into silence.
+
+See [HTTP/3](../usage/http3.md#serving-many-connections-on-one-socket) for how
+this sits inside the read and timer loop.
 
 ::: zttp.parse_datagram_header
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -41,8 +41,9 @@ A `Connection`'s role and protocol are fixed at construction:
   `receive_datagram` (see [HTTP/3](../usage/http3.md)).
 
 For HTTP/3, a server's TLS identity is passed as
-[`credentials=TlsCredentials(...)`][zttp.TlsCredentials] and a resumption secret
-as [`resumption=SessionResumption(...)`][zttp.SessionResumption] - typed value
+[`credentials=TlsCredentials(...)`](#zttp.TlsCredentials) and a resumption
+secret as [`resumption=SessionResumption(...)`](#zttp.SessionResumption) -
+typed value
 objects, so the same-typed `bytes` pairs can't be transposed (omit `credentials`
 and the server uses an ephemeral local identity). zttp supplies the QUIC
 transport defaults internally; the remaining constructor fields
@@ -100,10 +101,61 @@ Returned by an [`H3Connection`](#zttp.H3Connection)'s introspection methods.
 
 ### Sentinels
 
+`next_event()` returns one of these instead of an event when there is nothing to
+report. Both are singletons - compare with `is`, not `==`.
+
 | Value | Meaning |
 | --- | --- |
-| `zttp.NEED_DATA` | No complete event yet; feed more bytes. Compare with `is`. |
-| `zttp.CONNECTION_CLOSED` | The peer closed the connection. Compare with `is`. |
+| `zttp.NEED_DATA` | No complete event yet; feed more bytes. |
+| `zttp.CONNECTION_CLOSED` | The peer closed the connection. |
+
+::: zttp.NeedData
+
+::: zttp.ConnectionClosed
+
+### The event union
+
+`Event` is the union of everything [`next_event`](#zttp.Connection.next_event)
+can return, for annotating your own handlers:
+
+```python
+import zttp
+
+
+def handle(event: zttp.Event) -> None:
+    match event:
+        case zttp.Request(method=method):
+            ...
+        case zttp.Data(data=chunk):
+            ...
+```
+
+A connection only ever yields the events its protocol has: HTTP/1.1 never
+produces a `stream_id`-bearing control event, and only HTTP/2 produces `Ping` or
+`WindowUpdate`. The union is the widest of the three.
+
+## Demultiplexing a shared UDP socket
+
+An HTTP/3 server usually has one UDP socket and many connections on it, so it
+must decide which `H3Connection` a datagram belongs to **before** feeding it to
+one. `parse_datagram_header` reads the routable prefix without decrypting
+anything or touching connection state.
+
+```python
+import zttp
+
+header = zttp.parse_datagram_header(datagram)
+if header.is_long_header:
+    conn = connections.get(header.destination_connection_id)
+else:
+    # A short (1-RTT) header does not encode the id's length on the wire, so
+    # match the prefix against the connection ids you already track.
+    conn = lookup_by_prefix(datagram)
+```
+
+::: zttp.parse_datagram_header
+
+::: zttp.DatagramHeader
 
 ## Exceptions
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -144,9 +144,24 @@ anything or touching connection state.
 There are four cases, and a server has to handle all of them:
 
 ```python
+import time
+
 import zttp
 
 connections: dict[bytes, zttp.H3Connection] = {}  # keyed by local connection id
+
+
+def now_us() -> int:
+    """QUIC timestamps are monotonic microseconds."""
+    return time.monotonic_ns() // 1000
+
+
+def lookup_by_prefix(datagram: bytes) -> zttp.H3Connection | None:
+    """Match a short header's destination id, whose length is not on the wire."""
+    for connection_id, conn in connections.items():
+        if datagram[1:].startswith(connection_id):
+            return conn
+    return None
 
 
 def route(datagram: bytes, peer_address: bytes) -> None:

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,16 @@
+---
+icon: lucide/shield
+---
+
+# Security
+
+zttp parses bytes that arrive straight off the network, which makes it a security
+boundary. This page is the project's threat model: what zttp defends against,
+what it deliberately leaves to you, and the residual risks.
+
+!!! tip "Read the integrator responsibilities"
+    zttp is sans-IO, so timeouts, connection concurrency, and tunnel handling are
+    **yours**. The [Integrator responsibilities](#integrator-responsibilities)
+    section below is the part most likely to bite a real deployment.
+
+--8<-- "THREAT_MODEL.md"

--- a/docs/usage/errors.md
+++ b/docs/usage/errors.md
@@ -100,3 +100,9 @@ def handle(conn, raw_bytes):
         conn.end_message()
         ...
 ```
+
+## Where to go next
+
+* [Security](../security.md): the full threat model - the smuggling and DoS
+  classes zttp rejects, and the timeouts and connection caps that stay yours.
+* [A real server](real-server.md): this loop wired to an actual socket.

--- a/docs/usage/first-steps.md
+++ b/docs/usage/first-steps.md
@@ -4,7 +4,7 @@ icon: lucide/rocket
 
 # First steps
 
-zttp gives you one object: a [`Connection`][zttp.Connection].
+zttp gives you one object: a [`Connection`](../reference/api.md#zttp.Connection).
 
 ```python
 import zttp
@@ -143,3 +143,4 @@ You've seen the read side. Next:
 * [HTTP/1.1](http1.md): the read and write sides in depth - bodies, chunked encoding, trailers, building messages.
 * [A real server](real-server.md): wire it all to a socket - a complete `asyncio` server you can run.
 * [Errors](errors.md): what zttp rejects, and how.
+* [Security](../security.md): the threat model, and what you are responsible for.

--- a/docs/usage/http2.md
+++ b/docs/usage/http2.md
@@ -232,10 +232,13 @@ import zttp
 h1 = zttp.Connection(zttp.SERVER)
 h2 = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
 
-type(h1).__name__  #> 'H1Connection'
-type(h2).__name__  #> 'H2Connection'
+print(type(h1).__name__)
+#> H1Connection
+print(type(h2).__name__)
+#> H2Connection
 
-isinstance(h2, zttp.Connection)  #> True
+print(isinstance(h2, zttp.Connection))
+#> True
 ```
 
 An `H1Connection` carries the message-scoped send API you saw in

--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -211,6 +211,182 @@ You get the same `Request` / `Data` / `EndOfMessage` events, now tagged with the
 QUIC `stream_id`. An HTTP/3 request collapses its pseudo-headers into the same
 shape the other protocols use, and `http_version` is `b"3"`.
 
+!!! warning "`data_to_send()` returns a **list**"
+    On HTTP/1.1 and HTTP/2 it returns `bytes`, because TCP is a byte stream and
+    boundaries don't matter. On HTTP/3 it returns `list[bytes]` - **one UDP
+    datagram per element**. QUIC's datagram boundaries are semantic (they bound
+    a packet's AEAD protection), so you must `sendto` each element as its own
+    datagram. Concatenating them breaks the connection.
+
+    ```python
+    for datagram in conn.data_to_send():
+        sock.sendto(datagram, peer_address)
+    ```
+
+    Use [`data_to_send_with_addresses()`](../reference/api.md#zttp.H3Connection.data_to_send_with_addresses)
+    instead if the peer may have migrated and you need the address to send each
+    one to.
+
+## Sending a response
+
+The send surface is the one you already know from [HTTP/2](http2.md): responses
+go out on a `Stream` handle, because a connection carries many requests at once.
+`conn.stream(request.stream_id)` gets the handle, then it's
+`send_response` / `send_data` / `end_message`.
+
+Before any of that, though, QUIC has to finish its handshake, and that is just
+datagrams moving in both directions. Here is a complete client-and-server
+exchange with no sockets at all - the whole thing is a `transfer` helper that
+hands one side's datagrams to the other:
+
+```python title="roundtrip.py"
+import zttp
+
+
+def drain(conn):
+    while (event := conn.next_event()) is not zttp.NEED_DATA:
+        yield event
+
+
+def transfer(src, dst, now):
+    """Move every pending datagram from one connection to the other."""
+    for datagram in src.data_to_send():
+        dst.receive_datagram(datagram, now)
+
+
+client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"example.test")
+server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+
+transfer(client, server, 1000)  # ClientHello
+transfer(server, client, 2000)  # ServerHello and the rest of the server's flight
+transfer(client, server, 3000)  # the client's Finished - the handshake is done
+
+stream = client.send_request(b"GET", b"/", b"3", [(b"host", b"example.test")])
+stream.end_message()
+transfer(client, server, 4000)
+
+request = next(e for e in drain(server) if isinstance(e, zttp.Request))
+print(request.method, request.path, request.stream_id)
+#> b'GET' b'/' 0
+```
+
+The server answers on the stream the request arrived on:
+
+```python
+stream = server.stream(request.stream_id)
+stream.send_response(200, [(b"content-type", b"text/plain")])
+stream.send_data(b"Hello, HTTP/3!")
+stream.end_message()
+transfer(server, client, 5000)
+
+for event in drain(client):
+    print(event)
+#> Settings(params=[(1, 4096), (7, 16), (6, 65536)])
+#> Response(status_code=200, reason=b'', http_version=b'3', headers=[(b'content-type', b'text/plain')])
+#> Data(data=b'Hello, HTTP/3!')
+#> EndOfMessage(trailers=[])
+```
+
+That is the same `Stream` API as HTTP/2, and the same four building blocks as
+HTTP/1.1. Only the transport underneath changed.
+
+!!! note "The first client stream id is `0`"
+    On HTTP/2 the client's first request is stream `1`. QUIC numbers its streams
+    itself, and client-initiated bidirectional streams start at `0`, then `4`,
+    `8`, ... Don't hardcode either; use the `stream_id` the event carries.
+
+## Driving the clock
+
+This is the one duty HTTP/3 adds that the other protocols do not have. TCP ran
+its own timers inside the kernel. QUIC's timers are zttp's - but zttp is sans-IO
+and will not read a clock or sleep, so **you** have to fire them.
+
+There are two calls:
+
+* `next_timeout()`: the absolute deadline of the next armed timer, or `None` if
+  none is armed.
+* `handle_timeout(now)`: fire it. This retransmits a loss probe, or closes the
+  connection on an idle timeout.
+
+!!! danger "The clock is **microseconds**"
+    Every `now` you pass - to `receive_datagram`, to `handle_timeout` - and every
+    deadline `next_timeout()` returns is a monotonic timestamp in
+    **microseconds**. Pass milliseconds and every timer fires a thousand times
+    too early; pass nanoseconds and the connection never times out. Use
+    `time.monotonic_ns() // 1000`.
+
+Skip this and nothing appears broken at first - the handshake completes, requests
+flow - right up until a datagram is lost. Then nothing retransmits it, and the
+connection hangs forever instead of recovering.
+
+The loop looks like this:
+
+```python title="clock.py"
+import time
+
+
+def now_us() -> int:
+    return time.monotonic_ns() // 1000
+
+
+async def serve(conn, sock):
+    while not conn.is_closed():
+        deadline = conn.next_timeout()
+        timeout = None if deadline is None else max(0, deadline - now_us()) / 1_000_000
+
+        datagram = await recv_with_timeout(sock, timeout)
+        if datagram is None:
+            conn.handle_timeout(now_us())  # the timer expired before anything arrived
+        else:
+            conn.receive_datagram(datagram, now_us())
+
+        for event in drain(conn):
+            ...  # dispatch Request / Data / EndOfMessage
+
+        for out in conn.data_to_send():  # firing a timer can queue datagrams too
+            sock.sendto(out, peer_address)
+
+    if conn.idle_timed_out():
+        ...  # closed silently by the idle timeout, no CONNECTION_CLOSE was sent
+```
+
+The shape to keep: **wait for a datagram or the deadline, whichever comes
+first**, then always flush `data_to_send()` afterwards - firing a timer produces
+datagrams (a probe, a close) just as receiving one does.
+
+### Shutting down
+
+| Call | Effect |
+| --- | --- |
+| `conn.shutdown(stream_id)` | Graceful HTTP/3 `GOAWAY`: stop accepting new requests, finish the ones in flight (RFC 9114 5.2). |
+| `conn.close()` | Immediate QUIC `CONNECTION_CLOSE`. |
+| `conn.is_closed()` | Whether the connection is finished, for either reason. |
+| `conn.idle_timed_out()` | Whether it died silently on the idle timer rather than by a close. |
+| `conn.close_info()` | The peer's `CONNECTION_CLOSE` as a [`CloseInfo`](../reference/api.md#zttp.CloseInfo), or `None`. |
+
+After `close()`, flush `data_to_send()` one last time - the `CONNECTION_CLOSE`
+frame is queued like anything else, and the peer only learns you left if you
+actually send it.
+
+## Serving many connections on one socket
+
+A server has one UDP socket and many connections on it, so it has to route each
+datagram to the right `H3Connection` before feeding it. Use
+[`parse_datagram_header`](../reference/api.md#zttp.parse_datagram_header), which reads the routable
+prefix without decrypting anything:
+
+```python
+import zttp
+
+header = zttp.parse_datagram_header(datagram)
+if header.is_initial:
+    ...  # a new connection: create an H3Connection for header.destination_connection_id
+```
+
+See the [API reference](../reference/api.md#demultiplexing-a-shared-udp-socket)
+for the full picture, including short-header datagrams, which don't encode the
+connection id's length.
+
 ## The transport is inside
 
 For HTTP/1.1 and HTTP/2, the kernel's TCP gives zttp an ordered, reliable byte
@@ -239,5 +415,11 @@ protection, and the QPACK bomb defenses).
     ---
 
     How the from-scratch QUIC transport is built, layer by layer.
+
+-   :material-shield: **[Security](../security.md)**
+
+    ---
+
+    The threat model: what the QUIC transport defends against, and what is yours.
 
 </div>

--- a/scripts/docs
+++ b/scripts/docs
@@ -8,4 +8,8 @@ if [ -z "$GITHUB_ACTIONS" ]; then
 fi
 
 uv sync --frozen --only-group docs --no-install-project
-uv run --no-sync zensical build
+# --strict aborts on warnings. Without it an unresolved cross-reference is only a
+# log line and still exits 0, so a broken link renders as literal `[text][ref]`
+# on the live site. Cloudflare Workers Builds runs this script, so the deploy
+# fails instead of publishing them.
+uv run --no-sync zensical build --strict

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -62,11 +62,21 @@ class Example:
 
     @property
     def raises(self) -> tuple[int, str, str] | None:
-        """The (line index, exception name, message) of a documented exception."""
-        for index, line in enumerate(self.source.split("\n")):
-            if m := RAISES.match(line):
-                return index, m.group(1), m.group(2)
-        return None
+        """The (line index, exception name, message) of a documented exception.
+
+        A block documents at most one: execution stops at the first raise, so a
+        second marker could never be reached and would be silently ignored.
+        """
+        found = [
+            (index, m.group(1), m.group(2))
+            for index, line in enumerate(self.source.split("\n"))
+            if (m := RAISES.match(line))
+        ]
+        assert len(found) <= 1, (
+            f"{self.path.name}:{self.line} documents {len(found)} exceptions in one block. "
+            f"Execution stops at the first, so the rest can never be checked - split the block."
+        )
+        return found[0] if found else None
 
 
 def find_examples(root: Path) -> list[Example]:
@@ -114,6 +124,10 @@ def check_raises(example: Example, namespace: dict[str, Any]) -> None:
     assert found is not None
     index, name, message = found
     lines = example.source.split("\n")
+    assert len(example.claims) == 1, (
+        f"{example.path.name}:{example.line} documents an exception alongside other output. "
+        f"Nothing after the raise runs, so put the printed output in its own block."
+    )
 
     with pytest.raises(zttp.ProtocolError) as excinfo:
         exec("\n".join(lines[:index]), namespace)
@@ -196,15 +210,19 @@ def test_inline_output_markers_are_not_used() -> None:
 
 def undefined_names(source: str) -> set[str]:
     """The names `source` uses but never defines, via ruff's F821."""
-    with tempfile.NamedTemporaryFile("w", suffix=".py") as handle:
-        handle.write(source)
-        handle.flush()
+    with tempfile.TemporaryDirectory() as directory:
+        # A real file in a temp directory, not NamedTemporaryFile: Windows holds
+        # that one open exclusively, so ruff could not read it.
+        path = Path(directory) / "example.py"
+        path.write_text(source)
         result = subprocess.run(
-            ["ruff", "check", "--select", "F821", "--no-cache", "--output-format", "json", handle.name],
+            ["ruff", "check", "--select", "F821", "--no-cache", "--output-format", "json", str(path)],
             capture_output=True,
             text=True,
             check=False,
         )
+    if result.returncode not in (0, 1):  # 0 = clean, 1 = violations found
+        raise RuntimeError(f"ruff could not inspect the example: {result.stderr.strip()}")  # pragma: no cover
     return {m.group(1) for d in json.loads(result.stdout) if (m := re.search(r"`(.+)`", d["message"]))}
 
 
@@ -221,10 +239,17 @@ def test_examples_only_reference_documented_placeholders() -> None:
     for example in find_examples(DOCS):
         blocks[example.path.name].append(example.source)
 
+    seen = set()
     for page, sources in sorted(blocks.items()):
-        unexpected = undefined_names("\n".join(sources)) - PLACEHOLDERS.get(page, set())
+        undefined = undefined_names("\n".join(sources))
+        seen |= undefined
+        unexpected = undefined - PLACEHOLDERS.get(page, set())
         assert not unexpected, (
             f"{page} uses {sorted(unexpected)} without defining them. Define them in "
             f"the example, or add them to PLACEHOLDERS to declare that they are the "
             f"reader's to supply."
         )
+
+    # The pages above genuinely leave names to the reader, so finding none at all
+    # means ruff never really ran and this test passed vacuously.
+    assert seen, "ruff reported no undefined names anywhere - did it actually inspect the examples?"

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import re
+import shutil
+import subprocess
+import tempfile
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -90,6 +95,17 @@ def http2_request_bytes() -> bytes:
 
 # Placeholder names a page's prose describes but does not construct in a block.
 PAGE_CONTEXT = {"http2.md": http2_request_bytes}
+
+# Names an example deliberately leaves to the reader ("the bytes off your socket").
+# Anything undefined and *not* listed here is a broken example: either define it in
+# the block, or add it here to say it is the reader's to supply.
+PLACEHOLDERS = {
+    "architecture.md": {"raw", "udp_payload"},
+    "errors.md": {"conn"},
+    "first-steps.md": {"request", "transport"},
+    "http2.md": {"bytes_from_socket", "incoming_bytes", "very_large_body"},
+    "http3.md": {"cert", "key", "peer_address", "recv_with_timeout", "sock", "ticket_id", "ticket_psk", "udp_payload"},
+}
 
 
 def check_raises(example: Example, namespace: dict[str, Any]) -> None:
@@ -176,3 +192,39 @@ def test_inline_output_markers_are_not_used() -> None:
         if "#>" in line and not OUTPUT.match(line)
     ]
     assert not stray, f"`#>` must be on its own line, found trailing markers at: {stray}"
+
+
+def undefined_names(source: str) -> set[str]:
+    """The names `source` uses but never defines, via ruff's F821."""
+    with tempfile.NamedTemporaryFile("w", suffix=".py") as handle:
+        handle.write(source)
+        handle.flush()
+        result = subprocess.run(
+            ["ruff", "check", "--select", "F821", "--no-cache", "--output-format", "json", handle.name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    return {m.group(1) for d in json.loads(result.stdout) if (m := re.search(r"`(.+)`", d["message"]))}
+
+
+@pytest.mark.skipif(shutil.which("ruff") is None, reason="ruff is not installed")
+def test_examples_only_reference_documented_placeholders() -> None:
+    """An example may not silently depend on a name that nobody defines.
+
+    A reader copies a block and runs it. If it calls `now_us()` and the page never
+    says what that is, the example is broken - which is how this test came to be.
+    Concatenating a page's blocks mirrors reading it top to bottom, so a block may
+    still build on an earlier one.
+    """
+    blocks = defaultdict(list)
+    for example in find_examples(DOCS):
+        blocks[example.path.name].append(example.source)
+
+    for page, sources in sorted(blocks.items()):
+        unexpected = undefined_names("\n".join(sources)) - PLACEHOLDERS.get(page, set())
+        assert not unexpected, (
+            f"{page} uses {sorted(unexpected)} without defining them. Define them in "
+            f"the example, or add them to PLACEHOLDERS to declare that they are the "
+            f"reader's to supply."
+        )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,178 @@
+"""Execute the code examples in `docs/` and check their documented output.
+
+Every `#>` comment in the documentation is a claim about what zttp does. This
+module runs the examples and holds them to it, so a change to an error message
+or a repr cannot silently leave the docs behind. (It has: two `LocalProtocolError`
+messages drifted before this existed.)
+
+There are exactly two shapes of claim:
+
+* **Printed output** - one or more `#>` lines after a `print(...)`. Every `#>`
+  payload in the block, in order, must equal the block's stdout.
+* **A raised exception** - a `#>` line of the form `zttp.SomeError: message`
+  directly after the statement that raises it.
+
+A page's examples share one namespace and run in document order, the way a reader
+meets them, so a later block may build on an earlier one. Blocks with no `#>`
+claim are executed on a best-effort basis to populate that namespace and are
+allowed to fail: they are illustrative fragments (`await writer.drain()`,
+`transport.close()`) with nothing to verify. Nothing is masked by this - a
+skipped block that some `#>` block genuinely needed shows up as a `NameError` in
+the block that made the claim.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import zttp
+
+DOCS = Path(__file__).parent.parent / "docs"
+
+FENCE = re.compile(r"^(?P<indent> *)```+ *python\b[^\n]*\n(?P<source>.*?)^(?P=indent)```+ *$", re.M | re.S)
+OUTPUT = re.compile(r"^\s*#>[ ]?(.*)$")
+# `#> zttp.RemoteProtocolError: malformed header field`
+RAISES = re.compile(r"^\s*#>[ ]?(zttp\.\w*Error): (.*)$")
+
+
+@dataclass(frozen=True)
+class Example:
+    """One ```python fenced block in a documentation page."""
+
+    path: Path
+    line: int
+    source: str
+
+    @property
+    def claims(self) -> list[str]:
+        """The `#>` payloads in this block, in order."""
+        return [m.group(1) for line in self.source.split("\n") if (m := OUTPUT.match(line))]
+
+    @property
+    def raises(self) -> tuple[int, str, str] | None:
+        """The (line index, exception name, message) of a documented exception."""
+        for index, line in enumerate(self.source.split("\n")):
+            if m := RAISES.match(line):
+                return index, m.group(1), m.group(2)
+        return None
+
+
+def find_examples(root: Path) -> list[Example]:
+    """Every ```python block under `root`, in file then document order."""
+    examples = []
+    for path in sorted(root.rglob("*.md")):
+        text = path.read_text()
+        for match in FENCE.finditer(text):
+            line = text[: match.start()].count("\n") + 2
+            examples.append(Example(path, line, match.group("source")))
+    return examples
+
+
+def http2_request_bytes() -> bytes:
+    """The `incoming_bytes` that docs/usage/http2.md's read side reads off the socket.
+
+    The page introduces reading before it introduces the client that produces the
+    bytes, so this supplies what the prose describes: one `GET /` on the first
+    client-initiated stream.
+    """
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    stream = client.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])
+    stream.end_message()
+    return client.data_to_send()
+
+
+# Placeholder names a page's prose describes but does not construct in a block.
+PAGE_CONTEXT = {"http2.md": http2_request_bytes}
+
+
+def check_raises(example: Example, namespace: dict[str, Any]) -> None:
+    """The documented exception must be the one the final statement actually raises."""
+    found = example.raises
+    assert found is not None
+    index, name, message = found
+    lines = example.source.split("\n")
+
+    with pytest.raises(zttp.ProtocolError) as excinfo:
+        exec("\n".join(lines[:index]), namespace)
+
+    actual = f"zttp.{type(excinfo.value).__name__}: {excinfo.value}"
+    assert actual == f"{name}: {message}", (
+        f"{example.path.name}:{example.line + index} documents a different exception\n"
+        f"  documented: {name}: {message}\n"
+        f"  actual:     {actual}"
+    )
+
+    # The rest of the block still runs, so later blocks can build on it.
+    with contextlib.suppress(Exception):
+        exec("\n".join(lines[index + 1 :]), namespace)
+
+
+def check_output(example: Example, namespace: dict[str, Any]) -> None:
+    """The block's stdout must equal its `#>` payloads, in order."""
+    source = "\n".join(line for line in example.source.split("\n") if not OUTPUT.match(line))
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        exec(source, namespace)
+
+    actual = stdout.getvalue().splitlines()
+    assert actual == example.claims, (
+        f"{example.path.name}:{example.line} printed output does not match its `#>` comments\n"
+        f"  documented: {example.claims}\n"
+        f"  actual:     {actual}"
+    )
+
+
+def pages() -> list[str]:
+    return sorted({example.path.name for example in find_examples(DOCS)})
+
+
+@pytest.mark.parametrize("page", pages())
+def test_documented_output_is_accurate(page: str) -> None:
+    """Run a page's examples in order and verify every `#>` claim it makes."""
+    context = PAGE_CONTEXT.get(page)
+    namespace: dict[str, Any] = {"incoming_bytes": context()} if context else {}
+
+    for example in find_examples(DOCS):
+        if example.path.name != page:
+            continue
+        if not example.claims:
+            # An illustrative fragment: run it to populate the namespace, but it
+            # asserts nothing, so let it fail.
+            with contextlib.suppress(Exception):
+                exec(example.source, namespace)
+        elif example.raises:
+            check_raises(example, namespace)
+        else:
+            check_output(example, namespace)
+
+
+def test_the_docs_make_checkable_claims() -> None:
+    """Guard the convention itself: `#>` markers must still be found and parsed."""
+    examples = find_examples(DOCS)
+    assert len(examples) > 40, "the ```python fence scanner stopped matching"
+
+    with_claims = [e for e in examples if e.claims]
+    assert len(with_claims) > 15, "no documented output found - has the `#>` convention changed?"
+    assert {e.path.name for e in with_claims} <= set(pages())
+
+
+def test_inline_output_markers_are_not_used() -> None:
+    """`#>` must start its own line, or the checker above silently skips it.
+
+    A trailing `value  #> repr` reads fine but is invisible to the parser, so it
+    can drift exactly like the messages this module exists to pin down.
+    """
+    stray = [
+        f"{path.relative_to(DOCS)}:{number}"
+        for path in sorted(DOCS.rglob("*.md"))
+        for number, line in enumerate(path.read_text().split("\n"), 1)
+        if "#>" in line and not OUTPUT.match(line)
+    ]
+    assert not stray, f"`#>` must be on its own line, found trailing markers at: {stray}"

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,6 +23,7 @@ nav = [
     "usage/real-server.md",
   ] },
   { "Architecture" = "architecture.md" },
+  { "Security" = "security.md" },
   { "Reference" = [
     "reference/performance.md",
     "reference/api.md",
@@ -121,6 +122,11 @@ pygments_lang_class = true
 [project.markdown_extensions.pymdownx.magiclink]
 [project.markdown_extensions.pymdownx.mark]
 [project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.snippets]
+# THREAT_MODEL.md lives at the repo root (linked from the README and referenced
+# by security reports); docs/security.md includes it rather than duplicating it.
+base_path = ["."]
+check_paths = true
 [project.markdown_extensions.pymdownx.superfences]
 custom_fences = [
   { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }


### PR DESCRIPTION
The follow-ups listed in #168, plus two things found while doing them.

## 1. The documentation is now executable

Every `#>` comment in the docs is a claim about what zttp does, and nothing
checked them — which is exactly how two `LocalProtocolError` messages drifted
until #168.

`tests/test_docs.py` runs each page's examples **in document order, in one shared
namespace** — the way a reader meets them — and holds them to their claims:

- **Printed output** — every `#>` payload in a block, in order, must equal its stdout.
- **A raised exception** — a `#> zttp.SomeError: message` line must match what the
  preceding statement actually raises.

Blocks with no `#>` are executed best-effort to populate the namespace and are
allowed to fail; they're illustrative fragments (`await writer.drain()`) with
nothing to assert. Nothing is masked — a skipped block that a `#>` block needed
shows up as a `NameError` in the block that made the claim.

**21 blocks, 30 claims, all verified**, including a full QUIC handshake. Failures
report the real location:

```
AssertionError: http1.md:292 documents a different exception
    documented: zttp.LocalProtocolError: nope
    actual:     zttp.LocalProtocolError: sent more body than the declared Content-Length
```

Three claims were written as `value  #> repr` on a trailing comment, which is
invisible to any line-based checker. They're now print form, and
`test_inline_output_markers_are_not_used` keeps them that way.

### No new dependency

The issue suggested `pytest-examples`. It requires `black>=23`, and this project
uses `ruff format` — adding black to the dev env for a markdown fence scanner is
a bad trade. The scanner is ~20 lines, so it's inline. `uv.lock` is unchanged and
`scripts/install` gains nothing.

## 2. HTTP/3 had no send side

The page stopped at reading datagrams, though the README promised "the same
stream-scoped send surface as HTTP/2." Added:

- **Sending a response** — a complete client-and-server round-trip, handshake
  included, with no sockets. Its output is verified by the test above.
- **`data_to_send()` returns a `list`** — one UDP datagram per element, unlike
  HTTP/1.1 and HTTP/2 where it's `bytes`. Concatenating them breaks the
  connection. This was in the stub and nowhere in the prose.
- **Driving the clock** — `next_timeout()` / `handle_timeout(now)` appeared
  nowhere in the docs. You cannot write a working QUIC integration without them,
  and skipping them looks fine right up until a datagram is lost, at which point
  nothing retransmits and the connection hangs forever.
- **The clock unit is microseconds.** Written down nowhere — the stub only said
  "the integrator's monotonic clock." `src/core/quic/recovery.zig` is explicit
  (`INITIAL_RTT_US`, `GRANULARITY_US`). Pass milliseconds and every timer fires
  1000x early.
- **Shutdown** and **demultiplexing a shared UDP socket** via
  `parse_datagram_header`.
- The first client stream id is `0` on HTTP/3, not `1` as on HTTP/2 — a nice
  trap, now called out and asserted.

## 3. Five cross-references were broken on the live site

Not just build warnings — they rendered as literal text:

> zttp gives you one object: a [`Connection`][zttp.Connection].

zensical reports these but **exits 0**, so they shipped. `scripts/docs` now
passes `--strict`, which aborts the build; Cloudflare Workers Builds runs that
script, so a broken link fails the deploy instead of publishing it. The five refs
are converted to explicit anchors, which resolve reliably.

The docs build is now **clean** — it reported 3 issues before #168 and reports
`No issues found` now.

## 4. Security is in the nav

`THREAT_MODEL.md` was only reachable from GitHub. `docs/security.md` includes it
via `pymdownx.snippets` — one source of truth, still at the repo root where the
README and security reports point. Linked from the landing page, `errors.md`,
and `http3.md`.

## 5. Undocumented public API

`parse_datagram_header`, `DatagramHeader`, `Event`, `NeedData` and
`ConnectionClosed` were in `__all__` but absent from the reference. Added, with a
worked example for demultiplexing one UDP socket across many connections.

## Verification

- `scripts/check` — clean
- `scripts/test` — 303 passed, coverage **100.00%** (`tests/test_docs.py` included)
- `scripts/docs` — `No issues found`, exit 0; verified it still fails (exit 1) on
  a deliberately broken reference, and that it works in the docs-only
  environment Cloudflare uses (`--no-install-project`)
- `uv.lock` unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the docs executable and expand HTTP/3 to cover the send path, timers, and shutdown. Add a Security page, document demux APIs with safer routing, and fail the docs build on broken links.

- **New Features**
  - Executable docs: run examples in order; verify `#>` output and documented exceptions; enforce standalone `#>` lines; check for undefined names (via `ruff` F821) and require explicit placeholders; no new dev deps.
  - HTTP/3 send side: full client/server round‑trip without sockets; `data_to_send()` returns a list of UDP datagrams; mention `data_to_send_with_addresses()`; first client stream id is `0`.
  - HTTP/3 timers and shutdown: document `next_timeout()` / `handle_timeout(now)` (clock is microseconds) and show `GOAWAY` / `CONNECTION_CLOSE` patterns.
  - Demultiplexing: add `parse_datagram_header` and `DatagramHeader`; API example defines `now_us()` and `lookup_by_prefix()`; create a new connection only for Initials and drop unknown non‑Initials; document `Event` union plus `NeedData` and `ConnectionClosed`.
  - Security: publish `docs/security.md` by including `THREAT_MODEL.md` via `pymdownx.snippets`; add to nav and link from key pages.

- **Bug Fixes**
  - Fix broken cross‑references and run `zensical build --strict` in `scripts/docs` so unresolved links fail deploys.
  - Make the `ruff` F821 check portable and non‑vacuous: use a real temp file (works on Windows), assert at least one undefined name is found so the test isn’t vacuous, fail on unexpected `ruff` exit codes, and reject blocks that document multiple exceptions or mix exceptions with printed output.

<sup>Written for commit 2b8b8d9ad7d0bd34bf56eb854b6a1af596debd99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Security and threat-model guide, linked from the docs navigation, intro, and “Where to go next” sections.
  * Expanded HTTP/3 usage with QUIC/datagram routing, event guidance, clock driving, and shutdown semantics.
  * Improved API reference wording/link formatting and updated several example snippets/output expectations.
  * Added a “Where to go next” section to usage error docs and clarified first-steps/security links.
* **Tests**
  * Strengthened docs example validation, including stricter output/exception checks and placeholder-only reference enforcement.
* **Chores**
  * Made the docs build run in strict mode so broken references fail the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->