### PR TITLE
Intern the QUERY method

### DIFF
--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -487,7 +487,7 @@ const INTERNED_VALUES = [_][]const u8{
 // The request/status line draws from even smaller fixed sets: the standard
 // methods, the two HTTP/1.x versions, and the stock reason phrases. Same deal -
 // one PyBytes each at module init, returned on an exact-bytes match.
-const INTERNED_METHODS = [_][]const u8{ "GET", "POST", "HEAD", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH" };
+const INTERNED_METHODS = [_][]const u8{ "GET", "POST", "HEAD", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "QUERY" };
 const INTERNED_VERSIONS = [_][]const u8{ "1.1", "1.0" };
 const INTERNED_REASONS = [_][]const u8{
     "OK",

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -246,6 +246,33 @@ def test_garbage_after_complete_message_raises_on_next_cycle() -> None:
         drain_all(conn)
 
 
+def test_query_carries_a_body() -> None:
+    events = parse_request(b"QUERY /search HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\nhello")
+    req = events[0]
+    assert isinstance(req, zttp.Request)
+    assert req.method == b"QUERY"
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"hello"
+    assert isinstance(events[-1], zttp.EndOfMessage)
+
+
+def test_query_response_is_not_bodyless() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"QUERY", b"/search", b"1.1", [(b"Host", b"example.com")])
+    conn.receive_data(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nabc")
+    events = list(drain(conn))
+    assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"abc"
+
+
+def test_standard_methods_are_interned() -> None:
+    def method_of(raw: bytes) -> bytes:
+        req = parse_request(raw + b" / HTTP/1.1\r\nHost: x\r\n\r\n")[0]
+        assert isinstance(req, zttp.Request)
+        return req.method
+
+    assert method_of(b"QUERY") is method_of(b"QUERY")
+    assert method_of(b"FROBNICATE") is not method_of(b"FROBNICATE")
+
+
 def test_large_body_round_trips_unchanged() -> None:
     body = bytes(range(256)) * 256  # 64KB, every byte value
     raw = b"POST /up HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -261,6 +261,7 @@ def test_query_response_is_not_bodyless() -> None:
     conn.receive_data(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nabc")
     events = list(drain(conn))
     assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"abc"
+    assert isinstance(events[-1], zttp.EndOfMessage)
 
 
 def test_standard_methods_are_interned() -> None:


### PR DESCRIPTION
QUERY already round-tripped over HTTP/1.1, HTTP/2, and HTTP/3 - methods are parsed as generic RFC 9110 tokens rather than matched against an allowlist, and the bodyless rules in `src/core/h1/framing.zig` key off `HEAD`/`CONNECT`/status, so a QUERY response is already framed as carrying a body.

The gap was `INTERNED_METHODS`: QUERY missed the cached-`PyBytes` fast path and allocated a fresh object per request. Adding it there leaves unknown methods on the allocating path.

Tests cover the body semantics, the non-bodyless response, and the interning.

Not included: `Accept-Query` (RFC 9694) is an ordinary field and needs no parser work - happy to add it to `INTERNED_NAMES` if wanted. QUERY response caching keys on the request body, but `zttp` is sans-io and has no cache layer.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interns the HTTP QUERY method to use the cached PyBytes fast path and avoid per-request allocations. Adds tests confirming QUERY carries a body, responses are not treated as bodyless and terminate with an end-of-message event, and that standard methods are interned while unknown methods still allocate.

<sup>Written for commit a888c37e1f80f6aa251400c5330069a6d963ce7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the HTTP `QUERY` method.
  * `QUERY` requests can now carry a body correctly.
  * `QUERY` responses are handled as regular responses rather than being treated as bodyless.
* **Tests**
  * Added coverage to verify `QUERY` request/response behavior and confirm consistent method identity for standard methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->