### PR TITLE
Let applications control HTTP/3 receive credit

### DIFF
--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -48,6 +48,8 @@ const RequestStream = struct {
     /// Content-Length was sent. Reconciled against the DATA bytes at the FIN.
     content_length: ?u64 = null,
     body_received: u64 = 0,
+    /// DATA payload bytes parsed but not yet acknowledged by the application.
+    body_unconsumed: u64 = 0,
     /// Responses to HEAD, 204, and 304 carry no body regardless of Content-Length.
     expects_bodyless: bool = false,
     /// Client-side only: responses to a locally-sent HEAD request carry no body
@@ -216,6 +218,11 @@ pub const Connection = struct {
         _ = self.streams.remove(id);
     }
 
+    fn releaseStreamCredit(self: *Connection, id: u64, rs: *RequestStream) void {
+        self.qc.releaseStreamCredit(id);
+        rs.body_unconsumed = 0;
+    }
+
     /// Reset request stream `id` with `code` and drop its state: RESET_STREAM the
     /// response, STOP_SENDING the request, drain and reclaim. Used both for a
     /// malformed request (failStream) and a request covered by our GOAWAY.
@@ -224,6 +231,7 @@ pub const Connection = struct {
         _ = self.send_bodyless.remove(id);
         self.qc.resetStream(id, @intFromEnum(code)) catch return error.H3Error;
         self.qc.stopSending(id, @intFromEnum(code)) catch return error.H3Error;
+        if (self.streams.getPtr(id)) |rs| self.releaseStreamCredit(id, rs);
         const pending = self.qc.streamData(id).len;
         if (pending > 0) self.qc.consumeStream(id, pending);
         // Drop the stream if the transport can (recv terminal); otherwise mark it
@@ -415,6 +423,7 @@ pub const Connection = struct {
         if (rs.blocked_headers != null) {
             if (self.qc.streamReset(id) and !rs.rst_emitted) {
                 try self.cancelQpackSectionIfPending(id, rs);
+                self.releaseStreamCredit(id, rs);
                 try self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = self.qc.streamResetCode(id) orelse 0 } });
                 rs.rst_emitted = true;
             }
@@ -426,9 +435,10 @@ pub const Connection = struct {
         // every fully-decoded frame is consumed (removed from the QUIC stream)
         // before this returns, so the next pump always begins at offset 0 with the
         // not-yet-consumed tail (a partial frame plus any newer bytes). Tracking a
-        // persistent offset here would desync once consumeStream slides the buffer.
+        // persistent offset here would desync once the transport slides the buffer.
         const ready = self.qc.streamData(id);
         var consumed_total: usize = 0;
+        var credited_total: usize = 0;
         while (consumed_total < ready.len) {
             const rest = ready[consumed_total..];
             const d = h3_frame.decode(rest) catch break; // NeedData: wait for more
@@ -444,6 +454,7 @@ pub const Connection = struct {
                 else => return e,
             };
             consumed_total += d.len;
+            credited_total += if (d.frame.ftype == .data) d.len - d.frame.payload.len else d.len;
             if (rs.blocked_headers != null) break;
         }
         if (self.qc.streamFinished(id) and rs.blocked_headers == null and consumed_total < ready.len) {
@@ -467,7 +478,8 @@ pub const Connection = struct {
         // A FIN-only completion (the FIN arrived as a zero-length STREAM frame) still
         // needs the consume, or the stream never reaches terminal and cannot be dropped.
         if (consumed_total > 0 or (self.qc.streamFinished(id) and rs.state == .done)) {
-            self.qc.consumeStream(id, consumed_total);
+            self.qc.advanceStream(id, consumed_total);
+            self.qc.creditStream(id, credited_total);
         }
         // A peer RESET_STREAM cancels the request: surface it as an event (with the
         // peer's error code) once, before the stream is dropped, so the integrator is
@@ -475,6 +487,7 @@ pub const Connection = struct {
         // a re-fire if the stream cannot be dropped yet (e.g. an allocator failure).
         if (self.qc.streamReset(id) and !rs.rst_emitted) {
             try self.cancelQpackSectionIfPending(id, rs);
+            self.releaseStreamCredit(id, rs);
             try self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = self.qc.streamResetCode(id) orelse 0 } });
             rs.rst_emitted = true;
         }
@@ -483,7 +496,7 @@ pub const Connection = struct {
         // cannot grow the maps (the memory half of the Rapid-Reset class). The QUIC
         // send half is retained until its bytes are acked, so a still-in-flight
         // response is not freed from under recovery.
-        if (rs.state == .done or self.qc.streamReset(id)) {
+        if ((rs.state == .done and rs.body_unconsumed == 0) or self.qc.streamReset(id)) {
             if (self.qc.dropStream(id)) self.removeStreamState(id); // rs dangles after this
         }
     }
@@ -505,6 +518,7 @@ pub const Connection = struct {
         if (rs.blocked_headers != null) {
             if (self.qc.streamReset(id) and !rs.rst_emitted) {
                 try self.cancelQpackSectionIfPending(id, rs);
+                self.releaseStreamCredit(id, rs);
                 try self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = self.qc.streamResetCode(id) orelse 0 } });
                 rs.rst_emitted = true;
             }
@@ -514,6 +528,7 @@ pub const Connection = struct {
 
         const ready = self.qc.streamData(id);
         var consumed_total: usize = 0;
+        var credited_total: usize = 0;
         while (consumed_total < ready.len) {
             const rest = ready[consumed_total..];
             const d = h3_frame.decode(rest) catch break;
@@ -526,6 +541,7 @@ pub const Connection = struct {
                 else => return e,
             };
             consumed_total += d.len;
+            credited_total += if (d.frame.ftype == .data) d.len - d.frame.payload.len else d.len;
             if (rs.blocked_headers != null) break;
         }
         if (self.qc.streamFinished(id) and rs.blocked_headers == null and consumed_total < ready.len) {
@@ -545,14 +561,16 @@ pub const Connection = struct {
         // state, so dropStream below reclaims a finished stream instead of leaving it
         // for pumpAll to revisit on every datagram.
         if (consumed_total > 0 or (self.qc.streamFinished(id) and rs.state == .done)) {
-            self.qc.consumeStream(id, consumed_total);
+            self.qc.advanceStream(id, consumed_total);
+            self.qc.creditStream(id, credited_total);
         }
         if (self.qc.streamReset(id) and !rs.rst_emitted) {
             try self.cancelQpackSectionIfPending(id, rs);
+            self.releaseStreamCredit(id, rs);
             try self.push(.{ .rst_stream = .{ .stream_id = id, .error_code = self.qc.streamResetCode(id) orelse 0 } });
             rs.rst_emitted = true;
         }
-        if (rs.state == .done or self.qc.streamReset(id)) {
+        if ((rs.state == .done and rs.body_unconsumed == 0) or self.qc.streamReset(id)) {
             if (self.qc.dropStream(id)) self.removeStreamState(id);
         }
     }
@@ -982,11 +1000,13 @@ pub const Connection = struct {
             },
             .data => {
                 if (rs.state != .headers_done) return self.fail(.frame_unexpected, "DATA before HEADERS"); // RFC 9114 4.1
-                rs.body_received = std.math.add(u64, rs.body_received, f.payload.len) catch return self.failStream(.message_error);
+                const body_received = std.math.add(u64, rs.body_received, f.payload.len) catch return self.failStream(.message_error);
                 // More body than the declared Content-Length is malformed (RFC 9114 4.1.2).
-                if (rs.content_length) |cl| if (rs.body_received > cl) return self.failStream(.message_error);
+                if (rs.content_length) |cl| if (body_received > cl) return self.failStream(.message_error);
                 const body = try self.dupe(f.payload);
                 try self.push(.{ .data = .{ .data = body, .stream_id = id } });
+                rs.body_received = body_received;
+                rs.body_unconsumed += f.payload.len;
             },
             // Control-stream frames are not allowed on a request stream (RFC 9114
             // 7.1): H3_FRAME_UNEXPECTED.
@@ -1032,12 +1052,14 @@ pub const Connection = struct {
             .data => {
                 if (rs.state != .headers_done) return self.fail(.frame_unexpected, "DATA before response HEADERS");
                 if (rs.expects_bodyless and f.payload.len > 0) return self.failStream(.message_error);
-                rs.body_received = std.math.add(u64, rs.body_received, f.payload.len) catch return self.failStream(.message_error);
-                if (rs.content_length) |cl| if (rs.body_received > cl) return self.failStream(.message_error);
+                const body_received = std.math.add(u64, rs.body_received, f.payload.len) catch return self.failStream(.message_error);
+                if (rs.content_length) |cl| if (body_received > cl) return self.failStream(.message_error);
                 if (f.payload.len > 0) {
                     const body = try self.dupe(f.payload);
                     try self.push(.{ .data = .{ .data = body, .stream_id = id } });
                 }
+                rs.body_received = body_received;
+                rs.body_unconsumed += f.payload.len;
             },
             .push_promise => {
                 _ = varint.decode(f.payload) catch return self.fail(.frame_error, "malformed PUSH_PROMISE");
@@ -1255,6 +1277,17 @@ pub const Connection = struct {
 
     fn push(self: *Connection, ev: H3Event) Error!void {
         self.queue.append(self.gpa, ev) catch return error.OutOfMemory;
+    }
+
+    /// Return DATA payload credit after the application has consumed it.
+    pub fn consumeData(self: *Connection, id: u64, length: u64) Error!void {
+        const rs = self.streams.getPtr(id) orelse return error.H3Error;
+        if (length > rs.body_unconsumed) return error.H3Error;
+        self.qc.creditStream(id, length);
+        rs.body_unconsumed -= length;
+        if (rs.state == .done and rs.body_unconsumed == 0) {
+            if (self.qc.dropStream(id)) self.removeStreamState(id);
+        }
     }
 
     /// Pull the next ready event, or `need_data` when the queue is drained. Mirrors
@@ -1500,6 +1533,11 @@ pub const Connection = struct {
         if (self.peekSendState(id) == .fin_sent) return;
         self.qc.resetStream(id, error_code) catch return error.H3Error;
         self.qc.stopSending(id, error_code) catch return error.H3Error;
+        if (self.streams.getPtr(id)) |rs| {
+            try self.cancelQpackSectionIfPending(id, rs);
+            self.releaseStreamCredit(id, rs);
+            rs.state = .rejected;
+        }
         try self.setSendState(id, .fin_sent);
     }
 

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2811,21 +2811,38 @@ pub const Connection = struct {
         return &.{};
     }
 
-    /// Mark `n` bytes of a stream consumed, re-granting flow-control credit. The
-    /// connection window slides by the connection-wide consumed total (the sum
-    /// across streams), matching how `onStreamFrame` charges it.
+    /// Advance past `n` ordered stream bytes without returning flow-control credit.
+    /// HTTP/3 uses this for DATA payloads until the application acknowledges them.
+    pub fn advanceStream(self: *Connection, id: u64, n: usize) void {
+        if (self.streams.get(id)) |s| s.consume(n);
+    }
+
+    /// Return credit for up to `n` bytes already advanced by the parser.
+    pub fn creditStream(self: *Connection, id: u64, n: u64) void {
+        if (self.streams.get(id)) |s| self.applyStreamCredit(id, s, s.credit(n));
+    }
+
+    /// Return all received stream credit after a reset or local abandonment.
+    pub fn releaseStreamCredit(self: *Connection, id: u64) void {
+        if (self.streams.get(id)) |s| self.applyStreamCredit(id, s, s.releaseCredit());
+    }
+
+    fn applyStreamCredit(self: *Connection, id: u64, s: *stream.RecvStream, credited: u64) void {
+        self.conn_consumed_total += credited;
+        self.conn_recv_window.onConsumed(self.conn_consumed_total);
+        if (self.conn_recv_window.shouldUpdate()) self.max_data_pending = true;
+        if (self.recv_windows.getPtr(id)) |rw| {
+            rw.onConsumed(s.flow_consumed);
+            if (rw.shouldUpdate()) self.max_stream_data_pending.put(self.gpa, id, {}) catch {};
+        }
+    }
+
+    /// Mark `n` stream bytes parsed and return their flow-control credit.
     pub fn consumeStream(self: *Connection, id: u64, n: usize) void {
         if (self.streams.get(id)) |s| {
             const before = s.read_offset;
             s.consume(n);
-            self.conn_consumed_total += s.read_offset - before;
-            self.conn_recv_window.onConsumed(self.conn_consumed_total);
-            // Enough has been consumed to advertise a higher limit; flushSend emits it.
-            if (self.conn_recv_window.shouldUpdate()) self.max_data_pending = true;
-            if (self.recv_windows.getPtr(id)) |rw| {
-                rw.onConsumed(s.read_offset);
-                if (rw.shouldUpdate()) self.max_stream_data_pending.put(self.gpa, id, {}) catch {};
-            }
+            self.applyStreamCredit(id, s, s.credit(s.read_offset - before));
         }
     }
 

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -66,6 +66,9 @@ pub const RecvStream = struct {
     gpa: std.mem.Allocator,
     state: RecvState = .recv,
     read_offset: u64 = 0,
+    /// Bytes whose flow-control credit has been returned. This can trail
+    /// `read_offset` when HTTP/3 has parsed body data the application has not read.
+    flow_consumed: u64 = 0,
     contiguous: u64 = 0,
     /// The largest byte offset ever received on this stream (may exceed
     /// `contiguous` when fragments arrive out of order). Connection-level flow
@@ -177,6 +180,20 @@ pub const RecvStream = struct {
         std.mem.copyForwards(u8, self.ready.items[0..rest], self.ready.items[take..]);
         self.ready.shrinkRetainingCapacity(rest);
         if (self.isFinished() and self.ready.items.len == 0) self.state = .data_read;
+    }
+
+    /// Return up to `n` bytes of parsed data to flow control.
+    pub fn credit(self: *RecvStream, n: u64) u64 {
+        const credited = @min(n, self.read_offset -| self.flow_consumed);
+        self.flow_consumed += credited;
+        return credited;
+    }
+
+    /// Return all received credit when a stream is reset or abandoned.
+    pub fn releaseCredit(self: *RecvStream) u64 {
+        const credited = self.highest_received - self.flow_consumed;
+        self.flow_consumed = self.highest_received;
+        return credited;
     }
 
     /// Has every byte through the final size been delivered into `ready`?

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -640,6 +640,12 @@ const H3Engine = struct {
         return events_obj.fromH3Event(h.nextEvent());
     }
 
+    fn consumeData(self: *H3Engine, id: u64, length: u64) py.Object {
+        const h = self.h3 orelse return py.raise(exceptions.LocalProtocolError, "no datagram received yet: the HTTP/3 connection is not established");
+        h.consumeData(id, length) catch return py.raiseValue("unknown stream or length exceeds its unconsumed DATA");
+        return self.flush();
+    }
+
     /// The pending outbound datagrams (handshake flight, ACKs, response STREAM
     /// frames) as a list of bytes, one per UDP datagram - QUIC datagram boundaries
     /// are semantic, so each must reach the peer as its own packet, unlike the byte
@@ -1931,6 +1937,14 @@ fn receive_datagram(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.
     }
 }
 
+fn h3_consume_data(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+    const e = h3(@ptrCast(self_obj.?)) orelse return null;
+    var stream_id: c_ulonglong = 0;
+    var length: c_ulonglong = 0;
+    if (c.PyArg_ParseTuple(args, "KK", &stream_id, &length) == 0) return null;
+    return e.consumeData(@intCast(stream_id), @intCast(length));
+}
+
 fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const engine = self.engine orelse return py.raiseRuntime("connection is closed");
@@ -2689,6 +2703,7 @@ var h2_getset = [_]c.PyGetSetDef{
 // feeds handle_timeout; a Stream send uses the most recent `now` the caller gave.
 var h3_methods = [_]py.MethodDef{
     .{ .ml_name = "receive_datagram", .ml_meth = receive_datagram, .ml_flags = c.METH_VARARGS, .ml_doc = "Feed one received UDP datagram: receive_datagram(datagram, now=0, peer_address=None). peer_address is an optional opaque bytes key for QUIC path validation and migration." },
+    .{ .ml_name = "consume_data", .ml_meth = h3_consume_data, .ml_flags = c.METH_VARARGS, .ml_doc = "Acknowledge HTTP/3 DATA payload bytes after the application consumes them: consume_data(stream_id, length)." },
     .{ .ml_name = "data_to_send", .ml_meth = data_to_send, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear the pending outgoing UDP datagrams as a list of bytes (one per datagram - QUIC datagram boundaries are semantic)." },
     .{ .ml_name = "data_to_send_with_addresses", .ml_meth = h3_data_to_send_with_addresses, .ml_flags = c.METH_NOARGS, .ml_doc = "Return and clear pending HTTP/3 datagrams as (datagram, peer_address) pairs. peer_address is None when no address key is known." },
     .{ .ml_name = "challenge_path", .ml_meth = h3_challenge_path, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC PATH_CHALLENGE for a peer address: challenge_path(peer_address, data). data must be 8 unpredictable bytes. Drain with data_to_send_with_addresses." },

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -716,9 +716,68 @@ def test_http3_client_request_trailers() -> None:
         events.append(ev)
 
     assert any(isinstance(e, zttp.Request) for e in events)
-    assert any(isinstance(e, zttp.Data) and e.data == b"body" for e in events)
+    data = next(e for e in events if isinstance(e, zttp.Data))
+    assert data.data == b"body"
     eom = next(e for e in events if isinstance(e, zttp.EndOfMessage))
     assert eom.trailers == [(b"x-checksum", b"abc")]
+    server.consume_data(data.stream_id, len(data.data))
+    with pytest.raises(ValueError):
+        server.consume_data(data.stream_id, 1)
+
+
+def test_http3_receive_credit_waits_for_application_consumption() -> None:
+    config = dict(SERVER_CONFIG)
+    config["transport_params"] = (
+        b"\x04\x02\x42\x00"  # initial_max_data = 512
+        b"\x06\x02\x42\x00"  # initial_max_stream_data_bidi_remote = 512
+        b"\x07\x04\x80\x04\x00\x00"  # initial_max_stream_data_uni = 262144
+        b"\x08\x01\x08"  # initial_max_streams_bidi = 8
+        b"\x09\x01\x08"  # initial_max_streams_uni = 8
+    )
+    client = make_client()
+    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
+    transfer(client, server, 1000)
+    transfer(server, client, 2000)
+    transfer(client, server, 3000)
+
+    stream = client.send_request(
+        b"POST",
+        b"/slow",
+        b"3",
+        [(b"host", b"example.test"), (b"content-length", b"1024")],
+    )
+    for _ in range(4):
+        stream.send_data(b"x" * 256)
+    stream.end_message()
+    assert stream.pending_bytes is not None
+    assert stream.pending_bytes > 0
+    transfer(client, server, 4000)
+    events = drain_events(server)
+    request = next(event for event in events if isinstance(event, zttp.Request))
+    server.initiate_connection()
+    transfer(server, client, 5000)
+    client.initiate_connection()
+    transfer(client, server, 6000)
+    events.extend(drain_events(server))
+    data = b"".join(event.data for event in events if isinstance(event, zttp.Data))
+    assert data
+    assert len(data) < 1024
+
+    pending = stream.pending_bytes
+    server.initiate_connection()
+    transfer(server, client, 7000)
+    client.initiate_connection()
+    transfer(client, server, 8000)
+    assert stream.pending_bytes == pending
+
+    with pytest.raises(ValueError):
+        server.consume_data(request.stream_id, len(data) + 1)
+    server.consume_data(request.stream_id, len(data))
+    transfer(server, client, 9000)
+    client.initiate_connection()
+    transfer(client, server, 10_000)
+    assert stream.pending_bytes is not None
+    assert stream.pending_bytes < pending
 
 
 def test_http3_stream_send_window_and_pending_bytes_track_backpressure() -> None:
@@ -1244,6 +1303,19 @@ def test_http3_stream_reset() -> None:
     # An error code past the 62-bit QUIC range is rejected.
     with pytest.raises(ValueError):
         conn.stream(4).reset(1 << 62)
+
+
+def test_http3_reset_reclaims_unconsumed_data() -> None:
+    client, server = handshake_pair()
+    stream = client.send_request(b"POST", b"/cancel", b"3", [(b"host", b"example.test")])
+    stream.send_data(b"body")
+    transfer(client, server, 4000)
+    data = next(event for event in drain_events(server) if isinstance(event, zttp.Data))
+
+    server.stream(data.stream_id).reset()
+
+    with pytest.raises(ValueError):
+        server.consume_data(data.stream_id, 1)
 
 
 def test_http3_initiate_connection_sends_the_control_stream() -> None:

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -115,7 +115,9 @@ class Data:
         data: Owned body bytes that are safe to keep. Qualifying HTTP/1 spans
             reuse the immutable `bytes` supplied to `receive_data()` or
             `receive_event()`; other paths copy out of the parse buffer.
-        stream_id: The stream the body belongs to (`0` on HTTP/1.1).
+        stream_id: The stream the body belongs to (`0` on HTTP/1.1). For HTTP/3,
+            call `connection.consume_data(stream_id, len(data))` after delivering
+            these bytes to the application.
     """
 
     data: bytes
@@ -399,6 +401,14 @@ class H3Connection(Connection):
 
     def data_to_send(self) -> list[bytes]:
         """Return and clear the pending outgoing UDP datagrams, one per list element."""
+
+    def consume_data(self, stream_id: int, length: int, /) -> None:
+        """Return receive-window credit after the application consumes DATA bytes.
+
+        Reading a `Data` event does not return its payload credit. Call this after
+        the application accepts some or all of that event's bytes. Frame overhead
+        and non-DATA frames are credited internally.
+        """
 
     def receive_datagram(self, datagram: bytes, now: int = ..., peer_address: bytes | None = ..., /) -> None:
         """Feed one received UDP datagram. `peer_address` is an opaque key for path validation."""


### PR DESCRIPTION
Adds `H3Connection.consume_data(stream_id, length)` so DATA payload credit follows application consumption instead of parser progress. HTTP/3 frame overhead remains automatic, while completion and reset paths retain or release stream credit safely; the integration test proves a stalled sender advances only after acknowledgement.

Closes #199.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets applications control HTTP/3 DATA receive credit to align backpressure with consumption. Previously, the parser returned flow-control credit as it advanced; now only frame overhead and non-DATA are auto-credited, and DATA payload credit is returned when the application calls `consume_data(stream_id, length)`. Streams drop only after all DATA is acknowledged; resets release any remaining credit.

- New API and required migration: `H3Connection.consume_data(stream_id, length)` (Python: `connection.consume_data(stream_id, length)`) must be called after delivering `zttp.Data` bytes to the application. Over-crediting raises `ValueError`. Apps that do not call it may observe stalled HTTP/3 senders.
- Review focus: request/response pumps switched from `consumeStream` to `advanceStream` + `creditStream` with overhead-only crediting; `RecvStream` tracks `flow_consumed`; `releaseStreamCredit` is used on reset/reject; stream drop now waits for `body_unconsumed == 0`. Tests cover sender stalling until credit is returned and credit reclamation on reset. No changes for HTTP/1/2.

<sup>Written for commit 1528f04badbed61611e9ea2b3bcbec0931293d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

