### PR TITLE
Make Uvicorn benchmarks reproducible

### DIFF
--- a/benchmarks/http1.py
+++ b/benchmarks/http1.py
@@ -377,6 +377,11 @@ def extract_zttp(w: Workload) -> list[Message]:
         while (ev := conn.next_event()) is not zttp.NEED_DATA:
             if isinstance(ev, zttp.Request):
                 start, headers = ev.method, list(ev.headers)
+                if ev.end_stream:
+                    out.append((start, headers, body))
+                    start, headers, body = None, [], b""
+                    if len(out) < w.messages:
+                        conn.start_next_cycle()
             elif isinstance(ev, zttp.Response):
                 start, headers = ev.status_code, list(ev.headers)
             elif isinstance(ev, zttp.Data):

--- a/benchmarks/uvicorn.py
+++ b/benchmarks/uvicorn.py
@@ -5,7 +5,10 @@ one header tuple per ``on_header`` callback, then fills the request-line fields
 in ``on_headers_complete``.  This benchmark performs that same work for
 httptools and constructs the equivalent scope from zttp's Request event. Each
 iteration runs through request completion as Uvicorn must before dispatch. It
-also keeps the legacy eager zttp header-list path as an A/B control.
+compares zttp's split ``receive_data`` + ``next_event`` API with the combined
+``receive_event`` fast path, and keeps the legacy eager header-list path as an
+A/B control. Both fresh-connection and persistent keep-alive lifecycles are
+available.
 
 Reference implementation:
 https://github.com/Kludex/uvicorn/blob/main/uvicorn/protocols/http/httptools_impl.py
@@ -15,10 +18,15 @@ from __future__ import annotations
 
 import argparse
 import gc
+import os
+import platform
 import statistics
+import subprocess
+import sys
 import time
 import urllib.parse
 from collections.abc import Callable
+from importlib.metadata import version
 
 import httptools
 
@@ -104,15 +112,19 @@ class UvicornHttptoolsProtocol:
         self.complete = True
 
 
-def make_httptools(raw: bytes) -> Runner:
+def make_httptools(raw: bytes, *, persistent: bool) -> Runner:
     def run(iterations: int) -> None:
         scope: dict[str, object] | None = None
+        protocol = UvicornHttptoolsProtocol() if persistent else None
         for _ in range(iterations):
-            protocol = UvicornHttptoolsProtocol()
+            if protocol is None:
+                protocol = UvicornHttptoolsProtocol()
             protocol.parser.feed_data(raw)
             if not protocol.complete:
                 raise AssertionError("incomplete request")
             scope = protocol.scope
+            if not persistent:
+                protocol = None
         if scope is None:
             raise AssertionError("missing scope")
 
@@ -139,26 +151,42 @@ def scope_from_zttp(event: zttp.Request) -> dict[str, object]:
     return scope
 
 
-def make_zttp(raw: bytes, *, packed: bool) -> Runner:
+def drain_request(conn: zttp.H1Connection, event: zttp.Request) -> None:
+    if event.end_stream:
+        return
+    while True:
+        terminal = conn.next_event()
+        if isinstance(terminal, zttp.EndOfMessage):
+            return
+        if not isinstance(terminal, zttp.Data):
+            raise AssertionError("incomplete request")
+
+
+def make_zttp(raw: bytes, *, api: str, persistent: bool) -> Runner:
     Connection, SERVER = zttp.Connection, zttp.SERVER
 
     def run(iterations: int) -> None:
         scope: dict[str, object] | None = None
+        conn = Connection(SERVER) if persistent else None
         for _ in range(iterations):
-            conn = Connection(SERVER)
-            conn.receive_data(raw)
-            if packed:
-                event = conn.next_event()
+            if conn is None:
+                conn = Connection(SERVER)
+            if api == "combined":
+                event = conn.receive_event(raw)
             else:
+                conn.receive_data(raw)
+            if api == "split":
+                event = conn.next_event()
+            elif api == "eager":
                 event = getattr(conn, "_next_event_eager_for_benchmark")()
+            if not isinstance(event, zttp.Request):
+                raise AssertionError("missing request")
             scope = scope_from_zttp(event)
