### PR TITLE
Consolidate HTTP/1 message context

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -116,6 +116,14 @@ pub const Limits = struct {
     strict_crlf: bool = true,
 };
 
+/// Connection semantics derived from one parsed request or response head.
+/// `upgrade` borrows from the reader buffer, so adapters must consume this
+/// snapshot immediately after receiving the corresponding head event.
+pub const HeadInfo = struct {
+    should_close: bool = false,
+    upgrade: ?[]const u8 = null,
+};
+
 pub const Reader = struct {
     gpa: std.mem.Allocator,
     role: Role,
@@ -144,11 +152,9 @@ pub const Reader = struct {
     /// CONNECT 2xx, RFC 9112 6.3). Empty when unknown. Server-side unused.
     request_method: [16]u8 = undefined,
     request_method_len: usize = 0,
-    /// Connection-scoped signals for the most recently parsed head, valid until
-    /// the next reset. `conn_upgrade` slices into the head buffer, so it is only
-    /// valid until the next feed/nextEvent - read it right after the event.
-    conn_should_close: bool = false,
-    conn_upgrade: ?[]const u8 = null,
+    /// One-shot connection semantics for the most recently parsed head.
+    head_info: HeadInfo = .{},
+    head_info_pending: bool = false,
     eof_seen: bool = false,
     /// The error that poisoned the connection, re-raised on every later call.
     failed_with: ParseError = error.ProtocolError,
@@ -226,15 +232,16 @@ pub const Reader = struct {
         self.body_remaining = 0;
         self.chunk = .{};
         self.request_method_len = 0;
-        self.conn_should_close = false;
-        self.conn_upgrade = null;
+        self.head_info_pending = false;
     }
 
-    /// Whether the connection must close after the most recently parsed
-    /// request/response (RFC 9112 9.3, plus close-delimited responses). Valid
-    /// after a Request/Response event, until the next reset.
-    pub fn shouldClose(self: *const Reader) bool {
-        return self.conn_should_close;
+    /// Consume the connection semantics attached to the head event that was
+    /// just returned. A second call yields an empty snapshot, which prevents an
+    /// adapter from accidentally applying stale metadata to another message.
+    pub inline fn takeHeadInfo(self: *Reader) HeadInfo {
+        if (!self.head_info_pending) return .{};
+        self.head_info_pending = false;
+        return self.head_info;
     }
 
     /// True when every buffered byte has been consumed.
@@ -266,13 +273,6 @@ pub const Reader = struct {
         std.debug.assert(self.state == .body_length and n <= self.body_remaining);
         self.body_remaining -= n;
         if (self.body_remaining == 0) self.state = .eom_pending;
-    }
-
-    /// The `Upgrade` value of the most recently parsed request iff its
-    /// `Connection` header listed the `upgrade` token; else null. The slice is
-    /// borrowed from the head buffer - read it right after the Request event.
-    pub fn upgrade(self: *const Reader) ?[]const u8 {
-        return self.conn_upgrade;
     }
 
     fn compact(self: *Reader) void {
@@ -385,8 +385,11 @@ pub const Reader = struct {
             } else {
                 self.enterBody(framing);
             }
-            self.conn_should_close = semantics.shouldClose(rl.http_version);
-            self.conn_upgrade = semantics.upgrade();
+            self.head_info = .{
+                .should_close = semantics.shouldClose(rl.http_version),
+                .upgrade = semantics.upgrade(),
+            };
+            self.head_info_pending = true;
             return .{ .request = .{
                 .method = rl.method,
                 .target = rl.target,
@@ -422,7 +425,8 @@ pub const Reader = struct {
             .until_close_default = true,
         });
         self.enterBody(framing);
-        self.conn_should_close = semantics.shouldClose(st.http_version) or framing == .until_close;
+        self.head_info = .{ .should_close = semantics.shouldClose(st.http_version) or framing == .until_close };
+        self.head_info_pending = true;
         return .{ .response = .{
             .status_code = st.status_code,
             .reason = st.reason,
@@ -803,7 +807,23 @@ test "client exposes response connection close signal" {
     defer r.deinit();
     try r.feed("HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n");
     try expectTag(.response, try r.nextEvent());
-    try t.expect(r.shouldClose());
+    try t.expect(r.takeHeadInfo().should_close);
+    try t.expectEqual(HeadInfo{}, r.takeHeadInfo());
+}
+
+test "server head info is an immediate one-shot snapshot" {
+    var r = Reader.init(t.allocator, .server);
+    defer r.deinit();
+    try r.feed("GET / HTTP/1.1\r\nConnection: close, Upgrade\r\nUpgrade: websocket\r\n\r\n");
+    try expectTag(.request, try r.nextEvent());
+
+    const info = r.takeHeadInfo();
+    try t.expect(info.should_close);
+    try t.expectEqualStrings("websocket", info.upgrade.?);
+
+    const consumed = r.takeHeadInfo();
+    try t.expect(!consumed.should_close);
+    try t.expect(consumed.upgrade == null);
 }
 
 test "client treats HTTP/1.0 response as close unless keep-alive" {
@@ -811,7 +831,7 @@ test "client treats HTTP/1.0 response as close unless keep-alive" {
     defer r.deinit();
     try r.feed("HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n");
     try expectTag(.response, try r.nextEvent());
-    try t.expect(r.shouldClose());
+    try t.expect(r.takeHeadInfo().should_close);
 }
 
 test "client marks close-delimited response as closing" {
@@ -819,7 +839,7 @@ test "client marks close-delimited response as closing" {
     defer r.deinit();
     try r.feed("HTTP/1.1 200 OK\r\n\r\nbody");
     try expectTag(.response, try r.nextEvent());
-    try t.expect(r.shouldClose());
+    try t.expect(r.takeHeadInfo().should_close);
 }
 
 test "truncated content-length body errors at EOF" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -131,6 +131,64 @@ const PendingInput = struct {
     }
 };
 
+/// Per-message HTTP/1 adapter state. The request method is retained across an
+/// early start_next_cycle so a delayed response still gets HEAD/CONNECT
+/// framing, while `active_this_cycle` distinguishes that owed response from a
+/// stale method when the next request head fails. Connection signals are copied
+/// here at head-event time because the reader's snapshot borrows its buffer.
+const H1MessageContext = struct {
+    response_method: [16]u8 = undefined,
+    response_method_len: usize = 0,
+    active_this_cycle: bool = false,
+    should_close: bool = false,
+    upgrade_obj: py.Object = null,
+
+    inline fn rememberRequest(self: *H1MessageContext, method: []const u8) void {
+        self.active_this_cycle = true;
+        if (method.len > self.response_method.len) {
+            self.response_method_len = 0;
+            return;
+        }
+        @memcpy(self.response_method[0..method.len], method);
+        self.response_method_len = method.len;
+    }
+
+    inline fn framingMethod(self: *const H1MessageContext) []const u8 {
+        return self.response_method[0..self.response_method_len];
+    }
+
+    inline fn captureRequest(self: *H1MessageContext, method: []const u8, info: core.h1.reader.HeadInfo) bool {
+        self.rememberRequest(method);
+        self.should_close = info.should_close;
+        py.xdecref(self.upgrade_obj);
+        self.upgrade_obj = if (info.upgrade) |value| py.fromBytes(value) else null;
+        return info.upgrade == null or self.upgrade_obj != null;
+    }
+
+    inline fn captureResponse(self: *H1MessageContext, info: core.h1.reader.HeadInfo) void {
+        // A client that asked to close already set the flag when it serialized
+        // the request; an omitted response token does not take that back.
+        self.should_close = self.should_close or info.should_close;
+    }
+
+    inline fn parseFailed(self: *H1MessageContext) void {
+        if (!self.active_this_cycle) self.response_method_len = 0;
+    }
+
+    fn startNextCycle(self: *H1MessageContext) void {
+        self.active_this_cycle = false;
+        // Keep response_method: callers may start the next read cycle before
+        // serializing the response to the request they just received.
+        self.should_close = false;
+        py.xdecref(self.upgrade_obj);
+        self.upgrade_obj = null;
+    }
+
+    fn deinit(self: *H1MessageContext) void {
+        py.xdecref(self.upgrade_obj);
+    }
+};
+
 fn randomBytes(comptime len: usize) ?[len]u8 {
     var out: [len]u8 = undefined;
     const os = c.PyImport_ImportModule("os") orelse return null;
@@ -210,40 +268,10 @@ const H1Engine = struct {
     /// Created on the first send_* call: server connections that only parse
     /// never pay the Writer's allocation.
     writer: ?*Writer = null,
-    /// The method of the message the next response answers (server: the parsed
-    /// request; client: the request we sent), so the connection auto-derives
-    /// bodyless framing. NOT cleared by start_next_cycle - it is overwritten when
-    /// the next request is parsed, so send_response can read it before the previous
-    /// response is serialized (see next_message).
-    req_method: [16]u8 = undefined,
-    req_method_len: usize = 0,
-    /// Whether the remembered method belongs to a request already surfaced (server)
-    /// or sent (client) in the current read cycle. Reset by start_next_cycle. Used
-    /// to decide, on a parse failure, whether the method is stale (fresh-head
-    /// failure -> clear) or still owed a response (mid-body failure -> keep).
-    request_surfaced: bool = false,
-    /// Connection close signal for the last parsed request/response, captured at
-    /// event time so it outlives the head buffer. `upgrade_obj` remains
-    /// request-only and is held as Python bytes (or null).
-    should_close: bool = false,
-    upgrade_obj: py.Object = null,
+    message: H1MessageContext = .{},
     /// Single-copy body path: retains a Python-owned Content-Length body span
     /// outside the reader until next_event can materialise it directly.
     pending: PendingInput = .{},
-
-    fn rememberMethod(self: *H1Engine, m: []const u8) void {
-        if (m.len > self.req_method.len) {
-            self.req_method_len = 0;
-            return;
-        }
-        @memcpy(self.req_method[0..m.len], m);
-        self.req_method_len = m.len;
-        self.request_surfaced = true;
-    }
-
-    fn method(self: *const H1Engine) []const u8 {
-        return self.req_method[0..self.req_method_len];
-    }
 
     /// The writer, created on first use, or null with a Python error set.
     fn ensureWriter(self: *H1Engine) ?*Writer {
@@ -314,7 +342,7 @@ const H1Engine = struct {
             w.deinit();
             gpa.destroy(w);
         }
-        py.xdecref(self.upgrade_obj);
+        self.message.deinit();
         self.pending.deinit();
     }
 };
@@ -1920,7 +1948,7 @@ fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
             while (true) {
                 const ev = e.reader.nextEvent() catch |err| {
                     e.pending.clear();
-                    // req_method survives start_next_cycle by design. Clear it ONLY
+                    // The response method survives start_next_cycle by design. Clear it ONLY
                     // when the failure is on a fresh request head (no request
                     // surfaced this cycle): otherwise an error response the app sends
                     // (e.g. send_response(400, content-length: ...)) would be framed
@@ -1928,7 +1956,7 @@ fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
                     // if a request WAS already surfaced and its body then fails, the
                     // response to THAT request (a HEAD stays bodyless regardless of
                     // headers) still needs the method - keep it.
-                    if (!e.request_surfaced) e.req_method_len = 0;
+                    e.message.parseFailed();
                     return exceptions.raiseParse(err);
                 };
                 if (ev == .need_data and e.pending.hasData()) {
@@ -1942,18 +1970,9 @@ fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
                     continue;
                 }
                 if (ev == .request) {
-                    e.rememberMethod(ev.request.method);
-                    e.should_close = e.reader.shouldClose();
-                    py.xdecref(e.upgrade_obj);
-                    if (e.reader.upgrade()) |u| {
-                        e.upgrade_obj = py.fromBytes(u);
-                        if (e.upgrade_obj == null) return null; // propagate the pending MemoryError
-                    } else e.upgrade_obj = null;
+                    if (!e.message.captureRequest(ev.request.method, e.reader.takeHeadInfo())) return null;
                 } else if (ev == .response) {
-                    // A client that asked to close already set the flag when it
-                    // serialized the request; the peer omitting the token from
-                    // its response does not take that back.
-                    e.should_close = e.should_close or e.reader.shouldClose();
+                    e.message.captureResponse(e.reader.takeHeadInfo());
                 }
                 return if (eager_headers)
                     events_obj.fromH1Event(ev)
@@ -2200,9 +2219,9 @@ fn send_request(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obje
         .h1 => |*e| {
             const w = e.ensureWriter() orelse return null;
             w.sendRequest(mb, tb, vb, hdrs.headers) catch |err| return raiseWrite(err);
-            e.rememberMethod(mb);
+            e.message.rememberRequest(mb);
             e.reader.setRequestMethod(mb);
-            if (core.h1.connection.shouldClose(vb, hdrs.headers)) e.should_close = true;
+            if (core.h1.connection.shouldClose(vb, hdrs.headers)) e.message.should_close = true;
             return py.none();
         },
         .h3 => |*e| {
@@ -2255,8 +2274,8 @@ fn send_response(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obj
 
     const rb = core.h1.writer.reasonPhrase(@intCast(status));
     const w = e.ensureWriter() orelse return null;
-    w.sendResponse("1.1", @intCast(status), rb, header_slice, e.method()) catch |err| return raiseWrite(err);
-    if (core.h1.connection.connectionHasClose(header_slice)) e.should_close = true;
+    w.sendResponse("1.1", @intCast(status), rb, header_slice, e.message.framingMethod()) catch |err| return raiseWrite(err);
+    if (core.h1.connection.connectionHasClose(header_slice)) e.message.should_close = true;
     return py.none();
 }
 
@@ -2408,30 +2427,20 @@ fn next_message(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const e = h1(self) orelse return null;
     e.reader.reset();
-    // A new read cycle: the remembered method now belongs to the previous request,
-    // no longer one surfaced this cycle (so a parse failure on the next head clears
-    // it - see next_event).
-    e.request_surfaced = false;
-    // req_method is intentionally NOT cleared: a caller may call start_next_cycle()
-    // before serializing the previous response (e.g. pipelined keep-alive reads),
-    // and send_response reads it to frame HEAD / CONNECT responses as bodyless. It
-    // is overwritten when the next request is parsed, so a stale value is never seen.
-    e.should_close = false;
-    py.xdecref(e.upgrade_obj);
-    e.upgrade_obj = null;
+    e.message.startNextCycle();
     return py.none();
 }
 
 fn should_close(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const e = h1(self) orelse return null;
-    return py.boolean(e.should_close);
+    return py.boolean(e.message.should_close);
 }
 
 fn upgrade(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const e = h1(self) orelse return null;
-    const obj = e.upgrade_obj orelse return py.none();
+    const obj = e.message.upgrade_obj orelse return py.none();
     py.incref(obj);
     return obj;
 }


### PR DESCRIPTION
## Summary

- replace separate reader close/upgrade side channels with a one-shot `HeadInfo` snapshot
- consolidate response-framing method, current-cycle state, close state, and the owned upgrade object into `H1MessageContext`
- centralize fresh-head failure and early `start_next_cycle()` transitions
- keep the reader's request method only for client-side response framing, where the core parser genuinely needs it

This is stacked on #193. Its base stack also contains #191 and the merged EOF correction from #192.

## Why

The previous behavior was correct but its invariants were distributed across the reader and Python adapter. In particular, response framing had to distinguish three cases:

1. a current HEAD/CONNECT request still owed a response,
2. a method retained across an early cycle reset,
3. a stale retained method after the next request head fails.

`H1MessageContext` now owns that transition in one place. `Reader.takeHeadInfo()` makes close/upgrade metadata explicitly one-shot so it cannot be accidentally applied to a later message.

## Benchmark

Apple Silicon macOS, CPython 3.14.3, httptools 0.8.0, Zig `ReleaseSafe`. Values are medians of 21 batches × 20,000 API-shaped requests after warmup. The corrected Uvicorn harness rotates runner order. Higher is better.

| Lifecycle | This branch | #193 base | Delta vs base | `origin/main` | Delta vs main | httptools | zttp / httptools |
|---|---:|---:|---:|---:|---:|---:|---:|
| isolated | 713,279 scope/s | 718,105 scope/s | -0.7% | 723,220 scope/s | -1.4% | 479,193 scope/s | 1.49x |
| keep-alive | 792,073 scope/s | 785,178 scope/s | +0.9% | 790,604 scope/s | +0.2% | 570,376 scope/s | 1.39x |

The refactor is within 1% of its immediate parent in both production-shaped lifecycles and within 1.4% of main cumulatively.

## Validation

- `scripts/check`
- `zig build test -Doptimize=ReleaseSafe`
- `pytest`: 353 passed, 1 skipped
- existing HEAD/CONNECT, pipelining, malformed-fresh-head, mid-body failure, close, and upgrade tests
- new core test proving `HeadInfo` is consumed exactly once

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates HTTP/1 per‑message state into a one‑shot head snapshot, preventing stale `Connection: close`/`Upgrade` metadata from leaking across messages. External Python behavior is unchanged; HEAD/CONNECT response framing and cumulative client close semantics are preserved.

- Core `Reader`: adds `HeadInfo { should_close, upgrade }` and `takeHeadInfo()`; removes `shouldClose()` and `upgrade()`. `takeHeadInfo()` is one‑shot and later calls return empty; `upgrade` borrows the reader buffer.
- Python adapter: adds `H1MessageContext` to retain the response framing method across early `start_next_cycle()`, track `should_close`, hold `upgrade_obj`, and own parse‑failure and cycle transitions. Python `should_close()` and `upgrade()` APIs are unchanged; upgrade tokens are copied to Python bytes at head time.

**Migration**
- Replace uses of `Reader.shouldClose()`/`Reader.upgrade()` with `Reader.takeHeadInfo()`, and consume the snapshot immediately after the head event (copy fields if needed).

<sup>Written for commit aeb9a651fb188a5ec4f7f70863c140c9b413f461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

