### PR TITLE
Apply H1 buffer limits consistently

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -113,6 +113,16 @@ pub const Reader = struct {
         self.trailer_ranges.deinit(self.gpa);
     }
 
+    /// Reject input that would push unconsumed bytes past `max_buffer`, whether
+    /// the bytes are copied into `buf` or retained by a wrapper fast path.
+    pub fn checkBufferLimit(self: *const Reader, data_len: usize) ParseError!void {
+        if (self.limits.max_buffer == 0) return;
+        const unconsumed = self.buf.items.len - self.consumed;
+        if (unconsumed > self.limits.max_buffer or data_len > self.limits.max_buffer - unconsumed) {
+            return error.MessageTooLong;
+        }
+    }
+
     /// Append received bytes. An empty slice signals end of input (peer close).
     /// Rejects input that would push the unconsumed buffer past `max_buffer`,
     /// bounding peer-forced memory and compaction cost.
@@ -122,10 +132,7 @@ pub const Reader = struct {
             return;
         }
         if (self.eof_seen) return error.ProtocolError;
-        if (self.limits.max_buffer != 0) {
-            const unconsumed = self.buf.items.len - self.consumed;
-            if (unconsumed + data.len > self.limits.max_buffer) return error.MessageTooLong;
-        }
+        try self.checkBufferLimit(data.len);
         self.buf.appendSlice(self.gpa, data) catch return error.MessageTooLong;
     }
 

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -113,13 +113,22 @@ pub const Reader = struct {
         self.trailer_ranges.deinit(self.gpa);
     }
 
