### PR TITLE
Type-check the test suite with ty

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -9,7 +9,7 @@ set -x
 
 # Python.
 uv run --no-sync ruff format --check --diff $SOURCE_FILES
-uv run --no-sync ty check --error-on-warning zttp
+uv run --no-sync ty check --error-on-warning zttp tests
 # Verify the hand-written extension stub matches the compiled module, so the
 # types cannot silently drift from _zttp. Intentional gaps live in the allowlist.
 # mypy remains a development dependency only because it provides stubtest.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,18 +11,18 @@ def test_value_objects_are_frozen() -> None:
     creds = zttp.TlsCredentials(certificate=b"CERT", private_key=b"KEY")
     resumption = zttp.SessionResumption(identity=b"id", psk=b"\x00" * 32)
     with pytest.raises(dataclasses.FrozenInstanceError):
-        creds.certificate = b"other"  # type: ignore[misc]
+        creds.certificate = b"other"  # ty: ignore[invalid-assignment]
     with pytest.raises(dataclasses.FrozenInstanceError):
-        resumption.psk = b"other"  # type: ignore[misc]
+        resumption.psk = b"other"  # ty: ignore[invalid-assignment]
 
 
 def test_credentials_and_resumption_need_both_halves() -> None:
     # Naming both fields is the whole point: neither can be built half-formed, so a
     # certificate/key (or identity/psk) swap has nowhere to hide.
     with pytest.raises(TypeError):
-        zttp.TlsCredentials(certificate=b"CERT")  # type: ignore[call-arg]
+        zttp.TlsCredentials(certificate=b"CERT")  # ty: ignore[missing-argument]
     with pytest.raises(TypeError):
-        zttp.SessionResumption(identity=b"id")  # type: ignore[call-arg]
+        zttp.SessionResumption(identity=b"id")  # ty: ignore[missing-argument]
 
 
 def test_quic_transport_parameters_is_a_typed_dictionary() -> None:
@@ -49,7 +49,7 @@ def test_h3_constructor_rejects_the_old_raw_kwargs() -> None:
         {"resumption_identity": b"i", "resumption_psk": b"\x00" * 32},
     ):
         with pytest.raises(TypeError):
-            zttp.Connection(zttp.SERVER, zttp.HTTP3, **bad)  # type: ignore[call-overload]
+            zttp.Connection(zttp.SERVER, zttp.HTTP3, **bad)  # ty: ignore[no-matching-overload]
 
 
 def test_value_objects_are_keyword_only() -> None:
@@ -57,8 +57,8 @@ def test_value_objects_are_keyword_only() -> None:
     # fields are keyword-only: TlsCredentials(key, cert) is a TypeError, not a silent
     # transposition.
     with pytest.raises(TypeError):
-        zttp.TlsCredentials(b"cert", b"key")  # type: ignore[misc]
+        zttp.TlsCredentials(b"cert", b"key")  # ty: ignore[missing-argument, too-many-positional-arguments]
     with pytest.raises(TypeError):
-        zttp.SessionResumption(b"id", b"psk")  # type: ignore[misc]
+        zttp.SessionResumption(b"id", b"psk")  # ty: ignore[missing-argument, too-many-positional-arguments]
     # Keyword construction is unaffected.
     assert zttp.TlsCredentials(certificate=b"c", private_key=b"k").private_key == b"k"

--- a/tests/test_connection_signals.py
+++ b/tests/test_connection_signals.py
@@ -6,7 +6,7 @@ import zttp
 from tests.conftest import drain
 
 
-def _parse(data: bytes) -> zttp.Connection:
+def _parse(data: bytes) -> zttp.H1Connection:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(data)
     list(drain(conn))
@@ -63,7 +63,7 @@ def test_client_should_close_for_close_delimited_response() -> None:
     assert conn.should_close() is True
 
 
-def _respond(*headers: tuple[bytes, bytes]) -> zttp.Connection:
+def _respond(*headers: tuple[bytes, bytes]) -> zttp.H1Connection:
     conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
     assert conn.should_close() is False
     conn.send_response(200, [(b"content-length", b"0"), *headers])

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -23,7 +23,7 @@ def frame(ftype: int, flags: int, stream_id: int, payload: bytes) -> bytes:
     return header + payload
 
 
