### PR TITLE
Use uv to publish distributions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,10 @@ jobs:
       url: https://test.pypi.org/project/zttp
 
     steps:
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
       - name: Download all distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -98,12 +102,12 @@ jobs:
           merge-multiple: true
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          # main is pushed repeatedly with the same dev version; don't fail when
-          # that version already exists on TestPyPI.
-          skip-existing: true
+        # main is pushed repeatedly with the same dev version, so check TestPyPI
+        # first and skip files that have already been uploaded unchanged.
+        run: >-
+          uv publish
+          --publish-url https://test.pypi.org/legacy/
+          --check-url https://test.pypi.org/simple/
 
   publish:
     name: Publish to PyPI
@@ -119,6 +123,10 @@ jobs:
       url: https://pypi.org/project/zttp
 
     steps:
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
+
       - name: Download all distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -127,10 +135,4 @@ jobs:
           merge-multiple: true
 
       - name: Publish to PyPI
-        # SHA-pinned like every other action: this step runs with id-token: write
-        # (OIDC trusted publishing to real PyPI), so a mutable ref is the highest-
-        # value supply-chain target in the repo. Current release/v1 is a composite
-        # action that builds its own container at run time - it does not resolve a
-        # per-ref image - so SHA pinning works (no "manifest unknown"). Bump with the
-        # release tag when updating.
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        run: uv publish


### PR DESCRIPTION
## Summary

- install uv in the isolated TestPyPI and PyPI publishing jobs
- publish distributions with `uv publish` using the existing OIDC trusted-publishing permissions
- preserve TestPyPI's idempotent uploads with `--check-url`

## Why

The v0.0.22 release built every wheel and the source distribution successfully, but `pypa/gh-action-pypi-publish` rejected the generated Metadata 2.5 before upload. Publishing with uv removes that extra validation layer and follows uv's documented GitHub Actions trusted-publishing flow.

## Validation

- `zizmor .github/workflows/publish.yml`
- parsed `.github/workflows/publish.yml` with Ruby's YAML parser
- `git diff --check`

Failed release job: https://github.com/Kludex/zttp/actions/runs/31617258530/job/94187161625


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish distributions with `uv publish` instead of `pypa/gh-action-pypi-publish` to align with OIDC trusted publishing and avoid the action’s pre-upload metadata validation that blocked v0.0.22.

- Add `astral-sh/setup-uv` (SHA pinned, cache disabled) in TestPyPI and PyPI jobs.
- Replace action usage with `run: uv publish`; trusted publishing continues via existing `id-token: write`.
- Preserve TestPyPI idempotency with `--check-url https://test.pypi.org/simple/` and `--publish-url https://test.pypi.org/legacy/`.
- Keep build and artifact download steps unchanged; no secrets or workflow permissions changes required.

<sup>Written for commit 9ac2525ba2b8ba0e99ff58ebafc2f3e2c4cfb2b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

