### PR TITLE
Allow transfer codings before final chunked on HTTP/1 send

### DIFF
--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -260,6 +260,30 @@ print(conn.data_to_send())
 #> b'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWiki\r\n5\r\npedia\r\n0\r\nX-Checksum: abc\r\n\r\n'
 ```
 
+Other transfer codings may precede `chunked`, either in one field-line or across
+several. zttp treats them as one ordered list, requires `chunked` exactly once
+and last, preserves the field-lines you supplied, and adds the final chunk framing:
+
+```python
+import gzip
+
+import zttp
+
+already_gzipped = gzip.compress(b"hello")
+conn = zttp.Connection(zttp.SERVER)
+conn.send_response(200, [(b"Transfer-Encoding", b"gzip, chunked")])
+conn.send_data(already_gzipped)
+conn.end_message()
+wire_bytes = conn.data_to_send()  # write each produced byte to the socket
+```
+
+!!! warning "zttp does not apply the preceding coding"
+    `gzip` describes bytes your application already compressed. zttp does **not**
+    gzip `send_data`; it only adds the chunk framing it implements. Declaring
+    `gzip, chunked` around uncompressed bytes lies to the peer. A coding without
+    final `chunked`, `chunked, gzip`, duplicate `chunked`, and
+    `Transfer-Encoding` together with `Content-Length` are all rejected.
+
 ### Bodyless responses
 
 Some responses have no body no matter what (a `204`, a `304`, the reply to a

--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -280,9 +280,12 @@ wire_bytes = conn.data_to_send()  # write each produced byte to the socket
 !!! warning "zttp does not apply the preceding coding"
     `gzip` describes bytes your application already compressed. zttp does **not**
     gzip `send_data`; it only adds the chunk framing it implements. Declaring
-    `gzip, chunked` around uncompressed bytes lies to the peer. A coding without
-    final `chunked`, `chunked, gzip`, duplicate `chunked`, and
-    `Transfer-Encoding` together with `Content-Length` are all rejected.
+    `gzip, chunked` around uncompressed bytes lies to the peer. Malformed coding
+    lists, a coding without final `chunked`, `chunked, gzip`, duplicate `chunked`,
+    and `Transfer-Encoding` together with `Content-Length` are all rejected.
+    `Transfer-Encoding` is also forbidden on `1xx` / `204` and successful
+    `CONNECT` responses; `HEAD` and `304` may only describe the coding that would
+    have applied to the corresponding body.
 
 ### Bodyless responses
 

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -186,6 +186,9 @@ pub const FramingOptions = struct {
     /// Responses to HEAD, 1xx/204/304, and the connect side have no body
     /// regardless of headers (RFC 9112 6.3). The connection layer sets this.
     bodyless: bool = false,
+    /// 1xx/204 and successful CONNECT responses forbid Transfer-Encoding.
+    /// Separate from bodyless because HEAD and 304 may carry TE metadata.
+    forbid_transfer_encoding: bool = false,
     /// Whether absence of length info means "read until close". True for
     /// responses, false for requests (a request without length has no body).
     until_close_default: bool = false,
@@ -210,6 +213,7 @@ pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Frami
     // RFC 9112 6.1: if both are present, Transfer-Encoding overrides, but this
     // is a smuggling vector - reject outright (what secure parsers do).
     if (has_te and content_length != null) return error.InvalidFraming;
+    if (has_te and opts.forbid_transfer_encoding) return error.InvalidFraming;
 
     if (opts.bodyless) return .none;
 
@@ -372,6 +376,17 @@ test "bad content-length rejected" {
 
 test "bodyless forces none" {
     const h = [_]Header{.{ .name = "Content-Length", .value = "100" }};
+    try std.testing.expectEqual(Framing.none, try determine(&h, .{ .bodyless = true }));
+}
+
+test "forbidden Transfer-Encoding is rejected before bodyless framing" {
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
+    try std.testing.expectError(error.InvalidFraming, determine(&h, .{
+        .bodyless = true,
+        .forbid_transfer_encoding = true,
+    }));
+    // HEAD/304 use bodyless without the forbidden flag and may describe the
+    // coding that would have applied to their corresponding body.
     try std.testing.expectEqual(Framing.none, try determine(&h, .{ .bodyless = true }));
 }
 

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -52,6 +52,23 @@ const TransferEncoding = struct {
     }
 };
 
+/// Validate Transfer-Encoding across all field-lines as one ordered comma list.
+/// Returns whether the message declared Transfer-Encoding. The caller owns any
+/// codings before `chunked`; this layer only requires the framing coding it can
+/// decode/emit: `chunked` exactly once and last (RFC 9112 6.1, 7.1).
+pub fn validateTransferEncoding(headers: []const Header) ParseError!bool {
+    var te = TransferEncoding{};
+    var has_te = false;
+    for (headers) |h| {
+        if (eqIgnoreCase(h.name, "transfer-encoding")) {
+            has_te = true;
+            te.add(h.value);
+        }
+    }
+    if (has_te) _ = try te.resolve();
+    return has_te;
+}
+
 fn parseContentLength(value: []const u8) ParseError!u64 {
     const v = ascii.trimOws(value);
     return ascii.parseDecimal(u64, v) orelse error.InvalidFraming;
@@ -79,15 +96,11 @@ pub const FramingOptions = struct {
 /// Inspect the parsed headers and return the body framing. Enforces the
 /// CL/TE conflict and duplicate-Content-Length rules.
 pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Framing {
-    var te = TransferEncoding{};
-    var has_te = false;
+    const has_te = try validateTransferEncoding(headers);
     var content_length: ?u64 = null;
 
     for (headers) |h| {
-        if (eqIgnoreCase(h.name, "transfer-encoding")) {
-            has_te = true;
-            te.add(h.value);
-        } else if (eqIgnoreCase(h.name, "content-length")) {
+        if (eqIgnoreCase(h.name, "content-length")) {
             const n = try parseContentLength(h.value);
             if (content_length) |prev| {
                 if (prev != n) return error.InvalidFraming; // conflicting duplicates
@@ -102,12 +115,7 @@ pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Frami
 
     if (opts.bodyless) return .none;
 
-    if (has_te) {
-        // chunked must be the sole/final coding across ALL field-lines; resolve
-        // rejects non-final or unframeable Transfer-Encodings to avoid smuggling.
-        _ = try te.resolve();
-        return .chunked;
-    }
+    if (has_te) return .chunked;
     if (content_length) |n| {
         return if (n == 0) .none else .{ .content_length = n };
     }

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -6,6 +6,7 @@
 const std = @import("std");
 const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
+const tables = @import("../tables.zig");
 const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
@@ -25,21 +26,103 @@ pub const Framing = union(enum) {
 /// Accumulates Transfer-Encoding codings across (possibly multiple) field-lines,
 /// which RFC 9112 6.1 requires to be treated as a single ordered comma list. The
 /// only framing we accept is `chunked` appearing exactly once and as the final
-/// coding overall; anything else (chunked not last, chunked twice, an unknown
-/// coding after chunked) is a framing error - the request-smuggling guard.
+/// coding overall; anything else (chunked not last, chunked twice, malformed
+/// list/parameter grammar) is a framing error - the request-smuggling guard.
 const TransferEncoding = struct {
     saw_chunked: bool = false,
     /// True once any coding has been seen after a `chunked` coding (illegal).
     coding_after_chunked: bool = false,
 
-    /// Fold one field-line value's comma-separated codings into the accumulator.
-    fn add(self: *TransferEncoding, value: []const u8) void {
-        var it = std.mem.splitScalar(u8, value, ',');
-        while (it.next()) |raw| {
-            const coding = std.mem.trim(u8, raw, " \t");
-            if (coding.len == 0) continue;
-            if (self.saw_chunked) self.coding_after_chunked = true;
-            if (eqIgnoreCase(coding, "chunked")) self.saw_chunked = true;
+    fn skipOws(value: []const u8, i: *usize) void {
+        while (i.* < value.len and (value[i.*] == ' ' or value[i.*] == '\t')) i.* += 1;
+    }
+
+    fn takeToken(value: []const u8, i: *usize) ?[]const u8 {
+        const start = i.*;
+        while (i.* < value.len and tables.is_tchar[value[i.*]]) i.* += 1;
+        return if (i.* == start) null else value[start..i.*];
+    }
+
+    /// quoted-string / quoted-pair (RFC 9110 5.6.4). The surrounding field-value
+    /// check already rejects CR/LF/NUL, but this enforces the narrower grammar.
+    fn takeQuotedString(value: []const u8, i: *usize) bool {
+        if (i.* >= value.len or value[i.*] != '"') return false;
+        i.* += 1;
+        while (i.* < value.len) {
+            const ch = value[i.*];
+            i.* += 1;
+            if (ch == '"') return true;
+            if (ch == '\\') {
+                if (i.* >= value.len) return false;
+                const escaped = value[i.*];
+                i.* += 1;
+                if (!(escaped == '\t' or escaped == ' ' or (escaped >= 0x21 and escaped <= 0x7E) or escaped >= 0x80)) return false;
+            } else if (!(ch == '\t' or ch == ' ' or ch == 0x21 or (ch >= 0x23 and ch <= 0x5B) or (ch >= 0x5D and ch <= 0x7E) or ch >= 0x80)) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    fn noteCoding(self: *TransferEncoding, coding: []const u8) bool {
+        if (self.saw_chunked) self.coding_after_chunked = true;
+        const is_chunked = eqIgnoreCase(coding, "chunked");
+        if (is_chunked) self.saw_chunked = true;
+        return is_chunked;
+    }
+
+    /// Fold one field-line's `#transfer-coding` value into the accumulator,
+    /// validating token names, parameters, quoted strings, and list separators.
+    /// RFC 9110 5.6.1 forbids senders from generating empty list elements but
+    /// requires recipients to ignore a reasonable number, hence the policy flag.
+    fn add(self: *TransferEncoding, value: []const u8, allow_empty_members: bool) ParseError!void {
+        var i: usize = 0;
+        skipOws(value, &i);
+        if (i == value.len) {
+            if (allow_empty_members) return;
+            return error.InvalidFraming;
+        }
+
+        while (true) {
+            if (value[i] == ',') {
+                if (!allow_empty_members) return error.InvalidFraming;
+                i += 1;
+                skipOws(value, &i);
+                if (i == value.len) return;
+                continue;
+            }
+
+            const coding = takeToken(value, &i) orelse return error.InvalidFraming;
+            const is_chunked = self.noteCoding(coding);
+            skipOws(value, &i);
+
+            // `chunked` defines no parameters. Keeping it exact also preserves
+            // the reader's pre-existing rejection of `chunked;anything`.
+            if (is_chunked and i < value.len and value[i] == ';') return error.InvalidFraming;
+            while (i < value.len and value[i] == ';') {
+                i += 1;
+                skipOws(value, &i);
+                _ = takeToken(value, &i) orelse return error.InvalidFraming;
+                skipOws(value, &i);
+                if (i == value.len or value[i] != '=') return error.InvalidFraming;
+                i += 1;
+                skipOws(value, &i);
+                if (i < value.len and value[i] == '"') {
+                    if (!takeQuotedString(value, &i)) return error.InvalidFraming;
+                } else {
+                    _ = takeToken(value, &i) orelse return error.InvalidFraming;
+                }
+                skipOws(value, &i);
+            }
+
+            if (i == value.len) return;
+            if (value[i] != ',') return error.InvalidFraming;
+            i += 1;
+            skipOws(value, &i);
+            if (i == value.len) {
+                if (allow_empty_members) return;
+                return error.InvalidFraming;
+            }
         }
     }
 
