### PR TITLE
Reuse received bytes for HTTP/1 bodies

### DIFF
--- a/benchmarks/body_ownership.py
+++ b/benchmarks/body_ownership.py
@@ -1,0 +1,152 @@
+"""Measure HTTP/1 request-body delivery across realistic read sizes.
+
+The request head is delivered separately, as it normally is once an ASGI server
+starts an application after parsing the head. Body pieces are immutable ``bytes``
+objects like those passed by ``asyncio.Protocol.data_received``. Both parsers
+surface every body span and message completion; the benchmark verifies the same
+body length before timing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import statistics
+import time
+from collections.abc import Callable
+
+import httptools
+
+import zttp
+
+Runner = Callable[[int], None]
+
+
+def positive_int(raw: str) -> int:
+    value = int(raw)
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return value
+
+
+def pieces_of(size: int, fragment: int | None) -> list[bytes]:
+    body = b"x" * size
+    if fragment is None:
+        return [body]
+    return [body[offset : offset + fragment] for offset in range(0, size, fragment)]
+
+
+def request_head(size: int) -> bytes:
+    return (
+        b"POST /upload HTTP/1.1\r\n"
+        b"Host: files.example.com\r\n"
+        b"Content-Type: application/octet-stream\r\n"
+        b"Content-Length: " + str(size).encode() + b"\r\n\r\n"
+    )
+
+
+def make_zttp(size: int, fragment: int | None) -> Runner:
+    head = request_head(size)
+    pieces = pieces_of(size, fragment)
+    Connection, SERVER = zttp.Connection, zttp.SERVER
+    Request, Data, EndOfMessage = zttp.Request, zttp.Data, zttp.EndOfMessage
+
+    def run(iterations: int) -> None:
+        seen = 0
+        for _ in range(iterations):
+            conn = Connection(SERVER)
+            conn.receive_data(head)
+            if not isinstance(conn.next_event(), Request):
+                raise AssertionError("missing request")
+            for piece in pieces:
+                conn.receive_data(piece)
+                event = conn.next_event()
+                if not isinstance(event, Data):
+                    raise AssertionError("missing data")
+                seen += len(event.data)
+            if not isinstance(conn.next_event(), EndOfMessage):
+                raise AssertionError("missing end of message")
+        if seen != iterations * size:
+            raise AssertionError("body length differs")
+
+    return run
+
+
+class HttptoolsProtocol:
+    __slots__ = ("complete", "seen")
+
+    def __init__(self) -> None:
+        self.seen = 0
+        self.complete = False
+
+    def on_body(self, body: bytes) -> None:
+        self.seen += len(body)
+
+    def on_message_complete(self) -> None:
+        self.complete = True
+
+
+def make_httptools(size: int, fragment: int | None) -> Runner:
+    head = request_head(size)
+    pieces = pieces_of(size, fragment)
+
+    def run(iterations: int) -> None:
+        seen = 0
+        for _ in range(iterations):
+            protocol = HttptoolsProtocol()
+            parser = httptools.HttpRequestParser(protocol)
+            parser.feed_data(head)
+            for piece in pieces:
+                parser.feed_data(piece)
+            if not protocol.complete or protocol.seen != size:
+                raise AssertionError("body differs")
+            seen += protocol.seen
+        if seen != iterations * size:
+            raise AssertionError("body length differs")
+
+    return run
+
+
+def timed(run: Runner, iterations: int) -> float:
+    gc.collect()
+    gc.disable()
+    try:
+        started = time.perf_counter()
+        run(iterations)
+        return iterations / (time.perf_counter() - started)
+    finally:
+        gc.enable()
+
+
+def benchmark(name: str, size: int, fragment: int | None, iterations: int, repeats: int) -> None:
+    runners = {"zttp": make_zttp(size, fragment), "httptools": make_httptools(size, fragment)}
+    samples = {label: [] for label in runners}
+    for run in runners.values():
+        run(max(1, iterations // 20))
+    for _ in range(repeats):
+        for label, run in runners.items():
+            samples[label].append(timed(run, iterations))
+
+    medians = {label: statistics.median(values) for label, values in samples.items()}
+    print(
+        f"{name:<24} {medians['zttp']:>12,.0f} {medians['httptools']:>12,.0f} "
+        f"{medians['zttp'] / medians['httptools']:>8.2f}x"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=positive_int, default=20_000)
+    parser.add_argument("--repeats", type=positive_int, default=11)
+    args = parser.parse_args()
+
+    print(f"{'workload':<24} {'zttp req/s':>12} {'httptools':>12} {'ratio':>9}")
+    benchmark("64B body", 64, None, args.iterations, args.repeats)
+    benchmark("1KiB body", 1024, None, args.iterations, args.repeats)
+    benchmark("16KiB body", 16 * 1024, None, args.iterations, args.repeats)
+    benchmark("16KiB in MTU reads", 16 * 1024, 1448, max(1, args.iterations // 4), args.repeats)
+    benchmark("1MiB body", 1024 * 1024, None, max(1, args.iterations // 20), args.repeats)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/body_ownership.py
+++ b/benchmarks/body_ownership.py
@@ -1,10 +1,12 @@
-"""Measure HTTP/1 request-body delivery across realistic read sizes.
+"""Measure Uvicorn-shaped HTTP/1 request-body delivery.
 
 The request head is delivered separately, as it normally is once an ASGI server
 starts an application after parsing the head. Body pieces are immutable ``bytes``
-objects like those passed by ``asyncio.Protocol.data_received``. Both parsers
-surface every body span and message completion; the benchmark verifies the same
-body length before timing.
+objects like those passed by ``asyncio.Protocol.data_received``. Like Uvicorn's
+httptools protocol, each parser accumulates callback/event bodies in a
+``bytearray`` and materializes ``bytes`` for ASGI delivery. This keeps the
+zero-copy parser improvement in a production-shaped path instead of timing a
+reference handoff against a body-sized copy in isolation.
 """
 
 from __future__ import annotations
