### PR TITLE
Reject Transfer-Encoding where response semantics forbid it

### DIFF
--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -67,10 +67,21 @@ pub fn responseIsBodyless(method: []const u8, status: u16) bool {
     return false;
 }
 
+/// RFC 9112 6.1 forbids Transfer-Encoding on 1xx/204 and successful CONNECT
+/// responses. HEAD and 304 are also bodyless, but may carry `chunked` metadata
+/// for the corresponding body (RFC 9110 8.6, 15.4.5).
+pub fn responseForbidsTransferEncoding(method: []const u8, status: u16) bool {
+    if (status / 100 == 1 or status == 204) return true;
+    return eqIgnoreCase(method, "CONNECT") and status >= 200 and status < 300;
+}
+
 pub const FramingOptions = struct {
     /// Responses to HEAD, 1xx/204/304, and the connect side have no body
     /// regardless of headers (RFC 9112 6.3). The connection layer sets this.
     bodyless: bool = false,
+    /// 1xx/204 and successful CONNECT responses forbid Transfer-Encoding.
+    /// Separate from bodyless because HEAD and 304 may carry TE metadata.
+    forbid_transfer_encoding: bool = false,
     /// Whether absence of length info means "read until close". True for
     /// responses, false for requests (a request without length has no body).
     until_close_default: bool = false,
@@ -99,6 +110,7 @@ pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Frami
     // RFC 9112 6.1: if both are present, Transfer-Encoding overrides, but this
     // is a smuggling vector - reject outright (what secure parsers do).
     if (has_te and content_length != null) return error.InvalidFraming;
+    if (has_te and opts.forbid_transfer_encoding) return error.InvalidFraming;
 
     if (opts.bodyless) return .none;
 
@@ -124,6 +136,15 @@ test "responseIsBodyless rule" {
     try std.testing.expect(!responseIsBodyless("CONNECT", 404));
     try std.testing.expect(!responseIsBodyless("GET", 200));
     try std.testing.expect(!responseIsBodyless("POST", 201));
+}
+
+test "responseForbidsTransferEncoding rule" {
+    try std.testing.expect(responseForbidsTransferEncoding("GET", 103));
+    try std.testing.expect(responseForbidsTransferEncoding("GET", 204));
+    try std.testing.expect(responseForbidsTransferEncoding("CONNECT", 200));
+    try std.testing.expect(!responseForbidsTransferEncoding("HEAD", 200));
+    try std.testing.expect(!responseForbidsTransferEncoding("GET", 304));
+    try std.testing.expect(!responseForbidsTransferEncoding("CONNECT", 404));
 }
 
 test "no body" {
@@ -230,6 +251,17 @@ test "bad content-length rejected" {
 
 test "bodyless forces none" {
     const h = [_]Header{.{ .name = "Content-Length", .value = "100" }};
+    try std.testing.expectEqual(Framing.none, try determine(&h, .{ .bodyless = true }));
+}
+
+test "forbidden Transfer-Encoding is rejected before bodyless framing" {
+    const h = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    try std.testing.expectError(error.InvalidFraming, determine(&h, .{
+        .bodyless = true,
+        .forbid_transfer_encoding = true,
+    }));
+    // HEAD/304 use bodyless without the forbidden flag and may describe the
+    // chunked coding that would have applied to their corresponding body.
     try std.testing.expectEqual(Framing.none, try determine(&h, .{ .bodyless = true }));
 }
 

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -344,6 +344,7 @@ pub const Reader = struct {
         const method = self.request_method[0..self.request_method_len];
         const framing = try self.frameBody(.{
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
+            .forbid_transfer_encoding = framing_mod.responseForbidsTransferEncoding(method, st.status_code),
             .until_close_default = true,
         });
         self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items) or framing == .until_close;
@@ -645,6 +646,35 @@ test "client auto-frames 304 response as bodyless" {
     try r.feed("HTTP/1.1 304 Not Modified\r\nContent-Length: 100\r\n\r\n");
     try expectTag(.response, try r.nextEvent());
     try expectTag(.end_of_message, try r.nextEvent());
+}
+
+test "client rejects Transfer-Encoding where response semantics forbid it" {
+    const cases = .{
+        .{ "GET", "HTTP/1.1 204 No Content\r\nTransfer-Encoding: chunked\r\n\r\n" },
+        .{ "CONNECT", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" },
+    };
+    inline for (cases) |case| {
+        var r = Reader.init(t.allocator, .client);
+        defer r.deinit();
+        r.setRequestMethod(case[0]);
+        try r.feed(case[1]);
+        try t.expectError(error.InvalidFraming, r.nextEvent());
+    }
+}
+
+test "client permits chunked metadata on HEAD and 304" {
+    const cases = .{
+        .{ "HEAD", "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" },
+        .{ "GET", "HTTP/1.1 304 Not Modified\r\nTransfer-Encoding: chunked\r\n\r\n" },
+    };
+    inline for (cases) |case| {
+        var r = Reader.init(t.allocator, .client);
+        defer r.deinit();
+        r.setRequestMethod(case[0]);
+        try r.feed(case[1]);
+        try expectTag(.response, try r.nextEvent());
+        try expectTag(.end_of_message, try r.nextEvent());
+    }
 }
 
 test "client continues through informational response" {

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -13,6 +13,7 @@ const headers_mod = @import("headers.zig");
 
 const Header = events.Header;
 const responseIsBodyless = framing.responseIsBodyless;
+const responseForbidsTransferEncoding = framing.responseForbidsTransferEncoding;
 const eqIgnoreCase = ascii.eqIgnoreCase;
 const trimOws = ascii.trimOws;
 
@@ -178,6 +179,11 @@ fn validateHeaders(hdrs: []const Header) WriteError!void {
     try validateFraming(hdrs);
 }
 
+fn hasHeader(hdrs: []const Header, name: []const u8) bool {
+    for (hdrs) |h| if (eqIgnoreCase(h.name, name)) return true;
+    return false;
+}
+
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
 /// smuggling guards. A message carrying both Transfer-Encoding and
 /// Content-Length, multiple Transfer-Encoding fields, unsupported TE codings, or
@@ -276,6 +282,7 @@ pub const Writer = struct {
     /// is bodyless (RFC 9112 6.3), so the caller never tracks framing by hand.
     pub fn sendResponse(self: *Writer, version: []const u8, status: u16, reason: []const u8, hdrs: []const Header, request_method: []const u8) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
+        if (responseForbidsTransferEncoding(request_method, status) and hasHeader(hdrs, "transfer-encoding")) return error.InvalidField;
         try self.writeStatusLine(try normalizeVersion(version), status, reason, hdrs);
         if (responseIsBodyless(request_method, status)) {
             self.state = .body_none;
@@ -297,6 +304,7 @@ pub const Writer = struct {
     pub fn sendInformational(self: *Writer, status: u16, hdrs: []const Header) WriteError!void {
         if (self.state != .idle) return error.MessageNotEnded;
         if (status / 100 != 1 or status == 101) return error.InvalidField;
+        if (hasHeader(hdrs, "transfer-encoding")) return error.InvalidField;
         try self.writeStatusLine("1.1", status, reasonPhrase(status), hdrs);
     }
 
@@ -514,11 +522,42 @@ test "HEAD response is bodyless despite Content-Length" {
     try t.expectEqualStrings("HTTP/1.1 200 OK\r\nContent-Length: 1234\r\n\r\n", wr.pending());
 }
 
-test "bodyless response rejects unsupported transfer-encoding" {
+test "responses forbidden to carry Transfer-Encoding reject it before output" {
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    const cases = .{
+        .{ @as(u16, 103), "Early Hints", "GET" },
+        .{ @as(u16, 204), "No Content", "GET" },
+        .{ @as(u16, 200), "OK", "CONNECT" },
+    };
+    inline for (cases) |case| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        try t.expectError(error.InvalidField, wr.sendResponse("1.1", case[0], case[1], &hdrs, case[2]));
+        try t.expectEqualStrings("", wr.pending());
+    }
+}
+
+test "informational response rejects Transfer-Encoding before output" {
     var wr = Writer.init(t.allocator);
     defer wr.deinit();
-    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "gzip" }};
-    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 304, "Not Modified", &hdrs, "GET"));
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    try t.expectError(error.InvalidField, wr.sendInformational(103, &hdrs));
+    try t.expectEqualStrings("", wr.pending());
+}
+
+test "HEAD and 304 may describe chunked coding of corresponding body" {
+    const hdrs = [_]Header{.{ .name = "Transfer-Encoding", .value = "chunked" }};
+    const cases = .{
+        .{ @as(u16, 200), "OK", "HEAD" },
+        .{ @as(u16, 304), "Not Modified", "GET" },
+    };
+    inline for (cases) |case| {
+        var wr = Writer.init(t.allocator);
+        defer wr.deinit();
+        try wr.sendResponse("1.1", case[0], case[1], &hdrs, case[2]);
+        try t.expectError(error.NoBodyAllowed, wr.sendData("x"));
+        try wr.endMessage(&.{});
+    }
 }
 
 test "data before head is rejected" {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -110,6 +110,34 @@ def test_response_parsing() -> None:
     assert conn.next_event().data == b"xyz"
 
 
+@pytest.mark.parametrize(
+    ("method", "status", "reason"),
+    [(b"GET", 204, b"No Content"), (b"CONNECT", 200, b"OK")],
+)
+def test_response_rejects_forbidden_transfer_encoding(method: bytes, status: int, reason: bytes) -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(method, b"/", b"1.1", [(b"Host", b"example.com")])
+    conn.end_message()
+    conn.data_to_send()
+    conn.receive_data(b"HTTP/1.1 " + str(status).encode() + b" " + reason + b"\r\nTransfer-Encoding: chunked\r\n\r\n")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
+@pytest.mark.parametrize(
+    ("method", "status", "reason"),
+    [(b"HEAD", 200, b"OK"), (b"GET", 304, b"Not Modified")],
+)
+def test_bodyless_response_accepts_chunked_metadata(method: bytes, status: int, reason: bytes) -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(method, b"/", b"1.1", [(b"Host", b"example.com")])
+    conn.end_message()
+    conn.data_to_send()
+    conn.receive_data(b"HTTP/1.1 " + str(status).encode() + b" " + reason + b"\r\nTransfer-Encoding: chunked\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
 def test_response_until_close() -> None:
     conn = zttp.Connection(zttp.CLIENT)
     conn.receive_data(b"HTTP/1.1 200 OK\r\nServer: z\r\n\r\nbody here")

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -97,6 +97,27 @@ def test_chunked_response() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("status", "method"),
+    [(103, b"GET"), (204, b"GET"), (200, b"CONNECT")],
+)
+def test_transfer_encoding_rejected_when_response_forbids_it(status: int, method: bytes) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    if method != b"GET":
+        conn.receive_data(method + b" / HTTP/1.1\r\nHost: x\r\n\r\n")
+        list(drain(conn))
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_response(status, [(b"Transfer-Encoding", b"chunked")])
+    assert conn.data_to_send() == b""
+
+
+def test_informational_rejects_transfer_encoding() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_informational(103, [(b"Transfer-Encoding", b"chunked")])
+    assert conn.data_to_send() == b""
+
+
 def test_chunked_with_trailers() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.send_response(200, [(b"Transfer-Encoding", b"chunked")])


### PR DESCRIPTION
## Bug

RFC 9112 §6.1 forbids `Transfer-Encoding` on:

- any `1xx` response,
- `204 No Content`,
- successful `CONNECT` responses.

zttp selected bodyless framing for these responses but did not reject the
header. On send it emitted the illegal head and only prohibited body data. On
receive it surfaced the response followed by `EndOfMessage`; chunk bytes sent
by a malformed peer could remain buffered and be reinterpreted as the next
message.

This was found while reviewing #170 but is independent of non-chunked transfer
codings. #170 is being closed: zttp 0.0.17 already follows h11's narrow policy
and rejects every send-side `Transfer-Encoding` except literal `chunked`.

## Fix

Add one method/status rule shared by read and write:

```text
1xx                     reject Transfer-Encoding
204                     reject Transfer-Encoding
2xx to CONNECT          reject Transfer-Encoding
HEAD                    allow literal chunked metadata
304                     allow literal chunked metadata
```

`bodyless` and `forbid_transfer_encoding` are deliberately separate framing
options. HEAD and 304 have no body but RFC 9110 permits them to describe the
coding that would have applied to the corresponding representation.

The writer checks before `writeStatusLine`, including `send_informational`, so a
local error leaves pending output empty. The reader sets the explicit framing
option from the remembered request method and status before `frameBody()`.

## Scope

This does **not** add support for `gzip, chunked`. The h11-compatible zttp 0.0.17
policy remains unchanged:

- `Transfer-Encoding: chunked` — accepted;
- `gzip`, `gzip, chunked`, multiple TE field-lines — `LocalProtocolError`;
- TE + Content-Length — `LocalProtocolError`.

## Tests

- Core send/receive tests for 1xx, 204, and successful CONNECT.
- No partial writer output after rejection.
- Public Python regressions for 204 and CONNECT receive, all writer contexts,
  and `send_informational`.
- HEAD and 304 permitted metadata cases in core and public tests.

Validation:

- `zig build test`: **813/813**
- `scripts/check`: clean
- `scripts/test`: **315 passed**, one optional interop skip
- coverage: **100.00%**
- `scripts/docs`: strict build clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject `Transfer-Encoding` on responses where it’s forbidden by RFC 9112 (1xx, 204, and successful CONNECT) to prevent invalid headers and chunk bytes being misread as a new message.

- **Bug Fixes**
  - Add a shared rule and framing flag to reject `Transfer-Encoding` on 1xx/204/2xx-to-CONNECT in both reader and writer.
  - Writer checks before writing the status line and in `send_informational`, ensuring no partial output on error.
  - Reader sets the forbid flag from request method/status before framing and rejects invalid TE early.
  - Allow `HEAD` and `304` to carry literal `chunked` metadata (no body) as permitted by RFC 9110.
  - Policy unchanged: only literal `chunked` is accepted; non-chunked codings and TE + Content-Length remain rejected.

<sup>Written for commit 18d9b4747bc46b68031aba2f2723ce88ba23cce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced HTTP rules that forbid `Transfer-Encoding` on informational responses, `204 No Content`, and successful `CONNECT` responses.
  - Invalid headers are now rejected before any response data is sent.
  - Preserved support for `Transfer-Encoding` metadata on `HEAD` and `304 Not Modified` responses, while preventing response bodies where required.
  - Improved client-side detection of invalid response framing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->