### PR TITLE
Pack HeaderBlock into one allocation

### DIFF
--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -49,13 +49,13 @@ const EndOfMessageObject = extern struct {
     stream_id: c_ulonglong,
 };
 
-/// Lazy header container. One Python bytes object owns all header bytes; compact
-/// native ranges describe the fields. Python bytes/tuples are created only for
-/// fields the caller actually touches.
+/// Lazy header container. Compact native ranges and their bytes live together
+/// in the variable-sized tail of this one Python object. Python bytes/tuples
+/// are created only for fields the caller actually touches.
 const HeaderBlockObject = extern struct {
     ob_base: c.PyVarObject,
-    data: py.Object,
     count: usize,
+    data_len: usize,
 };
 
 const HeaderRange = extern struct {
@@ -687,8 +687,10 @@ fn headerRanges(self: *HeaderBlockObject) [*]HeaderRange {
     return @ptrFromInt(@intFromPtr(self) + @sizeOf(HeaderBlockObject));
 }
 
-fn headerData(self: *HeaderBlockObject) ?[]const u8 {
-    return py.asBytes(self.data);
+fn headerData(self: *HeaderBlockObject) []const u8 {
+    const start = @intFromPtr(headerRanges(self)) + self.count * @sizeOf(HeaderRange);
+    const ptr: [*]const u8 = @ptrFromInt(start);
+    return ptr[0..self.data_len];
 }
 
 fn headerName(data: []const u8, range: HeaderRange) []const u8 {
@@ -725,7 +727,7 @@ fn lowerHeaderName(name: []const u8) py.Object {
 }
 
 fn headerPair(self: *HeaderBlockObject, idx: usize, lowercase_name: bool) py.Object {
-    const data = headerData(self) orelse return null;
+    const data = headerData(self);
     const range = headerRanges(self)[idx];
     const name_bytes = headerName(data, range);
     const value_bytes = headerValue(data, range);
@@ -765,23 +767,24 @@ fn materializeHeaderBlock(self: *HeaderBlockObject, lowercase_names: bool) py.Ob
 }
 
 fn buildHeaderBlock(hdrs: []const events.Header) py.Object {
-    const tp: [*c]c.PyTypeObject = @ptrCast(header_block_type);
-    const obj = tp.*.tp_alloc.?(tp, @intCast(hdrs.len));
-    if (obj == null) return null;
-    const self: *HeaderBlockObject = @ptrCast(obj);
-    self.data = null;
-    self.count = hdrs.len;
-
     var total: usize = 0;
     for (hdrs) |h| total += h.name.len + h.value.len;
-    const data_obj = c.PyBytes_FromStringAndSize(null, @intCast(total));
-    if (data_obj == null) {
-        py.decref(obj);
-        return null;
-    }
-    self.data = data_obj;
-    const dst: [*]u8 = @ptrCast(c.PyBytes_AsString(data_obj));
+
+    // tp_alloc sizes variable objects in HeaderRange units. Reserve enough
+    // trailing units for the real ranges followed immediately by packed bytes;
+    // at most one range unit is padding.
+    const unit = @sizeOf(HeaderRange);
+    const data_units = (total + unit - 1) / unit;
+    const allocation_units = hdrs.len + data_units;
+    const tp: [*c]c.PyTypeObject = @ptrCast(header_block_type);
+    const obj = tp.*.tp_alloc.?(tp, @intCast(allocation_units));
+    if (obj == null) return null;
+    const self: *HeaderBlockObject = @ptrCast(obj);
+    self.count = hdrs.len;
+    self.data_len = total;
+
     const ranges = headerRanges(self);
+    const dst: [*]u8 = @ptrFromInt(@intFromPtr(ranges) + hdrs.len * unit);
     var offset: usize = 0;
     for (hdrs, 0..) |h, i| {
         const name_offset = offset;
@@ -864,7 +867,7 @@ fn headerBlockGet(obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object 
     if (c.PyArg_ParseTuple(args, "O|O", &name_obj, &default_obj) == 0) return null;
     const wanted = py.asBytes(name_obj) orelse return null;
     const wanted_hash = headerHash(wanted);
-    const data = headerData(self) orelse return null;
+    const data = headerData(self);
     for (headerRanges(self)[0..self.count]) |range| {
         if (range.hash == wanted_hash and headerNameEql(headerName(data, range), wanted)) {
             const value = headerValue(data, range);
@@ -878,7 +881,7 @@ fn headerBlockGetAll(obj: ?*c.PyObject, name_obj: ?*c.PyObject) callconv(.c) py.
     const self: *HeaderBlockObject = @ptrCast(obj.?);
     const wanted = py.asBytes(name_obj) orelse return null;
     const wanted_hash = headerHash(wanted);
-    const data = headerData(self) orelse return null;
+    const data = headerData(self);
     var count: usize = 0;
     for (headerRanges(self)[0..self.count]) |range| {
         if (range.hash == wanted_hash and headerNameEql(headerName(data, range), wanted)) count += 1;
@@ -930,9 +933,7 @@ fn headerBlockCmp(a: ?*c.PyObject, b: ?*c.PyObject, op: c_int) callconv(.c) py.O
 }
 
 fn headerBlockDealloc(obj: ?*c.PyObject) callconv(.c) void {
-    const self: *HeaderBlockObject = @ptrCast(obj.?);
-    py.xdecref(self.data);
-    py.freeInstance(@ptrCast(self));
+    py.freeInstance(obj.?);
 }
 
 fn headerBlockNew(_: ?*c.PyTypeObject, _: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {


### PR DESCRIPTION
## Summary

- store `HeaderBlock`'s native ranges and packed header bytes in the variable-sized Python object allocation
- remove the separate Python `bytes` allocation and reference-counted `data` member
- keep all existing lazy decoding and buffer-lifetime behavior

The resulting object is simpler: one allocation owns the complete immutable header block, and deallocation no longer has a second Python object to release.

## Stack

- builds on #183
- compare this PR against #183 as the previous revision, as well as `main` and httptools

## Benchmark

Full Uvicorn keep-alive request/response cycles, measured on arm64 macOS with Python 3.14.3. Each value is the median of 15 isolated runs of 30,000 cycles after a 2,000-cycle warmup; run order was rotated between all revisions and httptools 0.8.0. Higher is better.

| Workload | This PR req/s | #183 req/s | vs #183 | `main` req/s | vs `main` | httptools req/s | vs httptools |
|---|---:|---:|---:|---:|---:|---:|---:|
| tiny | 219,074 | 218,505 | +0.3% | 217,115 | +0.9% | 213,876 | +2.4% |
| API | 191,554 | 189,617 | +1.0% | 189,827 | +0.9% | 176,657 | +8.4% |
| Chrome | 151,893 | 150,939 | +0.6% | 149,947 | +1.3% | 139,469 | +8.9% |
| proxied | 141,349 | 141,342 | +0.0% | 140,462 | +0.6% | 131,194 | +7.7% |
| response headers | 167,166 | 167,084 | +0.0% | 166,699 | +0.3% | 116,660 | +43.3% |

The benefit scales with the request header block: about +1.0% for the API fixture and +0.6% for the Chrome fixture, while the cases where response work dominates are neutral.

## Validation

- `./scripts/check`
- `./scripts/test` (338 passed, 1 optional qh3 test skipped)
- focused Python 3.10 suite (65 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Packs `HeaderBlock` ranges and header bytes into one variable-sized Python allocation, removing the separate `bytes` object and refcount. This simplifies lifetime management, keeps lazy decoding, and is neutral to ~+1% on request-heavy workloads.

- Allocation: compute `total` and `data_units = ceil(total / sizeof(HeaderRange))`; call `tp_alloc` with `hdrs.len + data_units` (≤1 `HeaderRange` unit padding).
- Layout: drop `data`; add `data_len`; store bytes directly after the ranges; `headerData()` returns a non-null slice of that tail.
- Build: write name/value bytes into the tail; ranges hold offsets into it.
- Dealloc: remove decref of a `bytes` object; free the instance only.
- External API unchanged; no migration.

<sup>Written for commit 02ce8360553b36a9ffbb12e17fd6c649c4af23f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved header-block memory handling by storing header data more efficiently.
  * Reduced allocation overhead when creating and accessing header blocks.

* **Bug Fixes**
  * Improved reliability of header lookup and header-pair access by using consistently retained header data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->