-def drain_h2(conn: zttp.Connection) -> Iterator[object]:
+def drain_h2(conn: zttp.H2Connection) -> Iterator[object]:
     """Pull events until NEED_DATA. Unlike the HTTP/1.1 drain, it does NOT stop at
     the first EndOfMessage - HTTP/2 multiplexes many streams on one connection."""
     while True:
@@ -33,7 +33,7 @@ def drain_h2(conn: zttp.Connection) -> Iterator[object]:
         yield ev
 
 
-def server_with(*extra: bytes) -> zttp.Connection:
+def server_with(*extra: bytes) -> zttp.H2Connection:
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
     conn.receive_data(PREFACE + frame(0x04, 0, 0, b"") + b"".join(extra))
     return conn
@@ -207,7 +207,7 @@ def test_partial_feed_resumes() -> None:
 STATUS_200 = bytes([0x88])
 
 
-def client_with(*extra: bytes) -> zttp.Connection:
+def client_with(*extra: bytes) -> zttp.H2Connection:
     """A client sees only the server's SETTINGS (no preface to consume)."""
     conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
     conn.receive_data(frame(0x04, 0, 0, b"") + b"".join(extra))
@@ -279,7 +279,7 @@ def test_h2_send_side_trailers_rejected() -> None:
     with pytest.raises(zttp.LocalProtocolError, match="HTTP/2 send-side trailers are not supported yet"):
         stream.end_message([(b"x-trailer", b"v")])
     with pytest.raises(zttp.LocalProtocolError, match="HTTP/2 send-side trailers are not supported yet"):
-        stream.end_message([(b"malformed",)])  # type: ignore[list-item]
+        stream.end_message([(b"malformed",)])  # ty: ignore[invalid-argument-type]
 
 
 def test_h2_concurrent_responses_route_by_their_stream() -> None:
@@ -361,7 +361,7 @@ def test_protocol_defaults_to_http1() -> None:
 
 def test_invalid_protocol_rejected() -> None:
     with pytest.raises(ValueError):
-        zttp.Connection(zttp.SERVER, protocol=99)
+        zttp.Connection(zttp.SERVER, protocol=99)  # ty: ignore[no-matching-overload]
 
 
 def test_connection_factory_cannot_be_subclassed() -> None:
@@ -419,7 +419,7 @@ def test_stream_handle_round_trips_a_response() -> None:
 # -- Outbound flow control -----------------------------------------------------
 
 
-def server_with_small_window(initial: int) -> zttp.Connection:
+def server_with_small_window(initial: int) -> zttp.H2Connection:
     """A server whose peer advertised SETTINGS_INITIAL_WINDOW_SIZE=`initial`, with
     request stream 1 already opened and drained."""
     settings = (0x04).to_bytes(2, "big") + initial.to_bytes(4, "big")  # INITIAL_WINDOW_SIZE
@@ -544,7 +544,7 @@ def test_h2_close_accepts_an_explicit_code_and_last_stream_id() -> None:
 def test_h2_close_on_an_http1_connection_is_an_error() -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(AttributeError):
-        conn.close()
+        conn.close()  # ty: ignore[unresolved-attribute]
 
 
 def test_h2_response_after_stream_reset_is_ignored() -> None:
@@ -717,7 +717,7 @@ def test_initiate_connection_is_idempotent() -> None:
 def test_initiate_connection_on_http1_is_an_error() -> None:
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP1)
     with pytest.raises(AttributeError):
-        conn.initiate_connection()
+        conn.initiate_connection()  # ty: ignore[unresolved-attribute]
 
 
 def test_send_response_end_stream_rides_the_headers_frame() -> None:
@@ -894,4 +894,6 @@ def test_h2c_seed_twice_is_an_error() -> None:
 def test_initiate_upgrade_connection_on_http1_is_an_error() -> None:
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP1)
     with pytest.raises(AttributeError):
