### PR TITLE
Expose active local QUIC connection IDs

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -210,6 +210,13 @@ const LocalCid = struct {
     retired: bool = false,
 };
 
+/// One active destination connection ID the integrator must route to this
+/// connection. The borrowed ID remains valid until the next connection operation.
+pub const LocalConnectionId = struct {
+    sequence_number: u64,
+    connection_id: []const u8,
+};
+
 const ParsedShortForLocalCid = struct {
     hdr: packet.ShortHeader,
     local_cid_seq: u64,
@@ -835,6 +842,34 @@ pub const Connection = struct {
         const gop = self.pending_new_cids.getOrPut(self.gpa, seq) catch return error.OutOfMemory;
         gop.value_ptr.* = .{ .retire_prior_to = retire_prior_to };
         self.local_cid_max_seq = seq;
+    }
+
+    /// Copy the active local connection IDs into `out`. A newly issued ID appears
+    /// immediately, before its `NEW_CONNECTION_ID` can be drained and sent. An ID
+    /// disappears after the peer's `RETIRE_CONNECTION_ID` is processed.
+    pub fn localConnectionIds(self: *const Connection, out: []LocalConnectionId) usize {
+        var count: usize = 0;
+        if (!self.local_initial_cid_retired and count < out.len) {
+            out[count] = .{ .sequence_number = 0, .connection_id = self.scid };
+            count += 1;
+        }
+        var iterator = self.local_cids.iterator();
+        while (iterator.next()) |entry| {
+            if (entry.value_ptr.retired or count >= out.len) continue;
+            out[count] = .{ .sequence_number = entry.key_ptr.*, .connection_id = entry.value_ptr.cid };
+            count += 1;
+        }
+        return count;
+    }
+
+    /// Return the number of active local connection IDs.
+    pub fn localConnectionIdCount(self: *const Connection) usize {
+        var count: usize = if (self.local_initial_cid_retired) 0 else 1;
+        var iterator = self.local_cids.valueIterator();
+        while (iterator.next()) |local| if (!local.retired) {
+            count += 1;
+        };
+        return count;
     }
 
     /// Drop the drained datagrams (the integrator has sent them).
@@ -2522,7 +2557,12 @@ pub const Connection = struct {
     fn onNewConnectionId(self: *Connection, seq: u64, retire_prior_to: u64, cid: []const u8, token: []const u8) Error!void {
         if (token.len != 16) return error.ProtocolViolation;
         if (retire_prior_to > self.peer_retire_prior_to) {
+            const previous_retire_prior_to = self.peer_retire_prior_to;
             self.peer_retire_prior_to = retire_prior_to;
+            if (previous_retire_prior_to == 0 and retire_prior_to > 0) {
+                const initial = self.pending_retire_cids.getOrPut(self.gpa, 0) catch return error.OutOfMemory;
+                if (!initial.found_existing) initial.value_ptr.* = .{};
+            }
             var retire: std.ArrayListUnmanaged(u64) = .empty;
             defer retire.deinit(self.gpa);
             var it = self.peer_cids.keyIterator();
@@ -2546,7 +2586,10 @@ pub const Connection = struct {
         }
         if (std.mem.eql(u8, cid, self.peer_scid) or self.peerCidValueExists(cid)) return error.ProtocolViolation;
 
-        if (self.peer_cids.count() + 2 > self.local_tp.active_connection_id_limit) return error.ProtocolViolation;
+        const active_initial: usize = if (self.peer_retire_prior_to == 0) 1 else 0;
+        if (self.peer_cids.count() + active_initial + 1 > self.local_tp.active_connection_id_limit) {
+            return error.ProtocolViolation;
+        }
         const owned = self.gpa.dupe(u8, cid) catch return error.OutOfMemory;
         errdefer self.gpa.free(owned);
         self.peer_cids.put(self.gpa, seq, .{ .cid = owned, .token = token_array }) catch return error.OutOfMemory;

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -243,6 +243,7 @@ pub const Connection = struct {
     peer_scid: []u8, // the peer's scid: the dcid of everything we send (owned)
     retry_scid: ?[]u8 = null, // client only: SCID received in Retry, for TP validation
     peer_cids: std.AutoHashMapUnmanaged(u64, PeerCid) = .empty,
+    peer_cid_seq: u64 = 0,
     peer_retire_prior_to: u64 = 0,
     local_cids: std.AutoHashMapUnmanaged(u64, LocalCid) = .empty,
     local_cid_max_seq: u64 = 0,
@@ -819,6 +820,7 @@ pub const Connection = struct {
         const owned = self.gpa.dupe(u8, peer_cid.cid) catch return error.OutOfMemory;
         self.gpa.free(self.peer_scid);
         self.peer_scid = owned;
+        self.peer_cid_seq = seq;
     }
 
     /// Issue a replacement local connection id to the peer (RFC 9000 5.1/19.15).
@@ -2555,7 +2557,7 @@ pub const Connection = struct {
     }
 
     fn onNewConnectionId(self: *Connection, seq: u64, retire_prior_to: u64, cid: []const u8, token: []const u8) Error!void {
-        if (token.len != 16) return error.ProtocolViolation;
+        if (token.len != 16 or retire_prior_to > seq) return error.ProtocolViolation;
         if (retire_prior_to > self.peer_retire_prior_to) {
             const previous_retire_prior_to = self.peer_retire_prior_to;
             self.peer_retire_prior_to = retire_prior_to;
@@ -2582,6 +2584,7 @@ pub const Connection = struct {
         const token_array = token[0..16].*;
         if (self.peer_cids.get(seq)) |existing| {
             if (!std.mem.eql(u8, existing.cid, cid) or !std.mem.eql(u8, &existing.token, &token_array)) return error.ProtocolViolation;
+            if (self.peer_cid_seq < self.peer_retire_prior_to) try self.usePeerConnectionId(seq);
             return;
         }
         if (std.mem.eql(u8, cid, self.peer_scid) or self.peerCidValueExists(cid)) return error.ProtocolViolation;
@@ -2593,6 +2596,7 @@ pub const Connection = struct {
         const owned = self.gpa.dupe(u8, cid) catch return error.OutOfMemory;
         errdefer self.gpa.free(owned);
         self.peer_cids.put(self.gpa, seq, .{ .cid = owned, .token = token_array }) catch return error.OutOfMemory;
+        if (self.peer_cid_seq < self.peer_retire_prior_to) try self.usePeerConnectionId(seq);
     }
 
     /// RFC 9002 2: every frame except ACK, PADDING, and CONNECTION_CLOSE makes its
@@ -4555,18 +4559,18 @@ test "NEW_CONNECTION_ID retire_prior_to queues RETIRE_CONNECTION_ID" {
 
     var second: std.ArrayListUnmanaged(u8) = .empty;
     defer second.deinit(gpa);
-    try frame.encodeNewConnectionId(&second, gpa, 2, 2, &[_]u8{ 5, 6, 7, 8 }, token);
+    try frame.encodeNewConnectionId(&second, gpa, 2, 1, &[_]u8{ 5, 6, 7, 8 }, token);
     const d2 = try testBuildApp(gpa, &dcid, 1, second.items);
     defer gpa.free(d2);
     try conn.receiveDatagram(d2, 2000);
-    try testing.expect(conn.pending_retire_cids.contains(1));
+    try testing.expect(conn.pending_retire_cids.contains(0));
 
     conn.clearSend();
     try conn.flushSend(3000);
 
     const dgram = conn.datagramsToSend()[0..conn.datagramLengths()[0]];
     const keys = testAppKeys();
-    const hdr = try packet.parseShort(dgram, dcid.len);
+    const hdr = try packet.parseShort(dgram, conn.peer_scid.len);
     const work = try gpa.dupe(u8, dgram);
     defer gpa.free(work);
     const pn_len = try crypto.unprotectHeader(keys.hp, work, hdr.pn_offset, false);
@@ -4578,7 +4582,7 @@ test "NEW_CONNECTION_ID retire_prior_to queues RETIRE_CONNECTION_ID" {
     defer gpa.free(plaintext);
     const payload = try crypto.open(keys, truncated, header, ciphertext, plaintext);
     const decoded = try frame.decode(payload);
-    try testing.expectEqual(frame.Frame{ .retire_connection_id = 1 }, decoded.frame);
+    try testing.expectEqual(frame.Frame{ .retire_connection_id = 0 }, decoded.frame);
 }
 
 test "RETIRE_CONNECTION_ID can retire the initial local cid" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -793,6 +793,42 @@ const H3Engine = struct {
         return py.none();
     }
 
+    fn localConnectionIds(self: *const H3Engine) py.Object {
+        const q = self.qc orelse return py.raise(exceptions.LocalProtocolError, "no datagram received yet: the HTTP/3 connection is not established");
+        const ids = gpa.alloc(core.quic.connection.LocalConnectionId, q.localConnectionIdCount()) catch return c.PyErr_NoMemory();
+        defer gpa.free(ids);
+        const count = q.localConnectionIds(ids);
+        const result_type = resultType(&local_connection_id_type, "LocalConnectionId") orelse return null;
+        const list = py.newList(@intCast(count));
+        if (list == null) return null;
+        for (ids[0..count], 0..) |id, index| {
+            const tuple = py.tupleNew(2);
+            if (tuple == null) {
+                py.decref(list);
+                return null;
+            }
+            const sequence = c.PyLong_FromUnsignedLongLong(id.sequence_number);
+            const connection_id = py.fromBytes(id.connection_id);
+            if (sequence == null or connection_id == null) {
+                py.xdecref(sequence);
+                py.xdecref(connection_id);
+                py.decref(tuple);
+                py.decref(list);
+                return null;
+            }
+            py.tupleSet(tuple, 0, sequence);
+            py.tupleSet(tuple, 1, connection_id);
+            const value = c.PyObject_CallObject(result_type, tuple);
+            py.decref(tuple);
+            if (value == null) {
+                py.decref(list);
+                return null;
+            }
+            py.listSet(list, @intCast(index), value);
+        }
+        return list;
+    }
+
     fn issueConnectionId(self: *H3Engine, seq: u64, cid: []const u8, token: []const u8, retire_prior_to: u64) py.Object {
         const q = self.qc orelse return py.raise(exceptions.LocalProtocolError, "no datagram received yet: the HTTP/3 connection is not established");
         if (cid.len == 0 or cid.len > 20) return py.raiseValue("connection_id must be 1..20 bytes");
@@ -1152,6 +1188,7 @@ var stream_type: py.Object = null;
 var session_ticket_type: py.Object = null;
 var close_info_type: py.Object = null;
 var datagram_header_type: py.Object = null;
+var local_connection_id_type: py.Object = null;
 
 /// Module-level `parse_datagram_header(datagram) -> DatagramHeader`: the routable
 /// prefix of a received QUIC datagram, for demultiplexing a shared UDP socket onto
@@ -2373,6 +2410,11 @@ fn h3_use_peer_connection_id(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv
     return e.usePeerConnectionId(@intCast(seq));
 }
 
+fn h3_local_connection_ids(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
+    const e = h3(@ptrCast(self_obj.?)) orelse return null;
+    return e.localConnectionIds();
+}
+
 fn h3_issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
     const e = h3(@ptrCast(self_obj.?)) orelse return null;
     var seq: c_ulonglong = 0;
@@ -2693,6 +2735,7 @@ var h3_methods = [_]py.MethodDef{
     .{ .ml_name = "data_to_send_with_addresses", .ml_meth = h3_data_to_send_with_addresses, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear pending HTTP/3 datagrams as (datagram, peer_address) pairs. peer_address is None when no address key is known." },
     .{ .ml_name = "challenge_path", .ml_meth = h3_challenge_path, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC PATH_CHALLENGE for a peer address: challenge_path(peer_address, data). data must be 8 unpredictable bytes. Drain with data_to_send_with_addresses." },
     .{ .ml_name = "use_peer_connection_id", .ml_meth = h3_use_peer_connection_id, .ml_flags = c.METH_O, .ml_doc = "Switch future QUIC packets to a peer-issued NEW_CONNECTION_ID sequence: use_peer_connection_id(sequence_number)." },
+    .{ .ml_name = "local_connection_ids", .ml_meth = h3_local_connection_ids, .ml_flags = c.METH_NOARGS, .ml_doc = "Return every active local QUIC connection ID and sequence number." },
     .{ .ml_name = "issue_connection_id", .ml_meth = h3_issue_connection_id, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC NEW_CONNECTION_ID for a local CID: issue_connection_id(sequence_number, connection_id, stateless_reset_token, retire_prior_to=0). Drain with data_to_send." },
     .{ .ml_name = "request_key_update", .ml_meth = h3_request_key_update, .ml_flags = c.METH_NOARGS, .ml_doc = "Advance QUIC 1-RTT send keys. The next application packet carries the new key phase." },
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Open a request stream and return its Stream: send_request(method, target, version, headers). :authority is derived from a host header; the version arg is ignored." },

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -1059,7 +1059,6 @@ def test_local_connection_ids_track_issue_and_peer_retirement() -> None:
     transfer(server, client, 4000)
     transfer(client, server, 5000)
 
-    client.use_peer_connection_id(1)
     server.issue_connection_id(2, b"server-cid-2", b"\x6a" * 16, 1)
     transfer(server, client, 6000)
     client.initiate_connection()
@@ -1084,8 +1083,8 @@ def test_local_connection_ids_route_two_connections_on_one_endpoint() -> None:
         transfer(client, server, index * 1000 + 200)
         rotated = f"server-cid-{index}".encode()
         server.issue_connection_id(1, rotated, bytes((index,)) * 16)
-        for item in server.local_connection_ids():
-            routes[item.connection_id] = server
+        issued = next(item for item in server.local_connection_ids() if item.sequence_number == 1)
+        routes[issued.connection_id] = server
         transfer(server, client, index * 1000 + 300)
         transfer(client, server, index * 1000 + 400)
         client.use_peer_connection_id(1)
@@ -1094,7 +1093,9 @@ def test_local_connection_ids_route_two_connections_on_one_endpoint() -> None:
     for index, (client, _server, _rotated) in enumerate(pairs, start=1):
         client.send_request(b"GET", f"/connection-{index}".encode(), b"3", [(b"host", b"example.test")])
         for datagram in client.data_to_send():
-            destination = next(connection_id for connection_id in routes if datagram[1:].startswith(connection_id))
+            connection_id_length = len(rotated)
+            destination = datagram[1 : 1 + connection_id_length]
+            assert destination in routes
             routes[destination].receive_datagram(datagram, 5000 + index)
 
     for index, (_client, server, rotated) in enumerate(pairs, start=1):

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -1045,6 +1045,69 @@ def test_use_peer_connection_id_rejects_unknown_sequence() -> None:
         conn.use_peer_connection_id(1)
 
 
+def test_local_connection_ids_track_issue_and_peer_retirement() -> None:
+    client, server = handshake_pair()
+    initial = server.local_connection_ids()
+    assert len(initial) == 1
+    assert initial[0].sequence_number == 0
+
+    server.issue_connection_id(1, b"server-cid-1", b"\x5a" * 16)
+    assert {(item.sequence_number, item.connection_id) for item in server.local_connection_ids()} == {
+        (0, initial[0].connection_id),
+        (1, b"server-cid-1"),
+    }
+    transfer(server, client, 4000)
+    transfer(client, server, 5000)
+
+    client.use_peer_connection_id(1)
+    server.issue_connection_id(2, b"server-cid-2", b"\x6a" * 16, 1)
+    transfer(server, client, 6000)
+    client.initiate_connection()
+    transfer(client, server, 7000)
+
+    assert {(item.sequence_number, item.connection_id) for item in server.local_connection_ids()} == {
+        (1, b"server-cid-1"),
+        (2, b"server-cid-2"),
+    }
+
+
+def test_local_connection_ids_route_two_connections_on_one_endpoint() -> None:
+    pairs: list[tuple[zttp.H3Connection, zttp.H3Connection, bytes]] = []
+    routes: dict[bytes, zttp.H3Connection] = {}
+    for index, original in enumerate((b"client-a", b"client-b"), start=1):
+        config = dict(CLIENT_CONFIG)
+        config["connection_id"] = original
+        client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config)
+        server = make_server()
+        transfer(client, server, index * 1000)
+        transfer(server, client, index * 1000 + 100)
+        transfer(client, server, index * 1000 + 200)
+        rotated = f"server-cid-{index}".encode()
+        server.issue_connection_id(1, rotated, bytes((index,)) * 16)
+        for item in server.local_connection_ids():
+            routes[item.connection_id] = server
+        transfer(server, client, index * 1000 + 300)
+        transfer(client, server, index * 1000 + 400)
+        client.use_peer_connection_id(1)
+        pairs.append((client, server, rotated))
+
+    for index, (client, _server, _rotated) in enumerate(pairs, start=1):
+        client.send_request(b"GET", f"/connection-{index}".encode(), b"3", [(b"host", b"example.test")])
+        for datagram in client.data_to_send():
+            destination = next(connection_id for connection_id in routes if datagram[1:].startswith(connection_id))
+            routes[destination].receive_datagram(datagram, 5000 + index)
+
+    for index, (_client, server, rotated) in enumerate(pairs, start=1):
+        assert routes[rotated] is server
+        requests = [event for event in drain_events(server) if isinstance(event, zttp.Request)]
+        assert requests[-1].path == f"/connection-{index}".encode()
+
+
+def test_local_connection_ids_require_an_established_connection() -> None:
+    with pytest.raises(zttp.LocalProtocolError):
+        make_server().local_connection_ids()
+
+
 def test_issue_connection_id_queues_new_connection_id_datagram() -> None:
     _client, server = handshake_pair()
 

--- a/zttp/__init__.py
+++ b/zttp/__init__.py
@@ -31,7 +31,7 @@ from zttp._zttp import (
     parse_datagram_header,
 )
 from zttp.config import SessionResumption, TlsCredentials
-from zttp.results import CloseInfo, DatagramHeader, SessionTicket
+from zttp.results import CloseInfo, DatagramHeader, LocalConnectionId, SessionTicket
 from zttp.settings import H2Settings
 
 Event = (
@@ -69,6 +69,7 @@ __all__ = [
     "H1Connection",
     "H2Connection",
     "H3Connection",
+    "LocalConnectionId",
     "LocalProtocolError",
     "NeedData",
     "Ping",

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -8,7 +8,7 @@ from typing import Final, Literal, TypeVar, final, overload
 from typing_extensions import disjoint_base
 
 from zttp.config import SessionResumption, TlsCredentials
-from zttp.results import CloseInfo, DatagramHeader, SessionTicket
+from zttp.results import CloseInfo, DatagramHeader, LocalConnectionId, SessionTicket
 
 SERVER: Final = 1
 CLIENT: Final = 2
@@ -411,6 +411,14 @@ class H3Connection(Connection):
 
     def use_peer_connection_id(self, sequence_number: int, /) -> None:
         """Switch outgoing packets to a peer-issued `NEW_CONNECTION_ID` sequence."""
+
+    def local_connection_ids(self) -> list[LocalConnectionId]:
+        """Return a snapshot of every active local destination connection ID.
+
+        A newly issued ID appears before `issue_connection_id()` returns. An ID is
+        removed after `receive_datagram()` processes the peer's
+        `RETIRE_CONNECTION_ID`.
+        """
 
     def issue_connection_id(
         self,

--- a/zttp/results.py
+++ b/zttp/results.py
@@ -1,7 +1,7 @@
 """Value objects returned by HTTP/3 introspection methods.
 
-`H3Connection.session_tickets()` and `H3Connection.close_info()` return these frozen
-dataclasses. Read them by field name (`info.error_code`, `ticket.psk`) - they are not
+HTTP/3 introspection methods return these frozen dataclasses. Read them by field
+name (`info.error_code`, `ticket.psk`, `connection_id.sequence_number`) - they are not
 tuples, so there is no positional access to get wrong.
 """
 
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 __all__ = [
     "CloseInfo",
     "DatagramHeader",
+    "LocalConnectionId",
     "SessionTicket",
 ]
 
@@ -36,6 +37,14 @@ class CloseInfo:
     error_code: int
     reason: bytes
     is_application: bool
+
+
+@dataclass(frozen=True)
+class LocalConnectionId:
+    """An active destination connection ID routed to one HTTP/3 connection."""
+
+    sequence_number: int
+    connection_id: bytes
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Adds `H3Connection.local_connection_ids()` as a snapshot of active sequence numbers and destination IDs. Issued IDs appear before their `NEW_CONNECTION_ID` is sent, and peer retirements remove them after `receive_datagram()` processes `RETIRE_CONNECTION_ID`; the tests route two connections through one simulated endpoint.

Closes #201.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose active local QUIC connection IDs and make CID rotation safe. Previously local destination IDs were not visible and we could retire the active peer CID before switching; now `H3Connection.local_connection_ids()` returns active IDs, and on `NEW_CONNECTION_ID` with `retire_prior_to` we switch to the new peer CID before retiring older ones while enforcing the `active_connection_id_limit` (counts the initial CID).

- Add core APIs: `Connection.localConnectionIds(...)`, `Connection.localConnectionIdCount()`, and `LocalConnectionId` with snapshot semantics (IDs appear before `NEW_CONNECTION_ID` is sent; removed after `RETIRE_CONNECTION_ID` is processed).
- Add Python API: `H3Connection.local_connection_ids()` -> `list[LocalConnectionId]`; raises `LocalProtocolError` if the connection is not established. Export `LocalConnectionId` from `zttp.results` and `zttp.__init__`; update `zttp/_zttp.pyi`.
- Peer rotation: validate `retire_prior_to <= seq`; switch to the new peer CID before retiring active IDs; queue retirement of the initial CID when `retire_prior_to > 0`; account for the initial active CID when enforcing `active_connection_id_limit`.
- Tests cover issuance, peer retirement, and routing two connections through one `zttp` endpoint via returned local CIDs.

<sup>Written for commit bc9116e6c8d107665361ad493d5d29fe3e140cea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