-    /// Reject input that would push unconsumed bytes past `max_buffer`, whether
-    /// the bytes are copied into `buf` or retained by a wrapper fast path.
-    pub fn checkBufferLimit(self: *const Reader, data_len: usize) ParseError!void {
+    /// Poison the connection with `e`. Feed and parse failures share this
+    /// transition so every later operation re-raises the original error.
+    fn fail(self: *Reader, e: ParseError) ParseError {
+        self.state = .failed;
+        self.failed_with = e;
+        return e;
+    }
+
+    /// Reject and latch input that would push unconsumed bytes past
+    /// `max_buffer`, whether copied into `buf` or retained by a wrapper fast path.
+    pub fn checkBufferLimit(self: *Reader, data_len: usize) ParseError!void {
+        if (self.state == .failed) return self.failed_with;
         if (self.limits.max_buffer == 0) return;
         const unconsumed = self.buf.items.len - self.consumed;
         if (unconsumed > self.limits.max_buffer or data_len > self.limits.max_buffer - unconsumed) {
-            return error.MessageTooLong;
+            return self.fail(error.MessageTooLong);
         }
     }
 
@@ -127,13 +136,14 @@ pub const Reader = struct {
     /// Rejects input that would push the unconsumed buffer past `max_buffer`,
     /// bounding peer-forced memory and compaction cost.
     pub fn feed(self: *Reader, data: []const u8) ParseError!void {
+        if (self.state == .failed) return self.failed_with;
         if (data.len == 0) {
             self.eof_seen = true;
             return;
         }
-        if (self.eof_seen) return error.ProtocolError;
+        if (self.eof_seen) return self.fail(error.ProtocolError);
         try self.checkBufferLimit(data.len);
-        self.buf.appendSlice(self.gpa, data) catch return error.MessageTooLong;
+        self.buf.appendSlice(self.gpa, data) catch return self.fail(error.MessageTooLong);
     }
 
     /// Remember the method the client just sent, so the reader frames the
@@ -231,11 +241,7 @@ pub const Reader = struct {
     /// h11 does), so a desynchronized stream can never be silently re-parsed.
     pub fn nextEvent(self: *Reader) ParseError!Event {
         if (self.state == .failed) return self.failed_with;
-        return self.dispatch() catch |e| {
-            self.state = .failed;
-            self.failed_with = e;
-            return e;
-        };
+        return self.dispatch() catch |e| self.fail(e);
     }
 
     fn dispatch(self: *Reader) ParseError!Event {
@@ -862,6 +868,10 @@ test "feed rejects input past max_buffer" {
     defer r.deinit();
     const big = "Z" ** 2048;
     try t.expectError(error.MessageTooLong, r.feed(big));
+    try t.expectError(error.MessageTooLong, r.feed("GET / HTTP/1.1\r\n\r\n"));
+    try t.expectError(error.MessageTooLong, r.nextEvent());
+    r.reset();
+    try t.expectError(error.MessageTooLong, r.nextEvent());
 }
 
 test "feed rejects data after EOF" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -180,7 +180,8 @@ const H1Engine = struct {
         return w;
     }
 
-    fn stash(self: *H1Engine, obj: py.Object, rest: []const u8) void {
+    fn stash(self: *H1Engine, obj: py.Object, rest: []const u8) core.errors.ParseError!void {
+        try self.reader.checkBufferLimit(rest.len);
         py.incref(obj);
         self.pending_obj = obj;
         self.pending = rest;
@@ -215,13 +216,13 @@ const H1Engine = struct {
         if (data.len > 0 and self.reader.eofSeen()) return exceptions.raiseParse(error.ProtocolError);
         if (data.len > 0 and self.reader.backlogEmpty()) {
             if (self.reader.bodyLengthRemaining() != null) {
-                self.stash(obj, data);
+                self.stash(obj, data) catch |err| return exceptions.raiseParse(err);
                 return py.none();
             }
             if (data.len >= head_split_min_feed and self.reader.atMessageStart()) {
                 if (core.h1.reader.findHeadEnd(data)) |head_end| {
                     self.reader.feed(data[0..head_end]) catch |err| return exceptions.raiseParse(err);
-                    if (head_end < data.len) self.stash(obj, data[head_end..]);
+                    if (head_end < data.len) self.stash(obj, data[head_end..]) catch |err| return exceptions.raiseParse(err);
                     return py.none();
                 }
             }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -221,6 +221,7 @@ const H1Engine = struct {
             }
             if (data.len >= head_split_min_feed and self.reader.atMessageStart()) {
                 if (core.h1.reader.findHeadEnd(data)) |head_end| {
+                    self.reader.checkBufferLimit(data.len) catch |err| return exceptions.raiseParse(err);
                     self.reader.feed(data[0..head_end]) catch |err| return exceptions.raiseParse(err);
                     if (head_end < data.len) self.stash(obj, data[head_end..]) catch |err| return exceptions.raiseParse(err);
                     return py.none();

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -177,6 +177,10 @@ def test_oversized_feed_raises_remote_protocol_error() -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.RemoteProtocolError):
         conn.receive_data(b"Z" * (9 * 1024 * 1024))
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(b"GET / HTTP/1.1\r\n\r\n")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
 
 
 def test_content_length_fast_path_respects_max_buffer_on_single_feed() -> None:
@@ -185,6 +189,10 @@ def test_content_length_fast_path_respects_max_buffer_on_single_feed() -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.RemoteProtocolError):
         conn.receive_data(raw)
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(b"GET / HTTP/1.1\r\n\r\n")
 
 
 def test_content_length_fast_path_respects_max_buffer_on_later_body_feed() -> None:
@@ -194,6 +202,10 @@ def test_content_length_fast_path_respects_max_buffer_on_later_body_feed() -> No
     assert isinstance(conn.next_event(), zttp.Request)
     with pytest.raises(zttp.RemoteProtocolError):
         conn.receive_data(body)
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(b"A")
 
 
 def test_response_reason_with_control_byte_rejected() -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -179,6 +179,23 @@ def test_oversized_feed_raises_remote_protocol_error() -> None:
         conn.receive_data(b"Z" * (9 * 1024 * 1024))
 
 
+def test_content_length_fast_path_respects_max_buffer_on_single_feed() -> None:
+    body = b"A" * (9 * 1024 * 1024)
+    raw = b"POST / HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(raw)
+
+
+def test_content_length_fast_path_respects_max_buffer_on_later_body_feed() -> None:
+    body = b"A" * (9 * 1024 * 1024)
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_data(body)
+
+
 def test_response_reason_with_control_byte_rejected() -> None:
     conn = zttp.Connection(zttp.CLIENT)
     conn.receive_data(b"HTTP/1.1 200 O\x00K\r\nContent-Length: 0\r\n\r\n")


### PR DESCRIPTION
## Summary

- share the H1 unconsumed-input limit check between buffered and retained input paths
- apply the same accounting to the Content-Length single-copy path
- cover combined head/body feeds and later body feeds with regression tests

## Why

The Content-Length fast path retains its input outside the reader's owned buffer. Keeping its input accounting aligned with the regular feed path makes `max_buffer` behavior consistent regardless of which path handles the bytes.

## Validation

- `zig build test`
- `scripts/test tests/test_security.py -q`
- `scripts/test -q` (332 passed, 1 optional HTTP/3 interop test skipped because `qh3` is not installed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces H1 `max_buffer` across buffered reads and the Content-Length fast path, and makes feed/parse failures terminal. Oversized input now always triggers and keeps raising `zttp.RemoteProtocolError`.

- **Bug Fixes**
  - Centralized the unconsumed-bytes check in `Reader.checkBufferLimit` and used it in `feed`, the head/body split path, and the fast path.
  - Added `Reader.fail` to latch errors; `feed` and `nextEvent` now re-raise the original parse error.
  - Enforced the limit when stashing retained bytes in Python `H1Engine` and propagated failures; added tests for oversized single-feed and later-body feeds, plus error latching.

<sup>Written for commit 1a932d5995124a24d83302e858e1f2002495d026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enforcement of maximum HTTP input buffer limits.
  * Oversized HTTP request bodies now consistently raise a protocol error, whether received initially or in subsequent data.

* **Tests**
  * Added regression coverage for oversized bodies declared with `Content-Length`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->