### PR TITLE
Require hatch-ziglang 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@
 # invokes the native compiler, so a future version resolved from a lower bound
 # could execute unreviewed code into the wheels the publish job trusts. The
 # compiler (ziglang) is likewise pinned. Bump both deliberately.
-requires = ["hatchling", "hatch-vcs", "hatch-ziglang==0.2.0", "ziglang==0.16.0"]
+requires = ["hatchling", "hatch-vcs", "hatch-ziglang==0.2.1", "ziglang==0.16.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Unblocks the free-threaded Windows wheels enabled in #174, whose build is currently failing on `main`:

```
error: unable to find dynamic system library 'python314' using strategy 'paths_first'
searched: ...\python-freethreaded.3.14.5\tools\libs\python314.lib
```

The free-threaded install ships `python314t.lib`. [hatch-ziglang 0.2.1](https://github.com/Kludex/hatch-ziglang/releases/tag/v0.2.1) derives that `t` from `abi_thread` instead of `abiflags`, which is empty on Windows because there is no `sys.abiflags` there.

#174 supplied the other half (`Py_GIL_DISABLED` for `translate-c`); that was necessary but not sufficient - the link step still asked for the wrong library.

Windows CI on this PR does not build wheels (`publish.yml` runs on `main`/tags only), so the real check is the Publish run once this lands.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `hatch-ziglang` to 0.2.1 to fix Windows free-threaded builds by linking against `python314t.lib` instead of `python314.lib`. This unblocks the wheels introduced in #174.

- **Dependencies**
  - Update `hatch-ziglang` to `0.2.1`, which derives the `t` suffix from `abi_thread` on Windows, resolving the “unable to find ... python314.lib” link error.

<sup>Written for commit 14bbb4114fe9475070b72d60c2ec1cb56b033b65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling to a newer compatible version.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->