@@ -58,14 +60,17 @@ def make_zttp(size: int, fragment: int | None) -> Runner:
             conn.receive_data(head)
             if not isinstance(conn.next_event(), Request):
                 raise AssertionError("missing request")
+            buffered = bytearray()
             for piece in pieces:
                 conn.receive_data(piece)
                 event = conn.next_event()
                 if not isinstance(event, Data):
                     raise AssertionError("missing data")
-                seen += len(event.data)
+                buffered += event.data
             if not isinstance(conn.next_event(), EndOfMessage):
                 raise AssertionError("missing end of message")
+            delivered = bytes(buffered)
+            seen += len(delivered)
         if seen != iterations * size:
             raise AssertionError("body length differs")
 
@@ -73,14 +78,14 @@ def make_zttp(size: int, fragment: int | None) -> Runner:
 
 
 class HttptoolsProtocol:
-    __slots__ = ("complete", "seen")
+    __slots__ = ("body", "complete")
 
     def __init__(self) -> None:
-        self.seen = 0
+        self.body = bytearray()
         self.complete = False
 
     def on_body(self, body: bytes) -> None:
-        self.seen += len(body)
+        self.body += body
 
     def on_message_complete(self) -> None:
         self.complete = True
@@ -98,9 +103,10 @@ def make_httptools(size: int, fragment: int | None) -> Runner:
             parser.feed_data(head)
             for piece in pieces:
                 parser.feed_data(piece)
-            if not protocol.complete or protocol.seen != size:
+            if not protocol.complete:
                 raise AssertionError("body differs")
-            seen += protocol.seen
+            delivered = bytes(protocol.body)
+            seen += len(delivered)
         if seen != iterations * size:
             raise AssertionError("body length differs")
 
