### PR TITLE
Fuse HTTP/1 header semantics

### DIFF
--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -8,6 +8,8 @@
 const std = @import("std");
 const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
+const framing = @import("framing.zig");
+const ParseError = @import("../errors.zig").ParseError;
 
 const Header = events.Header;
 const eqIgnoreCase = ascii.eqIgnoreCase;
@@ -22,6 +24,49 @@ fn listContains(value: []const u8, token: []const u8) bool {
     }
     return false;
 }
+
+/// All semantics derived from an HTTP/1 head while its fields are parsed. The
+/// reader feeds each header exactly once, then finalizes framing and connection
+/// state after parsing the request/status line.
+pub const HeadSemantics = struct {
+    framing: framing.Analyzer = .{},
+    has_close: bool = false,
+    has_keep_alive: bool = false,
+    has_upgrade_token: bool = false,
+    upgrade_value: ?[]const u8 = null,
+    expect_continue: bool = false,
+
+    pub fn add(self: *HeadSemantics, h: Header) ParseError!void {
+        try self.framing.add(h);
+
+        if (eqIgnoreCase(h.name, "connection")) {
+            var it = std.mem.splitScalar(u8, h.value, ',');
+            while (it.next()) |raw| {
+                const token = trimOws(raw);
+                if (eqIgnoreCase(token, "close")) {
+                    self.has_close = true;
+                } else if (eqIgnoreCase(token, "keep-alive")) {
+                    self.has_keep_alive = true;
+                } else if (eqIgnoreCase(token, "upgrade")) {
+                    self.has_upgrade_token = true;
+                }
+            }
+        } else if (eqIgnoreCase(h.name, "upgrade")) {
+            self.upgrade_value = h.value;
+        } else if (eqIgnoreCase(h.name, "expect") and eqIgnoreCase(trimOws(h.value), "100-continue")) {
+            self.expect_continue = true;
+        }
+    }
+
+    pub fn shouldClose(self: HeadSemantics, http_version: []const u8) bool {
+        if (self.has_close) return true;
+        return eqIgnoreCase(http_version, "1.0") and !self.has_keep_alive;
+    }
+
+    pub fn upgrade(self: HeadSemantics) ?[]const u8 {
+        return if (self.has_upgrade_token) self.upgrade_value else null;
+    }
+};
 
 /// Whether a `Connection` header carries the `close` token, across any number of
 /// `Connection` field-lines. Applies to a head in either direction: a peer's, or
@@ -126,4 +171,20 @@ test "expectsContinue" {
     try t.expect(expectsContinue(&h2));
     const h3 = [_]Header{.{ .name = "Host", .value = "x" }};
     try t.expect(!expectsContinue(&h3));
+}
+
+test "head semantics collects framing and connection metadata in one pass" {
+    const headers = [_]Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Connection", .value = "keep-alive, Upgrade" },
+        .{ .name = "Upgrade", .value = "websocket" },
+        .{ .name = "Expect", .value = "100-Continue" },
+    };
+    var semantics = HeadSemantics{};
+    for (headers) |h| try semantics.add(h);
+
+    try t.expectEqual(@as(u64, 5), (try semantics.framing.finish(.{})).content_length);
+    try t.expect(!semantics.shouldClose("1.0"));
+    try t.expectEqualStrings("websocket", semantics.upgrade().?);
+    try t.expect(semantics.expect_continue);
 }

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -53,7 +53,7 @@ pub const HeadSemantics = struct {
             }
         } else if (eqIgnoreCase(h.name, "upgrade")) {
             self.upgrade_value = h.value;
-        } else if (eqIgnoreCase(h.name, "expect") and eqIgnoreCase(trimOws(h.value), "100-continue")) {
+        } else if (eqIgnoreCase(h.name, "expect") and listContains(h.value, "100-continue")) {
             self.expect_continue = true;
         }
     }