-            if not getattr(event, "end_stream", False):
-                while True:
-                    terminal = conn.next_event()
-                    if isinstance(terminal, zttp.EndOfMessage):
-                        break
-                    if not isinstance(terminal, zttp.Data):
-                        raise AssertionError("incomplete request")
+            drain_request(conn, event)
+            if persistent:
+                conn.start_next_cycle()
+            else:
+                conn = None
         if scope is None:
             raise AssertionError("missing scope")
 
@@ -171,19 +199,19 @@ def verify(raw: bytes) -> None:
     if not protocol.complete:
         raise AssertionError("httptools did not complete the request")
 
-    conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(raw)
-    request = conn.next_event()
-    packed_scope = scope_from_zttp(request)
-    if not getattr(request, "end_stream", False):
-        while True:
-            terminal = conn.next_event()
-            if isinstance(terminal, zttp.EndOfMessage):
-                break
-            if not isinstance(terminal, zttp.Data):
-                raise AssertionError("zttp did not complete the request")
-    if packed_scope != protocol.scope:
-        raise AssertionError(f"zttp scope differs from Uvicorn: {packed_scope!r} != {protocol.scope!r}")
+    for api in ("split", "combined"):
+        conn = zttp.Connection(zttp.SERVER)
+        if api == "combined":
+            request = conn.receive_event(raw)
+        else:
+            conn.receive_data(raw)
+            request = conn.next_event()
+        if not isinstance(request, zttp.Request):
+            raise AssertionError(f"zttp {api} API did not produce a request")
+        scope = scope_from_zttp(request)
+        drain_request(conn, request)
+        if scope != protocol.scope:
+            raise AssertionError(f"zttp {api} scope differs from Uvicorn: {scope!r} != {protocol.scope!r}")
 
 
 def timed(run: Runner, iterations: int) -> float:
@@ -205,31 +233,49 @@ def quartiles(values: list[float]) -> tuple[float, float, float]:
     return q1, median, q3
 
 
-def benchmark(name: str, raw: bytes, iterations: int, repeats: int) -> None:
+def benchmark(name: str, raw: bytes, iterations: int, repeats: int, lifecycle: str) -> None:
     verify(raw)
