### PR TITLE
Feed and parse HTTP/1 data in one call

### DIFF
--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -77,9 +77,10 @@ print(bytes(body))
 ```
 
 !!! tip
-    Each `Data` event's `.data` is a real `bytes` object, copied out of the parse
-    buffer, so it's safe to keep. You're never handed a view that the next
-    `receive_data` will overwrite.
+    Each `Data` event owns a real, immutable `bytes` object, so it's safe to
+    keep. For qualifying HTTP/1 body spans, zttp may reuse the exact `bytes`
+    passed to `receive_data()` or `receive_event()`; other paths copy out of the
+    parse buffer. You're never handed a view that a later feed will overwrite.
 
 ### Partial data
 

--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -14,6 +14,25 @@ with the send API.
 The read side is `receive_data` + `next_event`. Once bodies, chunked encoding,
 and partial data enter the picture, here's what happens.
 
+An event loop that immediately pulls after every socket read can combine those
+two extension calls with `receive_event(data)`. It returns the first event made
+available by `data`, or `NEED_DATA`; continue with `next_event()` to drain any
+additional events:
+
+```python
+import zttp
+
+
+def events_from(conn: zttp.H1Connection, data: bytes):
+    event = conn.receive_event(data)
+    while event is not zttp.NEED_DATA:
+        yield event
+        event = conn.next_event()
+```
+
+This is an HTTP/1 integration fast path. `receive_data()` and `next_event()`
+remain the general pull API and keep their existing behavior.
+
 ### Request completion
 
 When framing proves a request has no body, the `Request` arrives with

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -216,25 +216,47 @@ const H1Engine = struct {
     /// those on the existing copy path.
     const retain_body_min = 512;
 
-    fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
-        if (!self.flushPending()) return null;
-        if (data.len > 0 and self.reader.eofSeen()) return exceptions.raiseParse(error.ProtocolError);
+    fn feedData(self: *H1Engine, data: []const u8, obj: py.Object) bool {
+        if (!self.flushPending()) return false;
+        if (data.len > 0 and self.reader.eofSeen()) {
+            _ = exceptions.raiseParse(error.ProtocolError);
+            return false;
+        }
         if (data.len > 0 and self.reader.backlogEmpty()) {
             if (self.reader.bodyLengthRemaining() != null) {
-                self.stash(obj, data) catch |err| return exceptions.raiseParse(err);
-                return py.none();
+                self.stash(obj, data) catch |err| {
+                    _ = exceptions.raiseParse(err);
+                    return false;
+                };
+                return true;
             }
             if (data.len >= head_split_min_feed and self.reader.atMessageStart()) {
                 if (core.h1.reader.findHeadEnd(data)) |head_end| {
-                    self.reader.checkBufferLimit(data.len) catch |err| return exceptions.raiseParse(err);
-                    self.reader.feed(data[0..head_end]) catch |err| return exceptions.raiseParse(err);
-                    if (head_end < data.len) self.stash(obj, data[head_end..]) catch |err| return exceptions.raiseParse(err);
-                    return py.none();
+                    self.reader.checkBufferLimit(data.len) catch |err| {
+                        _ = exceptions.raiseParse(err);
+                        return false;
+                    };
+                    self.reader.feed(data[0..head_end]) catch |err| {
+                        _ = exceptions.raiseParse(err);
+                        return false;
+                    };
+                    if (head_end < data.len) self.stash(obj, data[head_end..]) catch |err| {
+                        _ = exceptions.raiseParse(err);
+                        return false;
+                    };
+                    return true;
                 }
             }
         }
-        self.reader.feed(data) catch |err| return exceptions.raiseParse(err);
-        return py.none();
+        self.reader.feed(data) catch |err| {
+            _ = exceptions.raiseParse(err);
+            return false;
+        };
+        return true;
+    }
+
+    fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
+        return if (self.feedData(data, obj)) py.none() else null;
     }
 
     fn deinit(self: *H1Engine) void {
@@ -1928,6 +1950,17 @@ fn next_event_eager_for_benchmark(self_obj: ?*c.PyObject, _: ?*c.PyObject) callc
     return nextEventImpl(self_obj, true);
 }
 
+/// Feed one HTTP/1 byte span and return its first available event in the same
+/// extension call. Callers can continue with next_event() when this did not
+/// return NEED_DATA, avoiding a container allocation on the one-event hot path.
+fn receive_event(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
+    const self: *ConnectionObject = @ptrCast(self_obj.?);
+    const bytes = py.asBytes(arg) orelse return null;
+    const engine = h1(self) orelse return null;
+    if (!engine.feedData(bytes, arg)) return null;
+    return nextEventImpl(self_obj, false);
+}
+
 /// Headers borrowed (zero-copy) from a Python sequence of (name, value) bytes
 /// pairs. Common ASGI lists fit in inline scratch storage. Exact tuple pairs of
 /// exact bytes only retain the pair when their outer list is mutable; custom
@@ -2582,6 +2615,7 @@ var base_methods = [_]py.MethodDef{
 // keep-alive / upgrade signals.
 var h1_methods = [_]py.MethodDef{
     .{ .ml_name = "receive_data", .ml_meth = receive_data, .ml_flags = c.METH_O, .ml_doc = "Append received bytes (empty bytes signals EOF)." },
+    .{ .ml_name = "receive_event", .ml_meth = receive_event, .ml_flags = c.METH_O, .ml_doc = "Feed received bytes and return the first available event, or NEED_DATA." },
     .{ .ml_name = "_next_event_eager_for_benchmark", .ml_meth = next_event_eager_for_benchmark, .ml_flags = c.METH_NOARGS, .ml_doc = "Private benchmark control for comparing the legacy eager header list." },
     .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing bytes." },
     .{ .ml_name = "start_next_cycle", .ml_meth = next_message, .ml_flags = c.METH_NOARGS, .ml_doc = "Reset to read the next message on a keep-alive connection." },

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -9,6 +9,32 @@ import zttp
 from tests.conftest import drain, drain_all, parse_request
 
 
+def test_receive_event_feeds_and_returns_first_available_http1_event() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    event = conn.receive_event(b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+
+    assert isinstance(event, zttp.Request)
+    data = conn.next_event()
+    assert isinstance(data, zttp.Data)
+    assert data.data == b"hello"
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
+def test_receive_event_returns_need_data_for_partial_http1_input() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    assert conn.receive_event(b"GET / HTTP/1.1\r\nHost:") is zttp.NEED_DATA
+    event = conn.receive_event(b" example.com\r\n\r\n")
+    assert isinstance(event, zttp.Request)
+
+
+def test_receive_event_preserves_terminal_parse_errors() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.receive_event(b"GET / HTTP/1.1\nBad header\n\n")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
 def test_simple_get() -> None:
     events = parse_request(b"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\n\r\n")
     assert len(events) == 1

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -113,8 +113,8 @@ class Data:
 
     Attributes:
         data: Owned body bytes that are safe to keep. Qualifying HTTP/1 spans
-            reuse the immutable `bytes` supplied to `receive_data()`; other
-            paths copy out of the parse buffer.
+            reuse the immutable `bytes` supplied to `receive_data()` or
+            `receive_event()`; other paths copy out of the parse buffer.
         stream_id: The stream the body belongs to (`0` on HTTP/1.1).
     """
 

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -316,6 +316,9 @@ class H1Connection(Connection):
     def receive_data(self, data: bytes, /) -> None:
         """Append received bytes to the parse buffer (empty bytes signals EOF)."""
 
+    def receive_event(self, data: bytes, /) -> Request | Response | Data | EndOfMessage | NeedData | ConnectionClosed:
+        """Feed received bytes and return the first available event, or `NEED_DATA`."""
+
     def data_to_send(self) -> bytes:
         """Return and clear the bytes queued to send."""
 


### PR DESCRIPTION
## Summary

- add `H1Connection.receive_event(data)` to feed bytes and return the first available event in one extension call
- keep `receive_data()` and `next_event()` unchanged as the general pull API
- share the native feed implementation without constructing an intermediate Python `None`
- document the event-loop integration pattern and type the new method
- preserve partial-input, body, EOF, and terminal parse-error behavior

This targets the common server loop that calls `receive_data(data)` and immediately calls `next_event()`. It removes one Python-to-extension crossing without allocating the tuple that made the earlier `receive_events(data)` prototype neutral/slower.

## Stack

- builds on #188
- the one-time header-classification prototype was measured between the two PRs and dropped: its best variant was neutral on API/Chrome and about 2% slower on the proxied workload

## Benchmark

Full Uvicorn keep-alive request/response cycles, measured on arm64 macOS with Python 3.14.3 and httptools 0.8.0. The prototype adapter passes `receive_event(data)` directly into its existing event generator; main and #188 use the current `receive_data()` + `next_event()` adapter.

Absolute values are medians of 31 isolated runs of 10,000 cycles after a 2,000-cycle warmup, with run order rotated between httptools, `main`, #188, and this PR. The incremental column is the median paired ratio from 21 adjacent runs of 20,000 cycles, which is less sensitive to shared-host scheduling drift. Higher is better.

| Workload | This PR req/s | paired vs #188 | `main` req/s | vs `main` | httptools req/s | vs httptools |
|---|---:|---:|---:|---:|---:|---:|
| tiny | 213,158 | +1.1% | 214,851 | -0.8% | 205,940 | +3.5% |
| API | 196,576 | +3.7% | 190,208 | +3.3% | 173,612 | +13.2% |
| Chrome | 145,946 | +4.1% | 140,041 | +4.2% | 128,755 | +13.4% |
| proxied | 135,748 | +1.2% | 133,700 | +1.5% | 123,041 | +10.3% |
| response headers | 151,960 | +0.5% | 145,812 | +4.2% | 100,235 | +51.6% |

The native feed-and-first-event path was also benchmarked directly against `receive_data(data); next_event()` in the same build. Its paired median improved by 2.7% tiny, 2.2% API, 0.6% Chrome, and 1.2% proxied.

## Validation

- `zig build test`
- `./scripts/check`
- `uv run --group dev --group bench pytest -q` (348 passed, 1 optional qh3 test skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Feeds HTTP/1 bytes and returns the first event in one call via `zttp.H1Connection.receive_event(data)`, removing a Python–extension boundary and an allocation on the read-then-pull hot path. The old path was `receive_data(data)` then `next_event()`; the new path allows `receive_event(data)` then `next_event()` to drain. Semantics for partial input (`NEED_DATA`), bodies, EOF, and terminal parse errors are unchanged. Clarifies `Data` ownership: events own immutable bytes; qualifying HTTP/1 body spans may reuse the input `bytes` from `receive_data()` or `receive_event()`.

- Introduces internal `feedData`; `receive_data` delegates to it; `receive_event` feeds and returns the first available event.
- Documents the fast-path loop in `docs/usage/http1.md`; updates `zttp/_zttp.pyi` docstrings on body ownership and the new API.
- Adds tests for first-event return, `NEED_DATA`, and error propagation.

**Adoption**
- No migration required.
- Event loops that pull after each read can call `receive_event(data)` and then `next_event()` to drain remaining events.
- Keep using `receive_data` + `next_event` where separate feed/pull is preferred.

<sup>Written for commit 32c6c8892b31bc66a93a63d41a02054375128b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