@@ -114,7 +114,7 @@ pub fn upgrade(headers: []const Header) ?[]const u8 {
 /// Whether the request carries `Expect: 100-continue` (RFC 9110 10.1.1).
 pub fn expectsContinue(headers: []const Header) bool {
     for (headers) |h| {
-        if (eqIgnoreCase(h.name, "expect") and eqIgnoreCase(trimOws(h.value), "100-continue")) return true;
+        if (eqIgnoreCase(h.name, "expect") and listContains(h.value, "100-continue")) return true;
     }
     return false;
 }
@@ -169,8 +169,10 @@ test "expectsContinue" {
     try t.expect(expectsContinue(&h));
     const h2 = [_]Header{.{ .name = "Expect", .value = "100-Continue" }};
     try t.expect(expectsContinue(&h2));
-    const h3 = [_]Header{.{ .name = "Host", .value = "x" }};
-    try t.expect(!expectsContinue(&h3));
+    const h3 = [_]Header{.{ .name = "Expect", .value = "something, 100-Continue" }};
+    try t.expect(expectsContinue(&h3));
+    const h4 = [_]Header{.{ .name = "Host", .value = "x" }};
+    try t.expect(!expectsContinue(&h4));
 }
 
 test "head semantics collects framing and connection metadata in one pass" {
@@ -178,7 +180,7 @@ test "head semantics collects framing and connection metadata in one pass" {
         .{ .name = "Content-Length", .value = "5" },
         .{ .name = "Connection", .value = "keep-alive, Upgrade" },
         .{ .name = "Upgrade", .value = "websocket" },
-        .{ .name = "Expect", .value = "100-Continue" },
+        .{ .name = "Expect", .value = "something, 100-Continue" },
     };
     var semantics = HeadSemantics{};
     for (headers) |h| try semantics.add(h);

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -97,7 +97,9 @@ pub fn shouldClose(http_version: []const u8, headers: []const Header) bool {
 
 /// The `Upgrade` header value iff the `Connection` header lists the `upgrade`
 /// token (RFC 9110 7.8); otherwise null. The integrator compares it to e.g.
-/// "websocket".
+/// "websocket". This standalone scan remains part of the public core API for
+/// integrations that receive an already-complete header slice instead of
+/// feeding fields through `HeadSemantics` while parsing.
 pub fn upgrade(headers: []const Header) ?[]const u8 {
     var has_upgrade_token = false;
     var upgrade_value: ?[]const u8 = null;
@@ -111,7 +113,9 @@ pub fn upgrade(headers: []const Header) ?[]const u8 {
     return if (has_upgrade_token) upgrade_value else null;
 }
 
-/// Whether the request carries `Expect: 100-continue` (RFC 9110 10.1.1).
+/// Whether the request carries `Expect: 100-continue` (RFC 9110 10.1.1). This
+/// standalone scan remains part of the public core API for integrations that
+/// did not build `HeadSemantics` incrementally.
 pub fn expectsContinue(headers: []const Header) bool {
     for (headers) |h| {
         if (eqIgnoreCase(h.name, "expect") and listContains(h.value, "100-continue")) return true;

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -87,43 +87,62 @@ pub const FramingOptions = struct {
     until_close_default: bool = false,
 };
 
-/// Inspect the parsed headers and return the body framing. Enforces the
-/// CL/TE conflict and duplicate-Content-Length rules.
-pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Framing {
-    var te = TransferEncoding{};
-    var has_te = false;
-    var content_length: ?u64 = null;
+/// Incrementally collect the framing fields while the caller parses the header
+/// block. Keeping this state beside the header parser lets connection-level
+/// metadata share the same pass instead of repeatedly walking the completed
+/// header list.
+pub const Analyzer = struct {
+    transfer_encoding: TransferEncoding = .{},
+    has_transfer_encoding: bool = false,
+    content_length: ?u64 = null,
 
-    for (headers) |h| {
+    pub fn add(self: *Analyzer, h: Header) ParseError!void {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
-            has_te = true;
-            te.add(h.value);
+            self.has_transfer_encoding = true;
+            self.transfer_encoding.add(h.value);
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const n = try parseContentLength(h.value);
-            if (content_length) |prev| {
-                if (prev != n) return error.InvalidFraming; // conflicting duplicates
+            if (self.content_length) |prev| {
+                if (prev != n) return error.InvalidFraming;
             }
-            content_length = n;
+            self.content_length = n;
         }
     }
 
-    // RFC 9112 6.1: if both are present, Transfer-Encoding overrides, but this
-    // is a smuggling vector - reject outright (what secure parsers do).
-    if (has_te and content_length != null) return error.InvalidFraming;
-    if (has_te and opts.forbid_transfer_encoding) return error.InvalidFraming;
-
-    if (opts.bodyless) return .none;
-
-    if (has_te) {
-        // chunked must be the sole/final coding across ALL field-lines; resolve
-        // rejects non-final or unframeable Transfer-Encodings to avoid smuggling.
-        _ = try te.resolve();
-        return .chunked;
+    /// Whether the head carries framing metadata at all. Informational
+    /// responses use this to reject Content-Length and Transfer-Encoding before
+    /// a final response is parsed.
+    pub fn hasFramingHeader(self: Analyzer) bool {
+        return self.has_transfer_encoding or self.content_length != null;
     }
-    if (content_length) |n| {
-        return if (n == 0) .none else .{ .content_length = n };
+
+    pub fn finish(self: Analyzer, opts: FramingOptions) ParseError!Framing {
+        // RFC 9112 6.1: if both are present, Transfer-Encoding overrides, but
+        // this is a smuggling vector - reject outright (what secure parsers do).
+        if (self.has_transfer_encoding and self.content_length != null) return error.InvalidFraming;
+        if (self.has_transfer_encoding and opts.forbid_transfer_encoding) return error.InvalidFraming;
+
+        if (opts.bodyless) return .none;
+
+        if (self.has_transfer_encoding) {
+            // chunked must be the sole/final coding across ALL field-lines;
+            // resolve rejects non-final or unframeable Transfer-Encodings.
+            _ = try self.transfer_encoding.resolve();
+            return .chunked;
+        }
+        if (self.content_length) |n| {
+            return if (n == 0) .none else .{ .content_length = n };
+        }
+        return if (opts.until_close_default) .until_close else .none;
     }
-    return if (opts.until_close_default) .until_close else .none;
+};
+
+/// Inspect the parsed headers and return the body framing. Enforces the
+/// CL/TE conflict and duplicate-Content-Length rules.
+pub fn determine(headers: []const Header, opts: FramingOptions) ParseError!Framing {
+    var analyzer = Analyzer{};
+    for (headers) |h| try analyzer.add(h);
+    return analyzer.finish(opts);
 }
 
 test "responseIsBodyless rule" {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -10,7 +10,6 @@
 
 const std = @import("std");
 const events = @import("../events.zig");
-const ascii = @import("../ascii.zig");
 const headers_mod = @import("headers.zig");
 const framing_mod = @import("framing.zig");
 const connection_mod = @import("connection.zig");
@@ -304,6 +303,7 @@ pub const Reader = struct {
         }).?;
 
         self.headers.clearRetainingCapacity();
+        var semantics = connection_mod.HeadSemantics{};
         var header_bytes: usize = 0;
         while (sc.line(self.limits.max_line, strict) catch |e| switch (e) {
             error.MessageTooLong => return error.MessageTooLong,
@@ -315,12 +315,13 @@ pub const Reader = struct {
                 return error.MessageTooLong;
             }
             const h = try headers_mod.parseHeaderLine(hl);
+            try semantics.add(h);
             self.headers.append(self.gpa, h) catch return error.MessageTooLong;
         }
 
         if (self.role == .server) {
             const rl = try headers_mod.parseRequestLine(first);
-            const framing = try framing_mod.determine(self.headers.items, .{ .until_close_default = false });
+            const framing = try semantics.framing.finish(.{ .until_close_default = false });
             const end_stream = framing == .none;
             if (end_stream) {
                 // The Request event itself completes a bodyless request. Avoid
@@ -330,8 +331,8 @@ pub const Reader = struct {
             } else {
                 self.enterBody(framing);
             }
-            self.conn_should_close = connection_mod.shouldClose(rl.http_version, self.headers.items);
-            self.conn_upgrade = connection_mod.upgrade(self.headers.items);
+            self.conn_should_close = semantics.shouldClose(rl.http_version);
+            self.conn_upgrade = semantics.upgrade();
             return .{ .request = .{
                 .method = rl.method,
                 .target = rl.target,
@@ -339,7 +340,7 @@ pub const Reader = struct {
                 .query = rl.query,
                 .http_version = rl.http_version,
                 .headers = self.headers.items,
-                .expect_continue = connection_mod.expectsContinue(self.headers.items),
+                .expect_continue = semantics.expect_continue,
                 .end_stream = end_stream,
             } };
         }
@@ -351,11 +352,7 @@ pub const Reader = struct {
             // requiring reset() or clearing the remembered request method. 1xx
             // responses cannot carry body framing fields; reject them before the
             // interim head is surfaced as trusted metadata.
-            for (self.headers.items) |h| {
-                if (ascii.eqIgnoreCase(h.name, "content-length") or ascii.eqIgnoreCase(h.name, "transfer-encoding")) {
-                    return error.InvalidFraming;
-                }
-            }
+            if (semantics.framing.hasFramingHeader()) return error.InvalidFraming;
             self.state = .head;
             return .{ .response = .{
                 .status_code = st.status_code,
@@ -365,24 +362,19 @@ pub const Reader = struct {
             } };
         }
         const method = self.request_method[0..self.request_method_len];
-        const framing = try self.frameBody(.{
+        const framing = try semantics.framing.finish(.{
             .bodyless = framing_mod.responseIsBodyless(method, st.status_code),
             .forbid_transfer_encoding = framing_mod.responseForbidsTransferEncoding(method, st.status_code),
             .until_close_default = true,
         });
-        self.conn_should_close = connection_mod.shouldClose(st.http_version, self.headers.items) or framing == .until_close;
+        self.enterBody(framing);
+        self.conn_should_close = semantics.shouldClose(st.http_version) or framing == .until_close;
         return .{ .response = .{
             .status_code = st.status_code,
             .reason = st.reason,
             .http_version = st.http_version,
             .headers = self.headers.items,
         } };
-    }
-
-    fn frameBody(self: *Reader, opts: framing_mod.FramingOptions) ParseError!Framing {
-        const framing = try framing_mod.determine(self.headers.items, opts);
-        self.enterBody(framing);
-        return framing;
     }
 
     fn enterBody(self: *Reader, f: Framing) void {


### PR DESCRIPTION
## Summary

- collect HTTP/1 framing, connection, upgrade, and expectation semantics while headers are already being parsed
- expose an incremental framing analyzer and reuse the accumulated result in both server-request and client-response handling
- remove the repeated post-parse header scans

Besides avoiding redundant work, this keeps the rules that describe one message head together instead of spreading them across several lookup passes.

## Benchmark

Full Uvicorn keep-alive request/response cycles, measured on arm64 macOS with Python 3.14.3. Each value is the median of 15 isolated runs of 30,000 cycles after a 2,000-cycle warmup; run order was rotated between zttp `main`, this PR, the later stack revisions, and httptools 0.8.0. Higher is better.

This is the first PR in the stack, so its previous revision is `main`.

| Workload | This PR req/s | `main` req/s | vs previous / `main` | httptools req/s | vs httptools |
|---|---:|---:|---:|---:|---:|
| tiny | 218,505 | 217,115 | +0.6% | 213,876 | +2.2% |
| API | 189,617 | 189,827 | -0.1% | 176,657 | +7.3% |
| Chrome | 150,939 | 149,947 | +0.7% | 139,469 | +8.2% |
| proxied | 141,342 | 140,462 | +0.6% | 131,194 | +7.7% |
| response headers | 167,084 | 166,699 | +0.2% | 116,660 | +43.2% |

The API result is effectively neutral; the larger request heads show about a 0.6–0.7% gain.

## Validation

- `zig build test`
- `./scripts/check`
- `./scripts/test` (338 passed, 1 optional qh3 test skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fuses HTTP/1 header parsing to collect framing, connection, upgrade, and Expect semantics in one pass, removing post-parse scans and documenting retained standalone scans for integrations. Old code re-scanned headers for CL/TE, Connection, Upgrade, and Expect; new code accumulates once during parse and rejects 1xx with a single framing-header check.

- Introduces connection.HeadSemantics: tracks an incremental framing analyzer, Connection tokens (close/keep-alive/upgrade), Upgrade value, and `Expect: 100-continue` from comma-separated lists.
- Reader feeds each header once, then uses semantics.framing.finish(...), semantics.shouldClose(version), semantics.upgrade(), and semantics.expect_continue; replaces 1xx CL/TE scan with semantics.framing.hasFramingHeader().
- Keeps framing.determine(...) as a thin wrapper over the analyzer and enforces CL/TE conflicts and duplicate Content-Length rules.
- Documents that standalone connection.upgrade(...) and expectsContinue(...) scans remain public for consumers that parse into a complete header slice. No migration required.

<sup>Written for commit f943766134673790e5a1d906212635d1bf64e8da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/1 header processing and framing validation.
  * More reliably handles connection-close, keep-alive, protocol upgrades, and `Expect: 100-continue`.
  * Detects conflicting `Content-Length` values during request and response parsing.
  * Preserves correct HTTP/1.0 connection behavior and informational response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->