+    persistent = lifecycle == "keep-alive"
     runners = {
-        "httptools": make_httptools(raw),
-        "zttp eager": make_zttp(raw, packed=False),
-        "zttp packed": make_zttp(raw, packed=True),
+        "httptools": make_httptools(raw, persistent=persistent),
+        "zttp eager": make_zttp(raw, api="eager", persistent=persistent),
+        "zttp split": make_zttp(raw, api="split", persistent=persistent),
+        "zttp combined": make_zttp(raw, api="combined", persistent=persistent),
     }
     for run in runners.values():
         run(max(1, iterations // 10))
 
     samples = {label: [] for label in runners}
-    for _ in range(repeats):
-        for label, run in runners.items():
+    ordered = list(runners.items())
+    for repeat in range(repeats):
+        # Rotate the first runner so thermal/scheduler drift does not always
+        # favour the same implementation.
+        rotated = ordered[repeat % len(ordered) :] + ordered[: repeat % len(ordered)]
+        for label, run in rotated:
             samples[label].append(iterations / timed(run, iterations))
 
     rates: dict[str, float] = {}
-    print(f"\n== {name} ({len(raw)}B, {repeats} batches of {iterations:,}) ==")
+    print(f"\n== {name} / {lifecycle} ({len(raw)}B, {repeats} batches of {iterations:,}) ==")
     for label, values in samples.items():
         p25, median, p75 = quartiles(values)
         rates[label] = median
-        print(f"  {label:>11}: {median:10,.0f} scope/s  (p25-p75 {p25:,.0f}-{p75:,.0f})")
+        print(f"  {label:>13}: {median:10,.0f} scope/s  (p25-p75 {p25:,.0f}-{p75:,.0f})")
     print(
-        f"  -> packed/eager {rates['zttp packed'] / rates['zttp eager']:.2f}x; "
-        f"packed/httptools {rates['zttp packed'] / rates['httptools']:.2f}x"
+        f"  -> combined/split {rates['zttp combined'] / rates['zttp split']:.2f}x; "
+        f"combined/httptools {rates['zttp combined'] / rates['httptools']:.2f}x; "
+        f"split/eager {rates['zttp split'] / rates['zttp eager']:.2f}x"
     )
+
+
+def git_revision() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=os.path.dirname(__file__),
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
 
 
 def main() -> None:
@@ -237,11 +283,19 @@ def main() -> None:
     parser.add_argument("--iterations", type=positive_int, default=50_000)
     parser.add_argument("--repeats", type=positive_int, default=11)
     parser.add_argument("--only", choices=WORKLOADS, default=None)
+    parser.add_argument("--lifecycle", choices=("isolated", "keep-alive", "both"), default="both")
     args = parser.parse_args()
 
+    print(
+        f"CPython {sys.version.split()[0]}, zttp {version('zttp')}, httptools {version('httptools')}, "
+        f"{platform.machine()} {platform.system()}, commit {git_revision()}, "
+        f"build {os.environ.get('HATCH_ZIG_BUILD_MODE', 'unknown')}"
+    )
     workloads = WORKLOADS.items() if args.only is None else [(args.only, WORKLOADS[args.only])]
-    for name, raw in workloads:
-        benchmark(name, raw, args.iterations, args.repeats)
+    lifecycles = ("isolated", "keep-alive") if args.lifecycle == "both" else (args.lifecycle,)
+    for lifecycle in lifecycles:
+        for name, raw in workloads:
+            benchmark(name, raw, args.iterations, args.repeats, lifecycle)
 
 
 if __name__ == "__main__":

--- a/benchmarks/uvicorn.py
+++ b/benchmarks/uvicorn.py
@@ -199,13 +199,13 @@ def verify(raw: bytes) -> None:
     if not protocol.complete:
         raise AssertionError("httptools did not complete the request")
 
-    for api in ("split", "combined"):
+    for api in ("eager", "split", "combined"):
         conn = zttp.Connection(zttp.SERVER)
         if api == "combined":
             request = conn.receive_event(raw)
         else:
             conn.receive_data(raw)
-            request = conn.next_event()
+            request = getattr(conn, "_next_event_eager_for_benchmark")() if api == "eager" else conn.next_event()
         if not isinstance(request, zttp.Request):
             raise AssertionError(f"zttp {api} API did not produce a request")
         scope = scope_from_zttp(request)

--- a/scripts/bench
+++ b/scripts/bench
@@ -12,7 +12,8 @@
 
 set -x
 
-HATCH_ZIG_BUILD_MODE=ReleaseSafe uv sync --all-groups
+export HATCH_ZIG_BUILD_MODE=ReleaseSafe
+uv sync --all-groups
 
 case "$1" in
     http1 | http2 | http3 | uvicorn)

--- a/scripts/bench
+++ b/scripts/bench
@@ -8,13 +8,14 @@
 # No args runs all three with their defaults. To pass flags (e.g. --batch,
 # --repeats, or --only), target one protocol:
 #   scripts/bench http2 --only GET
+#   scripts/bench uvicorn --only api --lifecycle keep-alive
 
 set -x
 
 HATCH_ZIG_BUILD_MODE=ReleaseSafe uv sync --all-groups
 
 case "$1" in
-    http1 | http2 | http3)
+    http1 | http2 | http3 | uvicorn)
         proto="$1"
         shift
         uv run --no-sync python "benchmarks/$proto.py" "$@"
@@ -25,7 +26,7 @@ case "$1" in
         uv run --no-sync python benchmarks/http3.py
         ;;
     *)
