### PR TITLE
Reject EOF during an incomplete HTTP/1 head

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -327,9 +327,12 @@ pub const Reader = struct {
         // previous call stopped and combines the terminator and limit scans.
         const region = self.avail();
         const scan = (try self.head_scanner.scan(region, self.limits)) orelse {
-            if (self.eof_seen and region.len == 0) {
-                self.state = .closed;
-                return .connection_closed;
+            if (self.eof_seen) {
+                if (region.len == 0) {
+                    self.state = .closed;
+                    return .connection_closed;
+                }
+                return error.ProtocolError;
             }
             return .need_data;
         };
@@ -637,6 +640,22 @@ test "partial head then complete" {
     const e = try r.nextEvent();
     try t.expectEqualStrings("GET", e.request.method);
     try t.expectEqualStrings("x", e.request.headers[0].value);
+}
+
+test "EOF during an incomplete head is a terminal protocol error" {
+    const partials = [_][]const u8{
+        "G",
+        "GET / HTTP/1.1\r\nHost: x\r\n",
+    };
+    for (partials) |partial| {
+        var r = Reader.init(t.allocator, .server);
+        defer r.deinit();
+        try r.feed(partial);
+        try expectTag(.need_data, try r.nextEvent());
+        try r.feed("");
+        try t.expectError(error.ProtocolError, r.nextEvent());
+        try t.expectError(error.ProtocolError, r.nextEvent());
+    }
 }
 
 test "split body across feeds" {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -35,6 +35,17 @@ def test_receive_event_preserves_terminal_parse_errors() -> None:
         conn.next_event()
 
 
+@pytest.mark.parametrize("partial", [b"G", b"GET / HTTP/1.1\r\nHost: x\r\n"])
+def test_eof_during_an_incomplete_head_is_a_terminal_error(partial: bytes) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    assert conn.receive_event(partial) is zttp.NEED_DATA
+    conn.receive_data(b"")
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
 def test_simple_get() -> None:
     events = parse_request(b"GET /path?q=1 HTTP/1.1\r\nHost: example.com\r\n\r\n")
     assert len(events) == 1


### PR DESCRIPTION
## Summary

- treat EOF with buffered, incomplete HTTP/1 head bytes as a protocol error
- keep clean EOF at a message boundary mapped to `CONNECTION_CLOSED`
- latch the error so subsequent reads cannot resume a desynchronized stream
- cover partial request lines and unterminated header blocks in Zig and Python

## Root cause

`Reader.readHead()` only handled EOF when the available region was empty. When EOF followed any non-empty incomplete head, the scanner returned no complete head and the reader returned `NEED_DATA` forever—even though no more data could arrive.

## Stack

- builds on #191, which makes the Uvicorn benchmark paths reproducible
- compare this PR against #191

## Benchmark

The changed branch is reached only after EOF with an incomplete head, so complete-request throughput should be unchanged. The checked-in Uvicorn-shaped matrix was run with CPython 3.14.3, Zig `ReleaseSafe`, 15 batches × 10,000 requests, and rotated runner order.

| Lifecycle | Workload | This PR `receive_event` | split API | httptools |
|---|---|---:|---:|---:|
| isolated | tiny | 1,073,600 | 1,077,819 | 756,907 |
| isolated | API | 720,122 | 726,392 | 476,064 |
| isolated | Chrome | 446,949 | 448,641 | 310,664 |
| isolated | proxied | 469,581 | 469,109 | 321,720 |
| keep-alive | tiny | 1,224,615 | 1,203,406 | 1,025,549 |
| keep-alive | API | 781,466 | 785,297 | 554,511 |
| keep-alive | Chrome | 479,666 | 481,722 | 357,042 |
| keep-alive | proxied | 500,393 | 505,642 | 371,755 |

Absolute values vary with host conditions; this PR does not claim a performance improvement. Its runtime change is outside every successful-request benchmark path.

## Validation

- `zig build test -Doptimize=ReleaseSafe`
- `scripts/check`
- `uv run --no-sync pytest -q` — 350 passed, 1 optional qh3 test skipped
- full Uvicorn-shaped benchmark matrix


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject EOF during an incomplete HTTP/1 head and surface a terminal protocol error. Previously, EOF with buffered but incomplete head returned NEED_DATA indefinitely; now it raises ProtocolError, latches the error, and preserves CONNECTION_CLOSED for clean EOF at a message boundary.

- Adds Zig and `zttp` tests for partial request lines and unterminated header blocks, confirming the error is terminal and repeated.
- Throughput is unchanged; this path only runs on EOF with an incomplete head.

**Migration**
- Handle ProtocolError (mapped to `RemoteProtocolError` in `zttp`) when EOF arrives with a partial head, and do not retry reads on the same connection.

<sup>Written for commit 0abd0a2631df9304bab3cc09888a1daa29e82c15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