@@ -123,8 +129,11 @@ def benchmark(name: str, size: int, fragment: int | None, iterations: int, repea
     samples = {label: [] for label in runners}
     for run in runners.values():
         run(max(1, iterations // 20))
-    for _ in range(repeats):
-        for label, run in runners.items():
+    labels = tuple(runners)
+    for repeat in range(repeats):
+        order = labels if repeat % 2 == 0 else labels[::-1]
+        for label in order:
+            run = runners[label]
             samples[label].append(timed(run, iterations))
 
     medians = {label: statistics.median(values) for label, values in samples.items()}
@@ -140,7 +149,7 @@ def main() -> None:
     parser.add_argument("--repeats", type=positive_int, default=11)
     args = parser.parse_args()
 
-    print(f"{'workload':<24} {'zttp req/s':>12} {'httptools':>12} {'ratio':>9}")
+    print(f"{'workload':<24} {'zttp ASGI/s':>12} {'httptools':>12} {'ratio':>9}")
     benchmark("64B body", 64, None, args.iterations, args.repeats)
     benchmark("1KiB body", 1024, None, args.iterations, args.repeats)
     benchmark("16KiB body", 16 * 1024, None, args.iterations, args.repeats)

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -211,6 +211,11 @@ const H1Engine = struct {
     /// itself when a sizeable body follows.
     const head_split_min_feed = 1024;
 
+    /// Retaining the caller's bytes object avoids a body-sized allocation and
+    /// copy, but an extra reference is marginally dearer for tiny spans. Keep
+    /// those on the existing copy path.
+    const retain_body_min = 512;
+
     fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
         if (!self.flushPending()) return null;
         if (data.len > 0 and self.reader.eofSeen()) return exceptions.raiseParse(error.ProtocolError);
@@ -1862,10 +1867,19 @@ fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
                 if (ev == .need_data and e.pending_obj != null) {
                     if (e.reader.backlogEmpty()) {
                         if (e.reader.bodyLengthRemaining()) |rem| {
-                            // Materialise body bytes straight from the stashed
-                            // buffer - the one copy - and account for them.
+                            // Deliver body bytes straight from the stashed
+                            // buffer and account for them.
                             const take: usize = @intCast(@min(rem, @as(u64, e.pending.len)));
-                            const out = events_obj.fromH1Event(.{ .data = .{ .data = e.pending[0..take] } });
+                            const can_retain = if (take >= H1Engine.retain_body_min) blk: {
+                                const owned = py.asBytes(e.pending_obj).?;
+                                break :blk take == e.pending.len and
+                                    e.pending.ptr == owned.ptr and
+                                    e.pending.len == owned.len;
+                            } else false;
+                            const out = if (can_retain)
+                                events_obj.makeH1DataFromBytes(e.pending_obj)
+                            else
+                                events_obj.fromH1Event(.{ .data = .{ .data = e.pending[0..take] } });
                             if (out == null) return null;
                             e.reader.skipBodyLength(take);
                             e.pending = e.pending[take..];

--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -1099,6 +1099,18 @@ fn makeData(d: events.Data) py.Object {
     return o;
 }
 
+/// Build an HTTP/1 Data event by retaining the exact immutable bytes object the
+/// caller fed. The connection has already established that the whole object is
+/// the emitted body span, so no slice or copy is needed.
+pub fn makeH1DataFromBytes(data_obj: py.Object) py.Object {
+    const o = py.allocInstance(data_type);
+    if (o == null) return null;
+    const s: *DataObject = @ptrCast(o);
+    s.data = py.newRef(data_obj);
+    s.stream_id = 0;
+    return o;
+}
+
 fn makeEom(e: events.EndOfMessage) py.Object {
     const o = py.allocInstance(end_of_message_type);
     if (o == null) return null;

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -159,6 +159,46 @@ def test_body_split_across_feeds() -> None:
     assert isinstance(conn.next_event(), zttp.EndOfMessage)
 
 
+def test_large_content_length_body_reuses_exact_received_bytes() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    body = b"x" * 1024
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: x\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+
+    conn.receive_data(body)
+    event = conn.next_event()
+    assert isinstance(event, zttp.Data)
+    assert event.data is body
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
+def test_small_content_length_body_keeps_copy_path() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    body = b"small body"
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\n")
+    assert isinstance(conn.next_event(), zttp.Request)
+
+    conn.receive_data(body)
+    event = conn.next_event()
+    assert isinstance(event, zttp.Data)
+    assert event.data == body
+    assert event.data is not body
+
+
+def test_body_buffer_with_pipelined_bytes_keeps_copy_path() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    body = b"x" * 1024
+    conn.receive_data(
+        b"POST / HTTP/1.1\r\nContent-Length: 1024\r\n\r\n" + body + b"GET /next HTTP/1.1\r\nHost: x\r\n\r\n"
+    )
+    assert isinstance(conn.next_event(), zttp.Request)
+    event = conn.next_event()
+    assert isinstance(event, zttp.Data)
+    assert event.data == body
+    assert event.data is not body
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
 def test_keep_alive_two_requests() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET /a HTTP/1.1\r\nHost: x\r\n\r\nGET /b HTTP/1.1\r\nHost: y\r\n\r\n")

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -197,6 +197,11 @@ def test_body_buffer_with_pipelined_bytes_keeps_copy_path() -> None:
     assert event.data == body
     assert event.data is not body
     assert isinstance(conn.next_event(), zttp.EndOfMessage)
+    conn.start_next_cycle()
+    next_request = conn.next_event()
+    assert isinstance(next_request, zttp.Request)
+    assert next_request.method == b"GET"
+    assert next_request.target == b"/next"
 
 
 def test_keep_alive_two_requests() -> None:

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -109,7 +109,9 @@ class Data:
     and content-length bodies both surface the same way, already decoded.
 
     Attributes:
-        data: The body bytes, copied out of the parse buffer (safe to keep).
+        data: Owned body bytes that are safe to keep. Qualifying HTTP/1 spans
+            reuse the immutable `bytes` supplied to `receive_data()`; other
+            paths copy out of the parse buffer.
         stream_id: The stream the body belongs to (`0` on HTTP/1.1).
     """
 


### PR DESCRIPTION
## Summary

- retain an immutable `bytes` object when it exactly matches an HTTP/1 `Data` span
- keep the existing copy path for bodies below 512 bytes, combined head/body buffers, partial spans, and pipelined input
- add identity, ownership, and pipelined-delivery coverage
- document that `Data.data` is always safe to retain but may reuse the supplied HTTP/1 bytes object

This removes a body-sized allocation and memory copy when an event-loop read maps exactly to a body event. The `Data` event owns a new reference, so it remains valid independently of the connection and later reads.

## Benchmarks

Apple Silicon, CPython 3.14.3, Zig `ReleaseSafe`, httptools 0.8.0. Medians of 15 batches. Runner order alternates each batch.

The benchmark now models Uvicorn's body path: each parser's body spans are accumulated into a `bytearray`, then materialized as `bytes` for ASGI delivery. This includes the application-facing copies instead of presenting the constant-time reference handoff as end-to-end request throughput.

| Workload | `main` zttp | This PR | PR / `main` | httptools | PR / httptools |
|---|---:|---:|---:|---:|---:|
| 64 B body | 1,348,224 req/s | 1,351,610 req/s | 1.00× | 1,844,437 req/s | 0.73× |
| 1 KiB body | 1,206,507 req/s | 1,273,944 req/s | **1.06×** | 1,562,575 req/s | 0.82× |
| 16 KiB body | 525,976 req/s | 847,075 req/s | **1.61×** | 746,629 req/s | **1.13×** |
| 16 KiB in 1,448 B reads | 224,661 req/s | 254,577 req/s | **1.13×** | 252,329 req/s | **1.01×** |
| 1 MiB body | 22,253 req/s | 31,507 req/s | **1.42×** | 22,470 req/s | **1.40×** |

The previously reported 24× result measured a deliberately narrow handoff: this PR retained one preallocated 1 MiB object while `main` and httptools copied it. That result was technically reproducible but not representative of application throughput, so it is intentionally replaced by the production-shaped table above.

Run with:

```console
uv run --no-sync python benchmarks/body_ownership.py --iterations 30000 --repeats 15
```

## Validation

- `./scripts/test` — 338 passed, 1 optional qh3 interop test skipped
- benchmark verifies identical ASGI-delivered body length and message completion
