### PR TITLE
Restore main branch CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dynamic = ["version"]
+dependencies = ["typing-extensions>=4.0"]
 
 [project.urls]
 Homepage = "https://github.com/Kludex/zttp"

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -763,13 +763,13 @@ def test_http3_client_request_trailers() -> None:
 
 
 def test_http3_receive_credit_waits_for_application_consumption() -> None:
-    config = dict(SERVER_CONFIG)
-    config["transport_params"] = (
-        b"\x04\x02\x42\x00"  # initial_max_data = 512
-        b"\x06\x02\x42\x00"  # initial_max_stream_data_bidi_remote = 512
-        b"\x07\x04\x80\x04\x00\x00"  # initial_max_stream_data_uni = 262144
-        b"\x08\x01\x08"  # initial_max_streams_bidi = 8
-        b"\x09\x01\x08"  # initial_max_streams_uni = 8
+    config = SERVER_CONFIG.copy()
+    config["transport_params"] = zttp.QuicTransportParameters(
+        initial_max_data=512,
+        initial_max_stream_data_bidi_remote=512,
+        initial_max_stream_data_uni=262144,
+        initial_max_streams_bidi=8,
+        initial_max_streams_uni=8,
     )
     client = make_client()
     server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
@@ -1244,7 +1244,7 @@ def test_local_connection_ids_route_two_connections_on_one_endpoint() -> None:
     pairs: list[tuple[zttp.H3Connection, zttp.H3Connection, bytes]] = []
     routes: dict[bytes, zttp.H3Connection] = {}
     for index, original in enumerate((b"client-a", b"client-b"), start=1):
-        config = dict(CLIENT_CONFIG)
+        config = CLIENT_CONFIG.copy()
         config["connection_id"] = original
         client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config)
         server = make_server()

--- a/uv.lock
+++ b/uv.lock
@@ -1374,6 +1374,9 @@ wheels = [
 [[package]]
 name = "zttp"
 source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
 
 [package.dev-dependencies]
 bench = [
@@ -1399,6 +1402,7 @@ fuzz = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.0" }]
 
 [package.metadata.requires-dev]
 bench = [


### PR DESCRIPTION
## Summary

- Add the missing runtime dependency on `typing-extensions` so built wheels can import `zttp`.
- Update the receive-credit test to use typed QUIC transport parameters.
- Preserve the HTTP/3 connection type when copying client test configuration.

## Testing

- `./scripts/check`
- `zig build test`
- `./scripts/test`
- `./scripts/coverage`
- `./scripts/docs`
- Built and installed the wheel in an isolated virtual environment.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores main-branch CI by declaring `typing-extensions` as a runtime dependency and updating HTTP/3 tests to use typed QUIC parameters. Previously built wheels could fail to import `zttp`; tests also used dict copies that could drop the HTTP/3 connection type.

**Review notes**
- Add `typing-extensions>=4.0` to runtime deps and `uv.lock` to ensure built wheels import `zttp`.
- Replace byte-encoded QUIC transport parameters with `zttp.QuicTransportParameters` in tests.
- Use `SERVER_CONFIG.copy()`/`CLIENT_CONFIG.copy()` instead of `dict(...)` to preserve the HTTP/3 connection type in tests.

<sup>Written for commit 57136ef57efd67008102559982757c2ad8e72cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

