### PR TITLE
Reflect a locally sent Connection: close in should_close()

### DIFF
--- a/docs/usage/real-server.md
+++ b/docs/usage/real-server.md
@@ -48,8 +48,9 @@ async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> 
             conn.end_message()
             writer.write(conn.data_to_send())
             await writer.drain()
-            # should_close() reflects the request just parsed (Connection: close, or
-            # HTTP/1.0 without keep-alive); start_next_cycle() clears it, so ask now.
+            # should_close() reflects the request just parsed and the response just
+            # sent (Connection: close, or HTTP/1.0 without keep-alive);
+            # start_next_cycle() clears it, so ask now.
             if conn.should_close():
                 return
             conn.start_next_cycle()  # reuse the connection for the next request
@@ -140,10 +141,12 @@ await writer.drain()
 ## Keep-alive
 
 HTTP/1.1 reuses the connection, so the outer loop serves request after request.
-zttp works out from the head whether the peer wants to close, so you don't scan
-headers - you ask. `should_close()` is only meaningful once the request head is
-parsed, and `start_next_cycle()` resets it, so check it **after** you've answered
-and before you cycle:
+zttp works out from the head whether the connection must close, so you don't scan
+headers - you ask. It covers both directions: the request the peer sent, and the
+response you serialized, so an application that answers with `Connection: close`
+is honored without you re-reading its headers. `should_close()` is only meaningful
+once the request head is parsed, and `start_next_cycle()` resets it, so check it
+**after** you've answered and before you cycle:
 
 ```python
 while True:

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -23,9 +23,10 @@ fn listContains(value: []const u8, token: []const u8) bool {
     return false;
 }
 
-/// Whether the request `Connection` header carries the `close` token, across any
-/// number of `Connection` field-lines.
-fn connectionHasClose(headers: []const Header) bool {
+/// Whether a `Connection` header carries the `close` token, across any number of
+/// `Connection` field-lines. Applies to a head in either direction: a peer's, or
+/// one the caller is about to serialize.
+pub fn connectionHasClose(headers: []const Header) bool {
     for (headers) |h| {
         if (eqIgnoreCase(h.name, "connection") and listContains(h.value, "close")) return true;
     }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2040,6 +2040,7 @@ fn send_request(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obje
             w.sendRequest(mb, tb, vb, hdrs.headers) catch |err| return raiseWrite(err);
             e.rememberMethod(mb);
             e.reader.setRequestMethod(mb);
+            if (core.h1.connection.connectionHasClose(hdrs.headers)) e.should_close = true;
             return py.none();
         },
         .h3 => |*e| {
@@ -2092,6 +2093,7 @@ fn send_response(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obj
     const rb = core.h1.writer.reasonPhrase(@intCast(status));
     const w = e.ensureWriter() orelse return null;
     w.sendResponse("1.1", @intCast(status), rb, header_slice, e.method()) catch |err| return raiseWrite(err);
+    if (core.h1.connection.connectionHasClose(header_slice)) e.should_close = true;
     return py.none();
 }
 
@@ -2477,7 +2479,7 @@ var h1_methods = [_]py.MethodDef{
     .{ .ml_name = "send_informational", .ml_meth = send_informational, .ml_flags = c.METH_VARARGS, .ml_doc = "Serialize an interim 1xx response: send_informational(status, headers=None). The real response still follows on the same cycle." },
     .{ .ml_name = "send_data", .ml_meth = send_data, .ml_flags = c.METH_O, .ml_doc = "Serialize a run of body bytes (chunk-framed if the head was chunked)." },
     .{ .ml_name = "end_message", .ml_meth = end_message, .ml_flags = c.METH_VARARGS, .ml_doc = "End the outgoing message: end_message(trailers=None)." },
-    .{ .ml_name = "should_close", .ml_meth = should_close, .ml_flags = c.METH_NOARGS, .ml_doc = "Whether the connection must close after the last request/response (Connection: close / HTTP/1.0 / close-delimited response)." },
+    .{ .ml_name = "should_close", .ml_meth = should_close, .ml_flags = c.METH_NOARGS, .ml_doc = "Whether the connection must close after the last request/response (Connection: close / HTTP/1.0 / close-delimited response). Covers both the head parsed from the peer and one serialized locally." },
     .{ .ml_name = "upgrade", .ml_meth = upgrade, .ml_flags = c.METH_NOARGS, .ml_doc = "The last request's Upgrade value if it asked to upgrade (Connection: upgrade), else None." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1894,7 +1894,10 @@ fn next_event(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
                         if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
                     } else e.upgrade_obj = null;
                 } else if (ev == .response) {
-                    e.should_close = e.reader.shouldClose();
+                    // A client that asked to close already set the flag when it
+                    // serialized the request; the peer omitting the token from
+                    // its response does not take that back.
+                    e.should_close = e.should_close or e.reader.shouldClose();
                 }
                 return events_obj.fromH1Event(ev);
             }
@@ -2040,7 +2043,7 @@ fn send_request(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obje
             w.sendRequest(mb, tb, vb, hdrs.headers) catch |err| return raiseWrite(err);
             e.rememberMethod(mb);
             e.reader.setRequestMethod(mb);
-            if (core.h1.connection.connectionHasClose(hdrs.headers)) e.should_close = true;
+            if (core.h1.connection.shouldClose(vb, hdrs.headers)) e.should_close = true;
             return py.none();
         },
         .h3 => |*e| {

--- a/tests/test_connection_signals.py
+++ b/tests/test_connection_signals.py
@@ -110,6 +110,51 @@ def test_rejected_response_does_not_set_should_close() -> None:
     assert conn.data_to_send() == b""
 
 
+def test_rejected_response_preserves_an_existing_close() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_response(204, [(b"transfer-encoding", b"chunked")])
+    assert conn.should_close() is True
+
+
+def test_should_close_for_locally_sent_1_0_request() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"GET", b"/", b"1.0", [(b"Host", b"x")])
+    conn.end_message()
+    assert conn.should_close() is True
+
+
+def test_locally_sent_1_0_request_with_keep_alive_stays_open() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"GET", b"/", b"1.0", [(b"Host", b"x"), (b"Connection", b"keep-alive")])
+    conn.end_message()
+    assert conn.should_close() is False
+
+
+def test_locally_sent_request_close_survives_a_response_without_close() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"GET", b"/", b"1.1", [(b"Host", b"x"), (b"Connection", b"close")])
+    conn.end_message()
+    conn.receive_data(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert conn.should_close() is True
+
+
+def test_locally_sent_request_close_does_not_leak_into_the_next_cycle() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"GET", b"/a", b"1.1", [(b"Host", b"x"), (b"Connection", b"close")])
+    conn.end_message()
+    conn.receive_data(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    list(drain(conn))
+    assert conn.should_close() is True
+    conn.start_next_cycle()
+    conn.send_request(b"GET", b"/b", b"1.1", [(b"Host", b"x")])
+    conn.end_message()
+    conn.receive_data(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Response)
+    assert conn.should_close() is False
+
+
 def test_upgrade_websocket() -> None:
     conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n")
     assert conn.upgrade() == b"websocket"

--- a/tests/test_connection_signals.py
+++ b/tests/test_connection_signals.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 import zttp
 from tests.conftest import drain
 
@@ -59,6 +61,53 @@ def test_client_should_close_for_close_delimited_response() -> None:
     conn.receive_data(b"HTTP/1.1 200 OK\r\n\r\nbody")
     assert isinstance(conn.next_event(), zttp.Response)
     assert conn.should_close() is True
+
+
+def _respond(*headers: tuple[bytes, bytes]) -> zttp.Connection:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    assert conn.should_close() is False
+    conn.send_response(200, [(b"content-length", b"0"), *headers])
+    conn.end_message()
+    return conn
+
+
+def test_should_close_for_locally_sent_response_close() -> None:
+    assert _respond((b"connection", b"close")).should_close() is True
+
+
+def test_should_close_for_locally_sent_response_token_in_list() -> None:
+    assert _respond((b"connection", b"keep-alive, close")).should_close() is True
+
+
+def test_should_close_for_locally_sent_response_is_case_insensitive() -> None:
+    assert _respond((b"Connection", b"CLOSE")).should_close() is True
+
+
+def test_locally_sent_response_without_close_stays_open() -> None:
+    assert _respond((b"connection", b"keep-alive")).should_close() is False
+    assert _respond().should_close() is False
+
+
+def test_should_close_for_locally_sent_request_close() -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.send_request(b"GET", b"/", b"1.1", [(b"Host", b"x"), (b"Connection", b"close")])
+    conn.end_message()
+    assert conn.should_close() is True
+
+
+def test_peer_close_survives_a_response_without_close() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+    conn.send_response(200, [(b"content-length", b"0")])
+    conn.end_message()
+    assert conn.should_close() is True
+
+
+def test_rejected_response_does_not_set_should_close() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    with pytest.raises(zttp.LocalProtocolError):
+        conn.send_response(204, [(b"transfer-encoding", b"chunked"), (b"connection", b"close")])
+    assert conn.should_close() is False
+    assert conn.data_to_send() == b""
 
 
 def test_upgrade_websocket() -> None:


### PR DESCRIPTION
Found while reviewing [uvicorn#2979](https://github.com/Kludex/uvicorn/pull/2979), which needs a local `_has_token` helper to re-scan the response headers its ASGI app returned.

## Bug

`should_close()` was computed only from the reader, so it saw the head parsed from the peer and never one serialized locally. zttp would emit `connection: close` and still report `False`:

```python
conn.send_response(200, [(b"content-length", b"0"), (b"connection", b"close")])
conn.end_message()
conn.should_close()   # False, despite `connection: close` on the wire
```

Any integrator not separately re-parsing its own outbound headers keeps the connection alive after the application asked to close it. h11 has no such gap - it transitions to `MUST_CLOSE` from the sent headers, which is what `h11_impl.py` checks.

## Fix

Fold an outbound `Connection: close` into the flag on both `send_request` and `send_response`, reusing the `connectionHasClose` helper the reader already uses - so the comma-separated token list and case-insensitive matching come for free.

The check runs after the write succeeds, so a rejected head (which serializes nothing) leaves the flag untouched. An inbound `close` still survives a response that carries no `close`, and `start_next_cycle()` clears it as before.

This lets uvicorn drop `_has_token` and call `should_close()` instead.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach `should_close()` to reflect a locally sent Connection: close on outgoing requests and responses, and to carry a locally requested close through the peer’s response. This aligns with h11 and lets `zttp` close without re-scanning headers.

- **Bug Fixes**
  - Set the flag after successful `send_request`/`send_response` (includes HTTP/1.0 unless `keep-alive`).
  - Preserve a local or peer `close` even if the response omits it; reset on `start_next_cycle()`.
  - Ignore rejected writes; case-insensitive and token-in-list matching; made `connectionHasClose()` public; docs and tests updated.

<sup>Written for commit 094cd0e0b735159e3454ba1588e5dd96ded93572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/1.1 connection-close signaling for both locally sent requests and responses.
  * Ensures peer-requested closure persists correctly across subsequent exchanges, while locally set closure does not leak into the next cycle.
  * Prevents rejected locally sent responses from incorrectly marking the connection for closure.
  * Respects HTTP/1.0 close-by-default behavior (and keeps alive when specified).

* **Documentation**
  * Refined keep-alive guidance and clarified when connection-close decisions are evaluated.

* **Tests**
  * Expanded automated coverage for close/keep-alive token parsing, case-insensitivity, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->