-        echo "usage: scripts/bench [http1|http2|http3] [args...]" >&2
+        echo "usage: scripts/bench [http1|http2|http3|uvicorn] [args...]" >&2
         exit 2
         ;;
 esac

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -327,9 +327,12 @@ pub const Reader = struct {
         // previous call stopped and combines the terminator and limit scans.
         const region = self.avail();
         const scan = (try self.head_scanner.scan(region, self.limits)) orelse {
-            if (self.eof_seen and region.len == 0) {
-                self.state = .closed;
-                return .connection_closed;
+            if (self.eof_seen) {
+                if (region.len == 0) {
+                    self.state = .closed;
+                    return .connection_closed;
+                }
+                return error.ProtocolError;
             }
             return .need_data;
         };
@@ -637,6 +640,22 @@ test "partial head then complete" {
     const e = try r.nextEvent();
     try t.expectEqualStrings("GET", e.request.method);
     try t.expectEqualStrings("x", e.request.headers[0].value);
+}
+
+test "EOF during an incomplete head is a terminal protocol error" {
+    const partials = [_][]const u8{
+        "G",
+        "GET / HTTP/1.1\r\nHost: x\r\n",
+    };
+    for (partials) |partial| {
+        var r = Reader.init(t.allocator, .server);
+        defer r.deinit();
+        try r.feed(partial);
+        try expectTag(.need_data, try r.nextEvent());
+        try r.feed("");
+        try t.expectError(error.ProtocolError, r.nextEvent());
+        try t.expectError(error.ProtocolError, r.nextEvent());
+    }
 }
 
 test "split body across feeds" {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -35,6 +35,17 @@ def test_receive_event_preserves_terminal_parse_errors() -> None:
         conn.next_event()
 
 
+@pytest.mark.parametrize("partial", [b"G", b"GET / HTTP/1.1\r\nHost: x\r\n"])
+def test_eof_during_an_incomplete_head_is_a_terminal_error(partial: bytes) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    assert conn.receive_event(partial) is zttp.NEED_DATA
+    conn.receive_data(b"")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
 def test_simple_get() -> None:
     events = parse_request(b"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\n\r\n")
     assert len(events) == 1


### PR DESCRIPTION
## Summary

- benchmark the new `H1Connection.receive_event(data)` fast path separately from `receive_data(data) + next_event()`
- keep the legacy eager-header path as an A/B control
- add both fresh-connection and persistent keep-alive lifecycles
- rotate runner order between batches to spread scheduler and thermal drift
- print the Python, package, platform, commit, and build-mode metadata
- expose the Uvicorn-shaped benchmark through `scripts/bench uvicorn`

This makes the performance claims around the combined receive API reproducible from the repository. It does not change runtime code.

## Benchmark

Arm64 macOS, CPython 3.14.3, zttp 0.0.23, httptools 0.8.0, Zig `ReleaseSafe`. Values are medians of 15 isolated batches × 10,000 requests after warmup, with runner order rotated. Higher is better.

### Fresh connection per request

| Workload | `receive_event` | split API | combined / split | httptools | combined / httptools |
|---|---:|---:|---:|---:|---:|
| tiny | 818,842 | 825,318 | 0.99× | 591,139 | 1.39× |
| API | 517,134 | 516,862 | 1.00× | 363,410 | 1.42× |
| Chrome | 310,128 | 312,314 | 0.99× | 219,084 | 1.42× |
| proxied | 310,641 | 311,192 | 1.00× | 215,363 | 1.44× |

### Persistent keep-alive connection

| Workload | `receive_event` | split API | combined / split | httptools | combined / httptools |
|---|---:|---:|---:|---:|---:|
| tiny | 852,100 | 851,296 | 1.00× | 710,538 | 1.20× |
| API | 569,045 | 576,845 | 0.99× | 410,716 | 1.39× |
| Chrome | 360,897 | 361,424 | 1.00× | 283,721 | 1.27× |
| proxied | 375,959 | 378,548 | 0.99× | 281,069 | 1.34× |

The combined API is neutral within benchmark noise here. The important result of this PR is that future changes can compare both public receive shapes and both connection lifecycles using a checked-in driver.

```console
scripts/bench uvicorn --iterations 10000 --repeats 15 --lifecycle both
```

## Validation

- `scripts/check`
- smoke benchmark across both lifecycles
- full 15 × 10,000 benchmark matrix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the `uvicorn`-shaped HTTP/1 benchmark reproducible across `zttp` API shapes and connection lifecycles, and treats EOF during an incomplete request head as a terminal protocol error. Previously truncated heads could be accepted; now they raise `RemoteProtocolError` and remain terminal on subsequent polls.

- Compares `zttp` split (`receive_data` + `next_event`), combined (`receive_event`), and legacy eager-header paths against `httptools`, and verifies scope equivalence for all `zttp` APIs.
- Supports isolated and keep-alive lifecycles; drains terminal request heads and calls `start_next_cycle` where needed; rotates runner order per batch to reduce scheduler/thermal bias.
- Prints environment/build metadata (CPython, `zttp`, `httptools`, platform/arch, commit, Zig build via `HATCH_ZIG_BUILD_MODE`); exposes the benchmark via `scripts/bench uvicorn` with `--lifecycle {isolated|keep-alive|both}`.
- Runtime change: EOF during an incomplete HTTP/1 head now raises `RemoteProtocolError`; servers must close the connection as a bad request.

<sup>Written for commit 5917b2660f6dbceaac793caf593089a82b66f923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