-        conn.initiate_upgrade_connection(b"GET", b"/", [(b"host", b"x")])
+        conn.initiate_upgrade_connection(  # ty: ignore[unresolved-attribute]
+            b"GET", b"/", [(b"host", b"x")]
+        )

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -4,6 +4,7 @@ import dataclasses
 import pickle
 
 import pytest
+from typing_extensions import TypedDict
 
 import zttp
 
@@ -23,7 +24,36 @@ SERVER_TRANSPORT_PARAMS = (
     b"\x06\x04\x80\x04\x00\x00"  # initial_max_stream_data_bidi_remote = 262144
     b"\x07\x04\x80\x04\x00\x00"  # initial_max_stream_data_uni = 262144
 )
-SERVER_CONFIG = {
+
+
+class ServerConfig(TypedDict):
+    credentials: zttp.TlsCredentials
+    transport_params: zttp.QuicTransportParameters
+    random: bytes
+    ephemeral_seed: bytes
+
+
+class ClientConfig(TypedDict):
+    transport_params: zttp.QuicTransportParameters
+    random: bytes
+    ephemeral_seed: bytes
+    connection_id: bytes
+    alpn: bytes
+    server_name: bytes
+
+
+class ResumedClientConfig(ClientConfig, total=False):
+    resumption: zttp.SessionResumption
+    obfuscated_ticket_age: int
+    early_data: bool
+    remembered_transport_params: bytes
+
+
+class ResumedServerConfig(ServerConfig, total=False):
+    resumption: zttp.SessionResumption
+
+
+SERVER_CONFIG: ResumedServerConfig = {
     "credentials": zttp.TlsCredentials(certificate=SERVER_PUBLIC_KEY, private_key=b"\x42" * 32),
     "transport_params": zttp.QuicTransportParameters(
         initial_max_data=1048576,
@@ -36,7 +66,7 @@ SERVER_CONFIG = {
     "ephemeral_seed": b"\x33" * 32,
 }
 
-CLIENT_CONFIG = {
+CLIENT_CONFIG: ResumedClientConfig = {
     "transport_params": zttp.QuicTransportParameters(
         initial_max_data=65536,
         initial_max_stream_data_bidi_local=262144,
@@ -154,7 +184,7 @@ def test_parse_datagram_header_does_not_trust_an_unsupported_version() -> None:
 def test_parse_datagram_header_result_is_frozen() -> None:
     header = zttp.parse_datagram_header(b"\x40\x00")
     with pytest.raises(dataclasses.FrozenInstanceError):
-        header.version = 9  # type: ignore[misc]
+        header.version = 9  # ty: ignore[invalid-assignment]
 
 
 def test_http3_client_construction_emits_an_initial() -> None:
@@ -168,7 +198,7 @@ def test_http3_client_construction_emits_an_initial() -> None:
 
 
 def test_http3_client_initial_can_carry_validation_token() -> None:
-    config = dict(CLIENT_CONFIG)
+    config = CLIENT_CONFIG.copy()
     config["connection_id"] = b"\x11\x22\x33\x4d"
     conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config, validation_token=b"validated-earlier")
     [initial] = conn.data_to_send()
@@ -181,14 +211,16 @@ def test_http3_validation_tokens_starts_empty() -> None:
 
 
 def test_http3_validation_token_must_not_be_empty() -> None:
-    config = dict(CLIENT_CONFIG)
+    config = CLIENT_CONFIG.copy()
     with pytest.raises(ValueError):
         zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config, validation_token=b"")
 
 
 def test_http3_validation_token_is_client_only() -> None:
     with pytest.raises(ValueError):
-        zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **SERVER_CONFIG, validation_token=b"token")
+        zttp.Connection(  # ty: ignore[no-matching-overload]
+            zttp.SERVER, protocol=zttp.HTTP3, **SERVER_CONFIG, validation_token=b"token"
+        )
 
 
 def test_http3_client_defaults_transport_settings_and_connection_id() -> None:
@@ -218,7 +250,7 @@ def test_http3_default_client_and_server_exchange_request() -> None:
 
 
 def test_http3_client_rejects_unverifiable_server_certificate() -> None:
-    config = dict(SERVER_CONFIG)
+    config = SERVER_CONFIG.copy()
     config["credentials"] = zttp.TlsCredentials(certificate=b"\xcc" * 48, private_key=b"\x42" * 32)
     client = make_client()
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
@@ -334,7 +366,7 @@ def test_http3_received_session_ticket_psk_resumes_later_connection() -> None:
     assert len(psk) == 32
     assert psk == issued_psk
 
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x47",
@@ -381,8 +413,9 @@ def test_http3_ticket_age_mismatch_does_not_accept_zero_rtt() -> None:
     assert transfer(first_server, first_client, 5000)
     [ticket] = first_client.session_tickets()
     identity, psk = ticket.ticket, ticket.psk
+    assert isinstance(psk, bytes)
 
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x48",
@@ -423,9 +456,10 @@ def test_http3_expired_ticket_does_not_accept_zero_rtt() -> None:
     assert transfer(first_server, first_client, 5000)
     [ticket] = first_client.session_tickets()
     age_add, identity, psk = ticket.age_add, ticket.ticket, ticket.psk
+    assert isinstance(psk, bytes)
 
     resume_at = 2_500_000
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x49",
@@ -466,9 +500,10 @@ def test_http3_ticket_without_early_data_extension_does_not_accept_zero_rtt() ->
     assert transfer(first_server, first_client, 5000)
     [ticket] = first_client.session_tickets()
     age_add, identity, psk = ticket.age_add, ticket.ticket, ticket.psk
+    assert isinstance(psk, bytes)
     assert ticket.max_early_data_size is None
 
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x4a",
@@ -509,9 +544,10 @@ def test_http3_zero_rtt_ticket_is_single_use() -> None:
     assert transfer(first_server, first_client, 5000)
     [ticket] = first_client.session_tickets()
     age_add, identity, psk = ticket.age_add, ticket.ticket, ticket.psk
+    assert isinstance(psk, bytes)
 
     def make_early_client(connection_id: bytes, now: int) -> zttp.H3Connection:
-        client_config = dict(CLIENT_CONFIG)
+        client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
         client_config.update(
             {
                 "connection_id": connection_id,
@@ -544,7 +580,7 @@ def test_http3_zero_rtt_ticket_is_single_use() -> None:
 
 def test_http3_client_server_resumed_handshake() -> None:
     psk = b"\x7b" * 32
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x45",
@@ -552,7 +588,7 @@ def test_http3_client_server_resumed_handshake() -> None:
             "obfuscated_ticket_age": 0x01020304,
         }
     )
-    server_config = dict(SERVER_CONFIG)
+    server_config: ResumedServerConfig = SERVER_CONFIG.copy()
     server_config.update(
         {
             "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
@@ -579,7 +615,7 @@ def test_http3_client_server_resumed_handshake() -> None:
 
 def test_http3_static_resumption_credentials_do_not_accept_zero_rtt() -> None:
     psk = b"\x7b" * 32
-    client_config = dict(CLIENT_CONFIG)
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
     client_config.update(
         {
             "connection_id": b"\x11\x22\x33\x46",
@@ -589,7 +625,7 @@ def test_http3_static_resumption_credentials_do_not_accept_zero_rtt() -> None:
             "remembered_transport_params": SERVER_TRANSPORT_PARAMS,
         }
     )
-    server_config = dict(SERVER_CONFIG)
+    server_config: ResumedServerConfig = SERVER_CONFIG.copy()
     server_config.update(
         {
             "resumption": zttp.SessionResumption(identity=b"ticket-identity", psk=psk),
@@ -763,7 +799,7 @@ def test_http3_server_defaults_transport_settings_and_credentials() -> None:
 
 
 def test_http3_accepts_typed_transport_parameters() -> None:
-    client_config = dict(CLIENT_CONFIG)
+    client_config = CLIENT_CONFIG.copy()
     client_config["transport_params"] = zttp.QuicTransportParameters(
         initial_max_data=65536,
         initial_max_stream_data_bidi_local=4096,
@@ -775,7 +811,7 @@ def test_http3_accepts_typed_transport_parameters() -> None:
         max_udp_payload_size=1200,
         disable_active_migration=True,
     )
-    server_config = dict(SERVER_CONFIG)
+    server_config = SERVER_CONFIG.copy()
     server_config["transport_params"] = zttp.QuicTransportParameters(
         initial_max_data=1048576,
         initial_max_stream_data_bidi_remote=262144,
@@ -801,7 +837,7 @@ def test_http3_accepts_typed_transport_parameters() -> None:
 
 
 def test_http3_typed_transport_parameters_preserve_role_defaults() -> None:
-    config = dict(SERVER_CONFIG)
+    config = SERVER_CONFIG.copy()
     config["transport_params"] = zttp.QuicTransportParameters(max_idle_timeout=30_000)
     client = make_client()
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
@@ -817,9 +853,15 @@ def test_http3_typed_transport_parameters_preserve_role_defaults() -> None:
 
 def test_http3_typed_transport_parameters_validate_in_the_extension() -> None:
     with pytest.raises(TypeError):
-        zttp.Connection(zttp.CLIENT, zttp.HTTP3, transport_params=b"raw")  # type: ignore[arg-type]
+        zttp.Connection(  # ty: ignore[no-matching-overload]
+            zttp.CLIENT, zttp.HTTP3, transport_params=b"raw"
+        )
     with pytest.raises(ValueError, match="unknown field"):
-        zttp.Connection(zttp.CLIENT, zttp.HTTP3, transport_params={"unknown": 1})  # type: ignore[typeddict-unknown-key]
+        zttp.Connection(  # ty: ignore[no-matching-overload]
+            zttp.CLIENT,
+            zttp.HTTP3,
+            transport_params={"unknown": 1},  # ty: ignore[invalid-key]
+        )
     with pytest.raises(ValueError, match="outside the QUIC range"):
         zttp.Connection(zttp.CLIENT, zttp.HTTP3, transport_params={"max_udp_payload_size": 1199})
     with pytest.raises(ValueError, match="only valid for HTTP/3 servers"):
@@ -833,9 +875,9 @@ def test_http3_typed_transport_parameters_validate_in_the_extension() -> None:
 def test_http3_server_custom_credentials_must_be_a_pair() -> None:
     # TlsCredentials names both halves, so a lone certificate or key cannot be built.
     with pytest.raises(TypeError):
-        zttp.TlsCredentials(certificate=b"\xcc" * 48)  # type: ignore[call-arg]
+        zttp.TlsCredentials(certificate=b"\xcc" * 48)  # ty: ignore[missing-argument]
     with pytest.raises(TypeError):
-        zttp.TlsCredentials(private_key=b"\x42" * 32)  # type: ignore[call-arg]
+        zttp.TlsCredentials(private_key=b"\x42" * 32)  # ty: ignore[missing-argument]
 
 
 def test_http3_rejects_a_wrong_size_key() -> None:
@@ -875,7 +917,7 @@ def test_first_datagram_must_be_an_initial() -> None:
 
 def test_a_non_conformant_client_hello_is_rejected() -> None:
     # Wrong ALPN - the server requires HTTP/3 clients to negotiate "h3".
-    config = dict(CLIENT_CONFIG)
+    config = CLIENT_CONFIG.copy()
     config["alpn"] = b"http/1.1"
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config)
     conn = make_server()
@@ -1133,7 +1175,7 @@ def test_issue_connection_id_validates_inputs() -> None:
     with pytest.raises(ValueError):
         server.issue_connection_id(1, b"server-cid-1", b"short")
     with pytest.raises(TypeError):
-        server.issue_connection_id(1, object(), b"\x5a" * 16)  # type: ignore[arg-type]
+        server.issue_connection_id(1, object(), b"\x5a" * 16)  # ty: ignore[invalid-argument-type]
 
 
 def test_request_key_update_requires_application_keys() -> None:
@@ -1159,8 +1201,8 @@ def test_request_key_update_applies_to_next_http3_packet() -> None:
 
 def test_disable_active_migration_rejects_new_peer_address_after_handshake() -> None:
     client = make_client()
-    config = dict(SERVER_CONFIG)
-    transport_params = dict(SERVER_CONFIG["transport_params"])
+    config = SERVER_CONFIG.copy()
+    transport_params = SERVER_CONFIG["transport_params"].copy()
     transport_params["disable_active_migration"] = True
     config["transport_params"] = transport_params
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
@@ -1185,7 +1227,7 @@ def test_disable_active_migration_rejects_new_peer_address_after_handshake() -> 
 def test_receive_datagram_peer_address_must_be_bytes() -> None:
     conn = make_server()
     with pytest.raises(TypeError):
-        conn.receive_datagram(CLIENT_HELLO, 1000, object())
+        conn.receive_datagram(CLIENT_HELLO, 1000, object())  # ty: ignore[invalid-argument-type]
 
 
 def test_http3_reads_a_get_request_after_a_real_handshake() -> None:
@@ -1520,7 +1562,7 @@ def test_next_timeout_arms_after_the_handshake_flight() -> None:
 
 
 def test_idle_timeout_closes_http3_connection() -> None:
-    config = dict(SERVER_CONFIG)
+    config = SERVER_CONFIG.copy()
     config["transport_params"] = zttp.QuicTransportParameters(max_idle_timeout=5)
     conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
 
@@ -1562,7 +1604,7 @@ def test_h3_result_rows_are_frozen_dataclasses() -> None:
     assert row.lifetime == 1
     assert row.max_early_data_size is None
     with pytest.raises(dataclasses.FrozenInstanceError):
-        row.lifetime = 2  # type: ignore[misc]
+        row.lifetime = 2  # ty: ignore[invalid-assignment]
 
 
 def test_h3_result_rows_are_picklable() -> None:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -69,14 +69,17 @@ def test_post_content_length() -> None:
 def test_zero_content_length_has_no_data() -> None:
     events = parse_request(b"POST / HTTP/1.1\r\nContent-Length: 0\r\n\r\n")
     assert not any(isinstance(e, zttp.Data) for e in events)
-    assert isinstance(events[-1], zttp.Request)
-    assert events[-1].end_stream is True
+    request = events[-1]
+    assert isinstance(request, zttp.Request)
+    assert request.end_stream is True
 
 
 def test_no_body_get_completes_on_request() -> None:
     events = parse_request(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
     assert len(events) == 1
-    assert events[0].end_stream is True
+    request = events[0]
+    assert isinstance(request, zttp.Request)
+    assert request.end_stream is True
 
 
 def test_chunked_body() -> None:
@@ -108,6 +111,7 @@ def test_headers_are_owned_and_sequence_compatible() -> None:
     conn.receive_data(b"GET /one HTTP/1.1\r\nHost: first\r\nX-Test: a\r\nX-Test: b\r\n\r\n")
     req = conn.next_event()
 
+    assert isinstance(req, zttp.Request)
     assert isinstance(req.headers, zttp.HeaderBlock)
     assert len(req.headers) == 3
     assert req.headers[0] == (b"Host", b"first")
@@ -126,7 +130,7 @@ def test_headers_are_owned_and_sequence_compatible() -> None:
     with pytest.raises(IndexError, match="header index out of range"):
         req.headers[3]
     with pytest.raises(TypeError, match="header indices must be integers or slices"):
-        req.headers[b"Host"]  # type: ignore[index]
+        req.headers[b"Host"]  # ty: ignore[invalid-argument-type]
     assert req.headers.to_list(lowercase_names=True) == [
         (b"host", b"first"),
         (b"x-test", b"a"),
@@ -146,7 +150,9 @@ def test_header_block_releases_its_heap_type_reference() -> None:
         for _ in range(100):
             conn = zttp.Connection(zttp.SERVER)
             conn.receive_data(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
-            conn.next_event().headers
+            request = conn.next_event()
+            assert isinstance(request, zttp.Request)
+            _ = request.headers
 
     # Warm any interpreter-level caches before measuring the type reference.
     create_blocks()
@@ -162,11 +168,12 @@ def test_h1_headers_are_immutable_by_default() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
     req = conn.next_event()
+    assert isinstance(req, zttp.Request)
     assert isinstance(req.headers, zttp.HeaderBlock)
     with pytest.raises(AttributeError):
-        req.headers.append((b"X", b"y"))  # type: ignore[attr-defined]
+        req.headers.append((b"X", b"y"))  # ty: ignore[unresolved-attribute]
     with pytest.raises(TypeError, match="created by HTTP/1 parsing"):
-        zttp.HeaderBlock()  # type: ignore[call-arg]
+        zttp.HeaderBlock()
 
 
 def test_header_value_whitespace_stripped() -> None:
@@ -190,10 +197,14 @@ def test_body_split_across_feeds() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhel")
     assert isinstance(conn.next_event(), zttp.Request)
-    assert conn.next_event().data == b"hel"
+    first = conn.next_event()
+    assert isinstance(first, zttp.Data)
+    assert first.data == b"hel"
     assert conn.next_event() is zttp.NEED_DATA
     conn.receive_data(b"loworld")
-    assert conn.next_event().data == b"loworld"
+    second = conn.next_event()
+    assert isinstance(second, zttp.Data)
+    assert second.data == b"loworld"
     assert isinstance(conn.next_event(), zttp.EndOfMessage)
 
 
@@ -282,10 +293,13 @@ def test_keep_alive_two_requests() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET /a HTTP/1.1\r\nHost: x\r\n\r\nGET /b HTTP/1.1\r\nHost: y\r\n\r\n")
     first = conn.next_event()
+    assert isinstance(first, zttp.Request)
     assert first.target == b"/a"
     assert first.end_stream is True
     conn.start_next_cycle()
-    assert conn.next_event().target == b"/b"
+    second = conn.next_event()
+    assert isinstance(second, zttp.Request)
+    assert second.target == b"/b"
 
 
 def test_response_parsing() -> None:
@@ -298,7 +312,9 @@ def test_response_parsing() -> None:
     assert resp.http_version == b"1.1"
     assert isinstance(resp.headers, zttp.HeaderBlock)
     assert resp.headers.get(b"content-length") == b"3"
-    assert conn.next_event().data == b"xyz"
+    data = conn.next_event()
+    assert isinstance(data, zttp.Data)
+    assert data.data == b"xyz"
 
 
 @pytest.mark.parametrize(
@@ -333,7 +349,9 @@ def test_response_until_close() -> None:
     conn = zttp.Connection(zttp.CLIENT)
     conn.receive_data(b"HTTP/1.1 200 OK\r\nServer: z\r\n\r\nbody here")
     assert isinstance(conn.next_event(), zttp.Response)
-    assert conn.next_event().data == b"body here"
+    data = conn.next_event()
+    assert isinstance(data, zttp.Data)
+    assert data.data == b"body here"
     assert conn.next_event() is zttp.NEED_DATA
     conn.receive_data(b"")  # EOF
     assert isinstance(conn.next_event(), zttp.EndOfMessage)
@@ -399,11 +417,15 @@ def test_body_and_pipelined_request_in_one_feed() -> None:
         b"POST /a HTTP/1.1\r\nContent-Length: 5\r\n\r\nfirstPOST /b HTTP/1.1\r\nContent-Length: 6\r\n\r\nsecond"
     )
     events = list(drain(conn))
-    assert events[0].target == b"/a"
+    first = events[0]
+    assert isinstance(first, zttp.Request)
+    assert first.target == b"/a"
     assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"first"
     conn.start_next_cycle()
     events = list(drain(conn))
-    assert events[0].target == b"/b"
+    second = events[0]
+    assert isinstance(second, zttp.Request)
+    assert second.target == b"/b"
     assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"second"
 
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+from collections.abc import Callable
 
 import pytest
 
@@ -29,7 +30,7 @@ def test_h2_synthesizing_sequence_headers_roundtrip() -> None:
 
     n = 40
     client = zttp.Connection(zttp.CLIENT)
-    client.send_request(b"GET", b"/", b"1.1", Synth(n))
+    client.send_request(b"GET", b"/", b"1.1", Synth(n))  # ty: ignore[invalid-argument-type]
     client.end_message()
     wire = client.data_to_send()
 
@@ -96,7 +97,7 @@ def test_bare_lf_request_rejected_by_default() -> None:
         lambda c: c.send_request(b"GET", b"/", b"1.1", [(b"Bad Name", b"x")]),
     ],
 )
-def test_send_path_injection_rejected(call) -> None:  # type: ignore[no-untyped-def]
+def test_send_path_injection_rejected(call: Callable[[zttp.H1Connection], object]) -> None:
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.LocalProtocolError):
         call(conn)
@@ -121,9 +122,9 @@ def test_event_cycle_is_collectable() -> None:
         e = c.next_event()
         assert isinstance(e, zttp.EndOfMessage)
         can = Canary()
-        e.trailers.append(e)
-        e.trailers.append(can)
-        can.back = e
+        e.trailers.append(e)  # ty: ignore[invalid-argument-type]
+        e.trailers.append(can)  # ty: ignore[invalid-argument-type]
+        can.back = e  # ty: ignore[unresolved-attribute]
 
     for _ in range(25):
         make_cycle()

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 import zttp
@@ -72,7 +74,7 @@ def test_trailers_rejected_on_bodyless_message() -> None:
         (lambda c: c.end_message(), "no message is in progress to end"),
     ],
 )
-def test_send_misuse_raises_specific_message(misuse, message: str) -> None:  # type: ignore[no-untyped-def]
+def test_send_misuse_raises_specific_message(misuse: Callable[[zttp.H1Connection], object], message: str) -> None:
     # Distinct, actionable messages - all catchable by the one base class.
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.ProtocolError, match=message):
@@ -99,7 +101,7 @@ def test_send_request() -> None:
 )
 def test_send_response_accepts_common_header_sequence_shapes(headers: object) -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.send_response(204, headers)  # type: ignore[arg-type]
+    conn.send_response(204, headers)  # ty: ignore[invalid-argument-type]
     conn.end_message()
     assert conn.data_to_send() == b"HTTP/1.1 204 No Content\r\nX-One: 1\r\nX-Two: 2\r\n\r\n"
 

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -10,12 +10,12 @@ from typing_extensions import disjoint_base
 from zttp.config import QuicTransportParameters, SessionResumption, TlsCredentials
 from zttp.results import CloseInfo, DatagramHeader, SessionTicket
 
-SERVER: Final = 1
-CLIENT: Final = 2
+SERVER: Final[Literal[1]] = 1
+CLIENT: Final[Literal[2]] = 2
 # Literal-typed so Connection(role, HTTP2) selects the H2Connection __new__ overload.
-HTTP1: Final = 1
-HTTP2: Final = 2
-HTTP3: Final = 3
+HTTP1: Final[Literal[1]] = 1
+HTTP2: Final[Literal[2]] = 2
+HTTP3: Final[Literal[3]] = 3
 
 _DefaultT = TypeVar("_DefaultT")
 


### PR DESCRIPTION
Extends the ty check to `tests` and makes the suite pass without broad rule exclusions. Test helpers now use their concrete connection types, HTTP/3 configuration dictionaries are typed, and event assertions narrow unions before accessing protocol-specific fields.

Intentional negative tests use targeted `ty: ignore` comments for the exact invalid operation they exercise. The full Python suite, Zig suite, and 100% coverage check pass.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Type-checks the entire test suite with `ty` and fixes types across tests and stubs so CI catches typing regressions without broad suppressions. Previously only `zttp` was checked; now `tests` is included. Runtime behavior is unchanged.

- Tooling: `scripts/check` runs `ty check --error-on-warning zttp tests`.
- Tests: helpers now return concrete `H1Connection`/`H2Connection`/`H3Connection`; event assertions narrow unions before field access; HTTP/3 configs use `TypedDict` and typed `QuicTransportParameters`; use `.copy()` instead of `dict(...)` to preserve `TypedDict` types; intentional negatives use targeted `ty: ignore[...]`.
- Types-only API: in `zttp/_zttp.pyi`, `SERVER`, `CLIENT`, and `HTTP1`/`HTTP2`/`HTTP3` are `Final[Literal[...]]` to improve overload selection for `Connection(...)`. No runtime change.

<sup>Written for commit a58535f65470275771ca4d083bcd9ce69d944e69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

