### PR TITLE
Build free-threaded wheels for Windows

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -83,6 +83,10 @@ pub fn build(b: *std.Build) void {
     // Windows only: the import library to link, e.g. "python314" (no extension).
     const py_lib = b.option([]const u8, "python-lib", "CPython import library name (Windows)") orelse
         b.graph.environ_map.get("HATCH_ZIG_PYTHON_LIB");
+    // The free-threaded ABI tag ("cp314t") is carried in the extension suffix -
+    // e.g. "_zttp.cp314t-win_amd64.pyd" - which every backend must get right for
+    // the module to be importable at all.
+    const free_threaded = std.mem.indexOf(u8, ext_suffix, "t-") != null;
 
     const core_mod = b.createModule(.{
         .root_source_file = b.path("src/core/root.zig"),
@@ -103,6 +107,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     translate.addIncludePath(.{ .cwd_relative = py_include });
+    // A free-threaded interpreter's headers describe a different ABI (extra
+    // PyObject fields, different inline bodies). POSIX pyconfig.h defines
+    // Py_GIL_DISABLED itself, but PC/pyconfig.h only ever *tests* it and relies
+    // on the build backend to pass it - so on Windows the translation silently
+    // targets the GIL ABI unless we define it here.
+    if (free_threaded and target.result.os.tag == .windows) translate.defineCMacro("Py_GIL_DISABLED", "1");
 
     const fixer = b.addExecutable(.{
         .name = "fix_cimport",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,11 +112,10 @@ include = ["zttp", "src", "tools", "build.zig"]
 # cp314t/cp315t are the free-threaded builds. The extension does NOT yet declare
 # Py_MOD_GIL_NOT_USED (it isn't synchronized - #151), so on these interpreters
 # CPython re-enables the compatibility GIL at import; the wheels still load and run.
-# Windows is skipped for the free-threaded builds: their pyconfig.h doesn't self-define
-# Py_GIL_DISABLED (POSIX does), so translate-c would compile against the GIL ABI and
-# mismatch (still true in 3.15's PC/pyconfig.h).
+# Their Windows variants need Py_GIL_DISABLED passed to translate-c by build.zig -
+# PC/pyconfig.h only tests the macro, where POSIX pyconfig.h defines it itself.
 build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-* cp315-* cp315t-*"
-skip = "*_i686 *-pp* cp314t-win* cp315t-win*"
+skip = "*_i686 *-pp*"
 # 3.15 is in beta; cibuildwheel only offers it behind this flag. Drop it (and cut
 # a release to rebuild the cp315 wheels) once 3.15.0 final is out - the C ABI is
 # only guaranteed stable from rc1 onward.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,14 +108,15 @@ include = ["zttp", "src", "tools", "build.zig"]
 [tool.cibuildwheel]
 # Zig comes from the `ziglang` build requirement (build isolation), so no system
 # toolchain install is needed. The sans-IO core has no OS dependencies, so it
-# builds for glibc, musl, macOS, and Windows alike. Skip only 32-bit and PyPy.
+# builds for glibc, musl, macOS, and Windows alike. PyPy is excluded by the cp-only
+# `build` list; `skip` only has to drop 32-bit.
 # cp314t/cp315t are the free-threaded builds. The extension does NOT yet declare
 # Py_MOD_GIL_NOT_USED (it isn't synchronized - #151), so on these interpreters
 # CPython re-enables the compatibility GIL at import; the wheels still load and run.
 # Their Windows variants need Py_GIL_DISABLED passed to translate-c by build.zig -
 # PC/pyconfig.h only tests the macro, where POSIX pyconfig.h defines it itself.
 build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-* cp315-* cp315t-*"
-skip = "*_i686 *-pp*"
+skip = "*_i686"
 # 3.15 is in beta; cibuildwheel only offers it behind this flag. Drop it (and cut
 # a release to rebuild the cp315 wheels) once 3.15.0 final is out - the C ABI is
 # only guaranteed stable from rc1 onward.


### PR DESCRIPTION
zttp shipped no `cp314t-win`/`cp315t-win` wheels: they were skipped because Winds `PC/pyconfig.h` never defines `Py_GIL_DISABLED` itself, so `translate-c` compiled the C-API against the GIL ABI and produced a mismatched `.pyd`.

That is not a Zig limitation - it is [documented CPython behavior](https://github.com/python/cpython/blob/v3.14.0/PC/pyconfig.h#L97-L107). `PC/pyconfig.h` only ever *tests* the macro and leaves defining it to the build backend:

> We undefine if it was set to zero because all later checks are `#ifdef`. Note that non-Windows builds do not do this, and so every effort should be made to avoid defining the variable at all when not desired.

## Fix

Define `Py_GIL_DISABLED` for `translate-c` when building a free-threaded Windows extension, then drop `cp314t-win*`/`cp315t-win*` from the cibuildwheel skip list.

Free-threadedness is detected from the extension suffix (`.cp314t-win_amd64.pyd`), which the backend must already get right for the module to be importable. The link side needed no change: `hatch-ziglang` appends `abiflags`, so it already resolves `python314t.lib`.

## Verification

Local coverage is partial - the failure mode this fixes is Windows-only, so **CI on this PR is the real test**. What I could check locally:

- A `cp314t` wheel builds and imports on free-threaded 3.14 (macOS), full suite 328 passed.
- No change on GIL builds: the define is gated on both free-threading and Windows.
- The suffix heuristic was checked against every real `EXT_SUFFIX` form (win/linux/macos, t and non-t).

Unchanged: the extension still does not declare `Py_MOD_GIL_NOT_USED` (#151), so CPython re-enables the compatibility GIL at import. These wheels load and run correctly but do not yet give free-threaded parallelism.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build free-threaded Windows wheels by defining the free-threaded ABI during translate-c. Enables `cp314t-win` and `cp315t-win` to build and import; GIL builds are unchanged.

- **Bug Fixes**
  - Define `Py_GIL_DISABLED` in build.zig when the extension suffix has `t` and the target is Windows to avoid an ABI mismatch.
  - Remove `cp314t-win*`/`cp315t-win*` from the `cibuildwheel` skip list in `pyproject.toml`.
  - Drop the dead PyPy skip pattern; the `build` matrix already excludes PyPy.
  - Note: the module still does not declare `Py_MOD_GIL_NOT_USED`, so the compatibility GIL is enabled at import.

<sup>Written for commit 2f415b472084c80a664acedb20ea6bf0a7efbb4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for building with free-threaded Python interpreters on Windows.
  - Enabled Windows build coverage for free-threaded Python 3.14 and 3.15 variants.

- **Bug Fixes**
  - Corrected Windows build configuration so free-threaded Python extensions target the appropriate ABI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->