@@ -52,17 +135,24 @@ const TransferEncoding = struct {
     }
 };
 
+pub const TransferEncodingMode = enum {
+    /// Recipients ignore empty list members (RFC 9110 5.6.1).
+    receive,
+    /// Senders must not generate empty list members.
+    send,
+};
+
 /// Validate Transfer-Encoding across all field-lines as one ordered comma list.
 /// Returns whether the message declared Transfer-Encoding. The caller owns any
 /// codings before `chunked`; this layer only requires the framing coding it can
 /// decode/emit: `chunked` exactly once and last (RFC 9112 6.1, 7.1).
-pub fn validateTransferEncoding(headers: []const Header) ParseError!bool {
+pub fn validateTransferEncoding(headers: []const Header, mode: TransferEncodingMode) ParseError!bool {
     var te = TransferEncoding{};
     var has_te = false;
     for (headers) |h| {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
             has_te = true;
-            te.add(h.value);
+            try te.add(h.value, mode == .receive);
         }
     }
     if (has_te) _ = try te.resolve();
@@ -84,6 +174,14 @@ pub fn responseIsBodyless(method: []const u8, status: u16) bool {
     return false;
 }
 
+/// RFC 9112 6.1 forbids Transfer-Encoding on 1xx/204 and successful CONNECT
+/// responses. HEAD and 304 are also bodyless, but may carry the coding that
+/// would have applied to the corresponding body (RFC 9110 8.6, 15.4.5).
+pub fn responseForbidsTransferEncoding(method: []const u8, status: u16) bool {
+    if (status / 100 == 1 or status == 204) return true;
+    return eqIgnoreCase(method, "CONNECT") and status >= 200 and status < 300;
+}
+
 pub const FramingOptions = struct {
     /// Responses to HEAD, 1xx/204/304, and the connect side have no body
     /// regardless of headers (RFC 9112 6.3). The connection layer sets this.
@@ -96,7 +194,7 @@ pub const FramingOptions = struct {
 /// Inspect the parsed headers and return the body framing. Enforces the
 /// CL/TE conflict and duplicate-Content-Length rules.
 pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Framing {
-    const has_te = try validateTransferEncoding(headers);
+    const has_te = try validateTransferEncoding(headers, .receive);
     var content_length: ?u64 = null;
 
     for (headers) |h| {
@@ -134,6 +232,15 @@ test "responseIsBodyless rule" {
     try std.testing.expect(!responseIsBodyless("POST", 201));
 }
 
+test "responseForbidsTransferEncoding rule" {
+    try std.testing.expect(responseForbidsTransferEncoding("GET", 103));
+    try std.testing.expect(responseForbidsTransferEncoding("GET", 204));
+    try std.testing.expect(responseForbidsTransferEncoding("CONNECT", 200));
+    try std.testing.expect(!responseForbidsTransferEncoding("HEAD", 200));
+    try std.testing.expect(!responseForbidsTransferEncoding("GET", 304));
+    try std.testing.expect(!responseForbidsTransferEncoding("CONNECT", 404));
+}
+
 test "no body" {
     const h = [_]Header{.{ .name = "Host", .value = "x" }};
     try std.testing.expectEqual(Framing.none, try determine(&h, .{}));
@@ -158,6 +265,33 @@ test "chunked" {
 test "chunked with preceding coding" {
     const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
     try std.testing.expectEqual(Framing.chunked, try determine(&h, .{}));
+}
+
+test "transfer coding parameters and quoted commas" {
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip ; level = 1 ; note = \"a,b\\\"c\", chunked" }};
+    try std.testing.expectEqual(Framing.chunked, try determine(&h, .{}));
+}
+
+test "receiver ignores empty transfer coding list members" {
+    inline for (.{ ",chunked", "chunked,", "gzip,,chunked", ",,gzip,,chunked,," }) |value| {
+        const h = [_]Header{.{ .name = "Transfer-Encoding", .value = value }};
+        try std.testing.expectEqual(Framing.chunked, try determine(&h, .{}));
+    }
+}
+
+test "malformed transfer coding grammar rejected" {
+    inline for (.{
+        "",
+        ";bad, chunked",
+        "gzip;flag, chunked",
+        "gzip;=value, chunked",
+        "gzip;level=, chunked",
+        "gzip;note=\"unterminated, chunked",
+        "gzip;note=\"bad\\\", chunked",
+    }) |value| {
+        const h = [_]Header{.{ .name = "Transfer-Encoding", .value = value }};
+        try std.testing.expectError(error.InvalidFraming, determine(&h, .{}));
+    }
 }
 
 test "te and cl together is rejected (smuggling)" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -344,6 +344,7 @@ pub const Reader = struct {
         const method = self.request_method[0..self.request_method_len];
         const framing = try self.frameBody(.{
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
+            .forbid_transfer_encoding = framing_mod.responseForbidsTransferEncoding(method, st.status_code),
             .until_close_default = true,
         });
         self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items) or framing == .until_close;
@@ -645,6 +646,35 @@ test "client auto-frames 304 response as bodyless" {
     try r.feed("HTTP/1.1 304 Not Modified\r\nContent-Length: 100\r\n\r\n");
     try expectTag(.response, try r.nextEvent());
     try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "client rejects Transfer-Encoding where response semantics forbid it" {
+    const cases = .{
+        .{ "GET", "HTTP/1.1 204 No Content\r\nTransfer-Encoding: chunked\r\n\r\n" },
+        .{ "CONNECT", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" },
+    };
+    inline for (cases) |case| {
+        var r = Reader.init(t.allocator, .client);
+        defer r.deinit();
+        r.setRequestMethod(case[0]);
+        try r.feed(case[1]);
+        try t.expectError(error.InvalidFraming, r.nextEvent());
+    }
+}
+
+test "client permits Transfer-Encoding metadata on HEAD and 304" {
+    const cases = .{
+        .{ "HEAD", "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n" },
+        .{ "GET", "HTTP/1.1 304 Not Modified\r\nTransfer-Encoding: gzip, chunked\r\n\r\n" },
+    };
+    inline for (cases) |case| {
+        var r = Reader.init(t.allocator, .client);
+        defer r.deinit();
+        r.setRequestMethod(case[0]);
+        try r.feed(case[1]);
+        try expectTag(.response, try r.nextEvent());
+        try expectTag(.end_of_message, try r.nextEvent());
+    }
 }
 
 test "client continues through informational response" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -405,6 +405,9 @@ fn parseLength(v: []const u8) u64 {
 }
 
 const t = std.testing;
+/// Deterministic gzip member for `hello` (mtime zero), used where the declared
+/// transfer-coding must agree with the bytes the test sends.
+const gzip_hello = "\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03\xcb\x48\xcd\xc9\xc9\x07\x00\x86\xa6\x10\x36\x05\x00\x00\x00";
 
 test "serialize a simple response" {
     var wr = Writer.init(t.allocator);
@@ -698,10 +701,10 @@ test "send accepts transfer coding before final chunked in one field" {
     defer wr.deinit();
     const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
     try wr.sendResponse("1.1", 200, "OK", &h, "GET");
-    try wr.sendData("hello");
+    try wr.sendData(gzip_hello);
     try wr.endMessage(&.{});
     try t.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n19\r\n" ++ gzip_hello ++ "\r\n0\r\n\r\n",
         wr.pending(),
     );
 }
@@ -714,10 +717,10 @@ test "send combines transfer codings across field-lines" {
         .{ .name = "Transfer-Encoding", .value = "chunked" },
     };
     try wr.sendResponse("1.1", 200, "OK", &h, "GET");
-    try wr.sendData("hello");
+    try wr.sendData(gzip_hello);
     try wr.endMessage(&.{});
     try t.expectEqualStrings(
-        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n19\r\n" ++ gzip_hello ++ "\r\n0\r\n\r\n",
         wr.pending(),
     );
 }

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -13,6 +13,7 @@ const headers_mod = @import("headers.zig");
 
 const Header = events.Header;
 const responseIsBodyless = framing.responseIsBodyless;
+const responseForbidsTransferEncoding = framing.responseForbidsTransferEncoding;
 const eqIgnoreCase = ascii.eqIgnoreCase;
 const trimOws = ascii.trimOws;
 
@@ -178,6 +179,11 @@ fn validateHeaders(hdrs: []const Header) WriteError!void {
     try validateFraming(hdrs);
 }
 
+fn hasHeader(hdrs: []const Header, name: []const u8) bool {
+    for (hdrs) |h| if (eqIgnoreCase(h.name, name)) return true;
+    return false;
+}
+
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
 /// smuggling guards. Transfer-Encoding field-lines form one ordered comma list;
 /// codings may precede `chunked`, but `chunked` must appear exactly once and last.
@@ -185,7 +191,7 @@ fn validateHeaders(hdrs: []const Header) WriteError!void {
 /// zttp supplies only the final chunk framing. TE + CL and conflicting duplicate
 /// Content-Lengths remain errors.
 fn validateFraming(hdrs: []const Header) WriteError!void {
-    const has_te = framing.validateTransferEncoding(hdrs) catch return error.InvalidField;
+    const has_te = framing.validateTransferEncoding(hdrs, .send) catch return error.InvalidField;
     var content_length: ?[]const u8 = null;
     for (hdrs) |h| {
         if (eqIgnoreCase(h.name, "content-length")) {
@@ -271,6 +277,7 @@ pub const Writer = struct {
     /// is bodyless (RFC 9112 6.3), so the caller never tracks framing by hand.
     pub fn sendResponse(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, request_method: []const u8) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
+        if (responseForbidsTransferEncoding(request_method, status) and hasHeader(hdrs, "transfer-encoding")) return error.InvalidField;
         try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs);
         if (responseIsBodyless(request_method, status)) {
             self.state = .body_none;
@@ -292,6 +299,7 @@ pub const Writer = struct {
     pub fn sendInformational(self: *Writer, status: u16, hdrs: []const Header) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
         if (status / 100 != 1 or status == 101) return error.InvalidField;
+        if (hasHeader(hdrs, "transfer-encoding")) return error.InvalidField;
         try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs);
     }
 
@@ -512,11 +520,42 @@ test "HEAD response is bodyless despite Content-Length" {
     try t.expectEqualStrings("HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n", wr.pending());
 }
 
-test "bodyless response rejects unsupported transfer-encoding" {
+test "responses forbidden to carry Transfer-Encoding reject it before output" {
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
+    const cases = .{
+        .{ @as(u16, 103), "Early Hints", "GET" },
+        .{ @as(u16, 204), "No Content", "GET" },
+        .{ @as(u16, 200), "OK", "CONNECT" },
+    };
+    inline for (cases) |case| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        try t.expectError(error.InvalidField, wr.sendResponse("1.1", case[0], case[1], &hdrs, case[2]));
+        try t.expectEqualStrings("", wr.pending());
+    }
+}
+
+test "informational response rejects Transfer-Encoding before output" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
-    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip" }};
-    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 304, "Not Modified", &hdrs, "GET"));
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    try t.expectError(error.InvalidField, wr.sendInformational(103, &hdrs));
+    try t.expectEqualStrings("", wr.pending());
+}
+
+test "HEAD and 304 may describe Transfer-Encoding of corresponding body" {
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
+    const cases = .{
+        .{ @as(u16, 200), "OK", "HEAD" },
+        .{ @as(u16, 304), "Not Modified", "GET" },
+    };
+    inline for (cases) |case| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        try wr.sendResponse("1.1", case[0], case[1], &hdrs, case[2]);
+        try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
+        try wr.endMessage(&.{});
+    }
 }
 
 test "data before head is rejected" {
@@ -672,6 +711,23 @@ test "send rejects prohibited trailers" {
         try wr.sendResponse("1.1", 200, "OK", &hdrs, "GET");
         const trailers = [_]Header{.{ .name = name, .value = "x" }};
         try t.expectError(error.InvalidField, wr.endMessage(&trailers));
+    }
+}
+
+test "send rejects malformed transfer-encoding grammar" {
+    inline for (.{
+        ",chunked",
+        "chunked,",
+        "gzip,,chunked",
+        ";bad, chunked",
+        "gzip;flag, chunked",
+        "gzip;note=\"unterminated, chunked",
+    }) |value| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        const h = [_]Header{.{ .name = "Transfer-Encoding", .value = value }};
+        try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+        try t.expectEqualStrings("", wr.pending());
     }
 }
 

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -179,21 +179,16 @@ fn validateHeaders(hdrs: []const Header) WriteError!void {
 }
 
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
-/// smuggling guards. A message carrying both Transfer-Encoding and
-/// Content-Length, multiple Transfer-Encoding fields, unsupported TE codings, or
-/// conflicting duplicate Content-Lengths would let a downstream parser disagree
-/// about message boundaries (response splitting).
+/// smuggling guards. Transfer-Encoding field-lines form one ordered comma list;
+/// codings may precede `chunked`, but `chunked` must appear exactly once and last.
+/// The caller supplies bytes to which those preceding codings are already applied;
+/// zttp supplies only the final chunk framing. TE + CL and conflicting duplicate
+/// Content-Lengths remain errors.
 fn validateFraming(hdrs: []const Header) WriteError!void {
-    var has_te = false;
+    const has_te = framing.validateTransferEncoding(hdrs) catch return error.InvalidField;
     var content_length: ?[]const u8 = null;
     for (hdrs) |h| {
-        if (eqIgnoreCase(h.name, "transfer-encoding")) {
-            if (has_te) return error.InvalidField;
-            has_te = true;
-            // h11-style send policy: zttp only emits the `chunked` transfer
-            // coding it implements, never unsupported metadata-only codings.
-            if (!eqIgnoreCase(trimOws(h.value), "chunked")) return error.InvalidField;
-        } else if (eqIgnoreCase(h.name, "content-length")) {
+        if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
             if (ascii.parseDecimal(u64, v) == null) return error.InvalidField; // non-empty digits, no overflow
             if (content_length) |prev| {
@@ -698,21 +693,33 @@ test "send rejects duplicate transfer-encoding chunked" {
     try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
 }
 
-test "send rejects unsupported transfer-encoding comma list" {
+test "send accepts transfer coding before final chunked in one field" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip, chunked" }};
-    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+    try wr.sendResponse("1.1", 200, "OK", &h, "GET");
+    try wr.sendData("hello");
+    try wr.endMessage(&.{});
+    try t.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip, chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+        wr.pending(),
+    );
 }
 
-test "send rejects multiple transfer-encoding fields" {
+test "send combines transfer codings across field-lines" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
     const h = [_]Header{
         .{ .name = "Transfer-Encoding", .value = "gzip" },
         .{ .name = "Transfer-Encoding", .value = "chunked" },
     };
-    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+    try wr.sendResponse("1.1", 200, "OK", &h, "GET");
+    try wr.sendData("hello");
+    try wr.endMessage(&.{});
+    try t.expectEqualStrings(
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+        wr.pending(),
+    );
 }
 
 test "send rejects ambiguous framing (TE + CL)" {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -110,6 +110,36 @@ def test_response_parsing() -> None:
     assert conn.next_event().data == b"xyz"
 
 
+@pytest.mark.parametrize(
+    ("method", "status", "reason"),
+    [(b"GET", 204, b"No Content"), (b"CONNECT", 200, b"OK")],
+)
+def test_response_rejects_forbidden_transfer_encoding(method: bytes, status: int, reason: bytes) -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(method, b"/", b"1.1", [(b"Host", b"example.com")])
+    conn.end_message()
+    conn.data_to_send()
+    conn.receive_data(b"HTTP/1.1 " + str(status).encode() + b" " + reason + b"\r\nTransfer-Encoding: chunked\r\n\r\n")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
+@pytest.mark.parametrize(
+    ("method", "status", "reason"),
+    [(b"HEAD", 200, b"OK"), (b"GET", 304, b"Not Modified")],
+)
+def test_bodyless_response_accepts_transfer_encoding_metadata(method: bytes, status: int, reason: bytes) -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(method, b"/", b"1.1", [(b"Host", b"example.com")])
+    conn.end_message()
+    conn.data_to_send()
+    conn.receive_data(
+        b"HTTP/1.1 " + str(status).encode() + b" " + reason + b"\r\nTransfer-Encoding: gzip, chunked\r\n\r\n"
+    )
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
 def test_response_until_close() -> None:
     conn = zttp.Connection(zttp.CLIENT)
     conn.receive_data(b"HTTP/1.1 200 OK\r\nServer: z\r\n\r\nbody here")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -97,6 +97,39 @@ def test_chunked_response() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [(b"Transfer-Encoding", b"gzip, chunked")],
+        [(b"Transfer-Encoding", b"gzip"), (b"Transfer-Encoding", b"chunked")],
+    ],
+)
+def test_chunked_framing_with_preceding_transfer_codings(headers: list[tuple[bytes, bytes]]) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.send_response(200, headers)
+    conn.send_data(b"compressed")
+    conn.end_message()
+
+    head, body = conn.data_to_send().split(b"\r\n\r\n", 1)
+    assert head.count(b"chunked") == 1
+    assert body == b"a\r\ncompressed\r\n0\r\n\r\n"
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [(b"Transfer-Encoding", b"gzip")],
+        [(b"Transfer-Encoding", b"chunked, gzip")],
+        [(b"Transfer-Encoding", b"chunked, chunked")],
+        [(b"Transfer-Encoding", b"chunked"), (b"Transfer-Encoding", b"chunked")],
+    ],
+)
+def test_invalid_transfer_coding_order_is_rejected(headers: list[tuple[bytes, bytes]]) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_response(200, headers)
+
+
 def test_chunked_with_trailers() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(200, [(b"Transfer-Encoding", b"chunked")])

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gzip
+
 import pytest
 
 import zttp
@@ -105,14 +107,16 @@ def test_chunked_response() -> None:
     ],
 )
 def test_chunked_framing_with_preceding_transfer_codings(headers: list[tuple[bytes, bytes]]) -> None:
+    compressed = gzip.compress(b"hello", mtime=0)
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(200, headers)
-    conn.send_data(b"compressed")
+    conn.send_data(compressed)
     conn.end_message()
 
     head, body = conn.data_to_send().split(b"\r\n\r\n", 1)
     assert head.count(b"chunked") == 1
-    assert body == b"a\r\ncompressed\r\n0\r\n\r\n"
+    assert body == f"{len(compressed):x}\r\n".encode() + compressed + b"\r\n0\r\n\r\n"
+    assert gzip.decompress(compressed) == b"hello"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -126,12 +126,39 @@ def test_chunked_framing_with_preceding_transfer_codings(headers: list[tuple[byt
         [(b"Transfer-Encoding", b"chunked, gzip")],
         [(b"Transfer-Encoding", b"chunked, chunked")],
         [(b"Transfer-Encoding", b"chunked"), (b"Transfer-Encoding", b"chunked")],
+        [(b"Transfer-Encoding", b",chunked")],
+        [(b"Transfer-Encoding", b"chunked,")],
+        [(b"Transfer-Encoding", b"gzip,,chunked")],
+        [(b"Transfer-Encoding", b";bad, chunked")],
+        [(b"Transfer-Encoding", b"gzip;flag, chunked")],
+        [(b"Transfer-Encoding", b'gzip;note="unterminated, chunked')],
     ],
 )
 def test_invalid_transfer_coding_order_is_rejected(headers: list[tuple[bytes, bytes]]) -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.LocalProtocolError):
         conn.send_response(200, headers)
+
+
+@pytest.mark.parametrize(
+    ("status", "method"),
+    [(103, b"GET"), (204, b"GET"), (200, b"CONNECT")],
+)
+def test_transfer_encoding_rejected_when_response_forbids_it(status: int, method: bytes) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    if method != b"GET":
+        conn.receive_data(method + b" / HTTP/1.1\r\nHost: x\r\n\r\n")
+        list(drain(conn))
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_response(status, [(b"Transfer-Encoding", b"gzip, chunked")])
+    assert conn.data_to_send() == b""
+
+
+def test_informational_rejects_transfer_encoding() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_informational(103, [(b"Transfer-Encoding", b"chunked")])
+    assert conn.data_to_send() == b""
 
 
 def test_chunked_with_trailers() -> None:


### PR DESCRIPTION
## The bug

The uvicorn zttp branch found a framing mismatch around non-chunked transfer
codings. The same assumption existed inside zttp 0.0.16:

```python
c.send_response(200, [(b"Transfer-Encoding", b"gzip")])
c.send_data(b"hello")
c.end_message()
```

produced:

```http
HTTP/1.1 200 OK
Transfer-Encoding: gzip

5
hello
0


```

The header declares only `gzip`, while the body is chunk-framed. A client follows
the declared coding order and tries to gunzip the chunk framing itself.

#156 made this safe in 0.0.17 by rejecting every send-side
`Transfer-Encoding` except one literal `chunked` field. That prevents corrupt
wire output, but is narrower than RFC 9112 and narrower than zttp's own reader:

| Header(s) | Reader | Writer before this PR |
| --- | --- | --- |
| `chunked` | accept | accept |
| `gzip, chunked` | accept | reject |
| `gzip` + `chunked` (two field-lines) | accept | reject |
| `gzip` | reject | reject |
| `chunked, gzip` | reject | reject |

This matters for uvicorn's fix: it appends `chunked` to an existing transfer-
coding list. Both RFC-valid representations it can produce were rejected by
zttp 0.0.17.

## The fix

Move Transfer-Encoding validation into one helper in `framing.zig`, shared by
both read and write. Both paths now follow the same rule:

1. Fold every `Transfer-Encoding` field-line into one ordered comma list (RFC
   9110 §5.2 / RFC 9112 §6.1).
2. Require `chunked` exactly once and last.
3. Let codings before it describe transformations the caller has already
   applied; zttp supplies only the final chunk framing it implements.

So these now work:

```http
Transfer-Encoding: gzip, chunked
```

and the equivalent split form:

```http
Transfer-Encoding: gzip
Transfer-Encoding: chunked
```

The supplied field-lines are preserved on the wire; only their combined ordering
is validated.

## Security invariants retained

This is not a general Transfer-Encoding relaxation. All ambiguous/unframeable
forms remain `LocalProtocolError`:

- `gzip` — no final framing coding
- `chunked, gzip` — coding after `chunked`
- `chunked, chunked` — duplicate `chunked`
- split `chunked` + `chunked` — duplicate across field-lines
- any `Transfer-Encoding` together with `Content-Length`

This also answers the "append if it does not end in chunked" suggestion from the
uvicorn review: zttp never repairs `chunked, gzip` into
`chunked, gzip, chunked`. It rejects the malformed input, and never declares
`chunked` twice.

## Caller responsibility

zttp does not apply `gzip` (or any preceding coding). `send_data()` must already
contain gzip-compressed bytes; zttp only wraps those bytes in chunks. The HTTP/1
documentation now says this explicitly and gives a `gzip.compress()` example.

## Tests

- Exact-wire Zig tests for a single `gzip, chunked` field and split `gzip` +
  `chunked` fields.
- Public Python tests for both accepted forms.
- Public Python regressions for no-final-chunked, non-final chunked, and duplicate
  chunked both within and across field-lines.
- The executable documentation caught and prevented state leaking into the next
  example.

Validation:

- `zig build test`: **807/807**
- `scripts/check`: clean
- `scripts/test`: **313 passed**, 1 optional interop skip
- coverage: **100.00%**
- `scripts/docs`: `No issues found` under strict mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
HTTP/1 reader and writer now accept transfer codings before a final `chunked`, strictly validate `Transfer-Encoding` grammar, and reject TE where HTTP forbids it (1xx/204 and successful CONNECT), aligning both directions with RFC 9112/9110. This fixes framing mismatches, prevents misparsing on inbound bodyless responses, and unblocks `uvicorn`; docs and tests use valid gzip bytes.

- **Bug Fixes**
  - Accept `Transfer-Encoding: gzip, chunked` and the split form; preserve field-lines and emit only chunk framing.
  - Validate full grammar: token names/parameters and quoted strings; reject empty list members on send, ignore on receive (RFC 9110 §5.6.1).
  - Forbid TE on `1xx`/`204` and successful `CONNECT` on send and receive; allow `HEAD`/`304` to carry metadata; fail before writing any bytes.
  - Keep rejecting: `gzip` alone, `chunked, gzip`, duplicate `chunked` (including across lines), any TE with `Content-Length`, and parameters on `chunked`.

- **Refactors**
  - Centralized TE checks in `framing.validateTransferEncoding` with distinct `receive`/`send` modes and a new `forbid_transfer_encoding` framing option used by reader and writer.
  - Docs clarify callers must pre-encode bytes (`gzip.compress(..., mtime=0)`); tests add exact-wire cases, malformed grammar, and forbidden-context regressions.

<sup>Written for commit 1a97276e02a5ebff9ba7913f5872001fb3bde39d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supports ordered `Transfer-Encoding` where `chunked` appears exactly once and last, including `gzip, chunked`, and supports `Transfer-Encoding` split across multiple header fields.
* **Bug Fixes**
  * Rejects malformed/invalid `Transfer-Encoding` (duplicate/misordered `chunked`, invalid syntax/parameters) and still rejects ambiguous `Transfer-Encoding` + `Content-Length`.
  * Enforces response rules that forbid `Transfer-Encoding` for `1xx`, `204`, successful `CONNECT`, and informational responses.
  * Ensures bodyless responses can retain `Transfer-Encoding` metadata.
* **Documentation**
  * Updates HTTP/1.1 guidance with clarified framing rules and examples.
* **Tests**
  * Adds/updates reader/writer coverage for acceptance, rejection, and edge cases (including parameter/quoted-comma handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

A follow-up reader review found the matching inbound gap (`1a97276`): 204 and
successful CONNECT responses carrying TE were accepted as bodyless, so following
chunk bytes could be reinterpreted as a new message. The reader now derives an
explicit `forbid_transfer_encoding` option from the remembered method and status
before framing. HEAD/304 retain their permitted metadata case; informational
responses were already rejected by their dedicated path.
