### PR TITLE
Accept buffer protocol inputs in receive paths

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -15,7 +15,8 @@ protocol you picked - an `H1Connection` (the default), an `H2Connection`, or an
 isn't a usable instance type and can't be subclassed; only `next_event()` is
 common to all three, because the read/write *byte* surface is transport-specific.
 HTTP/1.1 provides `receive_event` and `receive_data`, HTTP/2 reads
-`receive_data`, and HTTP/3 reads `receive_datagram`.
+`receive_data`, and HTTP/3 reads `receive_datagram`. Each receive method accepts
+any contiguous buffer, including `bytes`, `bytearray`, and `memoryview`.
 
 ::: zttp.Connection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP",
 ]
 dynamic = ["version"]
-dependencies = ["typing-extensions>=4.0"]
+dependencies = ["typing-extensions>=4.6"]
 
 [project.urls]
 Homepage = "https://github.com/Kludex/zttp"

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1,5 +1,5 @@
 //! The Python `Connection` object: a thin wrapper over the core engine exposing
-//! the sans-IO pull API. `receive_data(bytes)` appends to the parse buffer;
+//! the sans-IO pull API. `receive_data(buffer)` appends to the parse buffer;
 //! `next_event()` returns the next Request/Response/Data/EndOfMessage event, or
 //! the NEED_DATA singleton. The write side (send/data_to_send) is added on top.
 
@@ -62,6 +62,7 @@ const PendingInput = struct {
     const retain_body_min = 512;
 
     inline fn retain(self: *PendingInput, reader: *Reader, owner: py.Object, bytes: []const u8) core.errors.ParseError!void {
+        std.debug.assert(owner != null);
         std.debug.assert(bytes.len > 0);
         std.debug.assert(self.owner == null);
         std.debug.assert(self.bytes.len == 0);
@@ -460,7 +461,7 @@ const H1Engine = struct {
     /// itself when a sizeable body follows.
     const head_split_min_feed = 1024;
 
-    fn feedData(self: *H1Engine, data: []const u8, obj: py.Object) bool {
+    fn feedData(self: *H1Engine, data: []const u8, stable_owner: py.Object) bool {
         self.pending.flushInto(&self.reader) catch |err| {
             _ = exceptions.raiseParse(err);
             return false;
@@ -469,9 +470,9 @@ const H1Engine = struct {
             _ = exceptions.raiseParse(error.ProtocolError);
             return false;
         }
-        if (data.len > 0 and self.reader.backlogEmpty()) {
+        if (stable_owner != null and data.len > 0 and self.reader.backlogEmpty()) {
             if (self.reader.bodyLengthRemaining() != null) {
-                self.pending.retain(&self.reader, obj, data) catch |err| {
+                self.pending.retain(&self.reader, stable_owner, data) catch |err| {
                     _ = exceptions.raiseParse(err);
                     return false;
                 };
@@ -487,7 +488,7 @@ const H1Engine = struct {
                         _ = exceptions.raiseParse(err);
                         return false;
                     };
-                    if (head_end < data.len) self.pending.retain(&self.reader, obj, data[head_end..]) catch |err| {
+                    if (head_end < data.len) self.pending.retain(&self.reader, stable_owner, data[head_end..]) catch |err| {
                         _ = exceptions.raiseParse(err);
                         return false;
                     };
@@ -502,8 +503,8 @@ const H1Engine = struct {
         return true;
     }
 
-    fn receiveData(self: *H1Engine, data: []const u8, obj: py.Object) py.Object {
-        return if (self.feedData(data, obj)) py.none() else null;
+    fn receiveData(self: *H1Engine, data: []const u8, stable_owner: py.Object) py.Object {
+        return if (self.feedData(data, stable_owner)) py.none() else null;
     }
 
     fn deinit(self: *H1Engine) void {
@@ -1432,8 +1433,9 @@ var outbound_datagram_type: py.Object = null;
 /// prefix of a received QUIC datagram, for demultiplexing a shared UDP socket onto
 /// per-connection state without constructing a connection.
 fn parse_datagram_header(_: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
-    const data = py.asBytes(arg) orelse return null;
-    const hdr = core.quic.packet.parseDatagramHeader(data) catch
+    var data = py.BorrowedBuffer.init(arg) orelse return null;
+    defer data.deinit();
+    const hdr = core.quic.packet.parseDatagramHeader(data.bytes) catch
         return py.raise(exceptions.RemoteProtocolError, "malformed QUIC packet header");
     const dh_type = resultType(&datagram_header_type, "DatagramHeader") orelse return null;
     const tuple = py.tupleNew(6);
@@ -2339,17 +2341,18 @@ fn h1(self: *ConnectionObject) ?*H1Engine {
 
 fn receive_data(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
-    const bytes = py.asBytes(arg) orelse return null;
+    var data = py.BorrowedBuffer.init(arg) orelse return null;
+    defer data.deinit();
     const engine = self.engine orelse return py.raiseRuntime("connection is closed");
     switch (engine.*) {
         .h2 => |*e| {
-            e.conn.feed(bytes) catch |err| {
+            e.conn.feed(data.bytes) catch |err| {
                 e.emitGoAwayIfOwed(); // a fatal feed (e.g. max_buffer flood) still owes a GOAWAY
                 return exceptions.raiseH2(err);
             };
             return py.none();
         },
-        .h1 => |*e| return e.receiveData(bytes, arg),
+        .h1 => |*e| return e.receiveData(data.bytes, data.stable_owner),
         .h3 => return py.raiseRuntime("receive_data is not valid for an HTTP/3 connection; use receive_datagram"),
     }
 }
@@ -2363,9 +2366,10 @@ fn receive_datagram(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.
             var now: c_ulonglong = 0;
             var addr_obj: ?*c.PyObject = null;
             if (c.PyArg_ParseTuple(args, "O|KO", &dgram_obj, &now, &addr_obj) == 0) return null;
-            const dgram = py.asBytes(dgram_obj) orelse return null;
+            var dgram = py.BorrowedBuffer.init(dgram_obj) orelse return null;
+            defer dgram.deinit();
             const peer_address = if (addr_obj != null and !py.isNone(addr_obj)) py.asBytes(addr_obj) orelse return null else null;
-            return e.receiveDatagram(dgram, @intCast(now), peer_address);
+            return e.receiveDatagram(dgram.bytes, @intCast(now), peer_address);
         },
         else => return py.raiseRuntime("receive_datagram is only valid for an HTTP/3 connection"),
     }
@@ -2444,9 +2448,10 @@ fn next_event_eager_for_benchmark(self_obj: ?*c.PyObject, _: ?*c.PyObject) callc
 /// return NEED_DATA, avoiding a container allocation on the one-event hot path.
 fn receive_event(self_obj: ?*c.PyObject, arg: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
-    const bytes = py.asBytes(arg) orelse return null;
+    var data = py.BorrowedBuffer.init(arg) orelse return null;
+    defer data.deinit();
     const engine = h1(self) orelse return null;
-    if (!engine.feedData(bytes, arg)) return null;
+    if (!engine.feedData(data.bytes, data.stable_owner)) return null;
     return nextEventImpl(self_obj, false);
 }
 

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -117,14 +117,41 @@ pub fn fromBytes(s: []const u8) Object {
     return c.PyBytes_FromStringAndSize(s.ptr, @intCast(s.len));
 }
 
-/// Borrow the buffer behind a Python `bytes`/`bytearray`/buffer-protocol object.
-/// Returns null and sets a TypeError if `o` is not bytes-like.
+/// Borrow the contents of a Python `bytes` object for the active call.
 pub fn asBytes(o: Object) ?[]const u8 {
     var ptr: [*c]u8 = undefined;
     var len: ssize = undefined;
     if (c.PyBytes_AsStringAndSize(o, @ptrCast(&ptr), &len) != 0) return null;
     return ptr[0..@intCast(len)];
 }
+
+/// A contiguous buffer export borrowed for one native call. Exact `bytes` keep
+/// their allocation-free fast path and may be retained by HTTP/1 body events.
+pub const BorrowedBuffer = struct {
+    bytes: []const u8,
+    stable_owner: Object = null,
+    view: c.Py_buffer = undefined,
+    acquired: bool = false,
+
+    pub fn init(o: Object) ?BorrowedBuffer {
+        if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(&c.PyBytes_Type)) {
+            const ptr: [*]const u8 = @ptrCast(c.PyBytes_AS_STRING(o));
+            return .{ .bytes = ptr[0..@intCast(c.PyBytes_GET_SIZE(o))], .stable_owner = o };
+        }
+
+        var view: c.Py_buffer = undefined;
+        if (c.PyObject_GetBuffer(o, &view, c.PyBUF_SIMPLE) != 0) return null;
+        const bytes: []const u8 = if (view.len == 0)
+            &.{}
+        else
+            @as([*]const u8, @ptrCast(view.buf))[0..@intCast(view.len)];
+        return .{ .bytes = bytes, .view = view, .acquired = true };
+    }
+
+    pub fn deinit(self: *BorrowedBuffer) void {
+        if (self.acquired) c.PyBuffer_Release(&self.view);
+    }
+};
 
 // -- containers ---------------------------------------------------------------
 

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -135,8 +135,7 @@ pub const BorrowedBuffer = struct {
 
     pub fn init(o: Object) ?BorrowedBuffer {
         if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(&c.PyBytes_Type)) {
-            const ptr: [*]const u8 = @ptrCast(c.PyBytes_AS_STRING(o));
-            return .{ .bytes = ptr[0..@intCast(c.PyBytes_GET_SIZE(o))], .stable_owner = o };
+            return .{ .bytes = asBytes(o) orelse return null, .stable_owner = o };
         }
 
         var view: c.Py_buffer = undefined;

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -73,6 +73,12 @@ def test_quic_endpoint_accepts_without_retry_and_manages_the_connection(initial:
     assert endpoint.next_timeout() is None
 
 
+def test_quic_endpoint_accepts_bytearray_input(initial: bytes) -> None:
+    endpoint = zttp.QuicEndpoint(connection_id_factory=lambda length: b"s" * length)
+
+    assert endpoint.receive_datagram(bytearray(initial), b"address", 0) is not None
+
+
 def test_quic_endpoint_does_not_retain_an_unauthenticated_initial(initial: bytes) -> None:
     corrupted = initial[:-1] + bytes((initial[-1] ^ 1,))
     endpoint = zttp.QuicEndpoint(

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -60,6 +60,14 @@ def _own_settings(buf: bytes) -> dict[int, int]:
     }
 
 
+def test_receive_data_accepts_bytearray_input() -> None:
+    conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+
+    conn.receive_data(bytearray(PREFACE + frame(0x04, 0, 0, b"")))
+
+    assert isinstance(conn.next_event(), zttp.Settings)
+
+
 def test_handshake_advertises_real_settings() -> None:
     # The server must advertise its enforced limits, not an empty SETTINGS, or a
     # peer uses RFC defaults and gets spurious REFUSED_STREAM resets (RFC 9113 6.5).

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -151,7 +151,7 @@ def test_parse_datagram_header_routes_a_client_initial() -> None:
         zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"localhost", connection_id=b"\xaa\xbb\xcc\xdd"
     )
     initial = client.data_to_send()[0]
-    header = zttp.parse_datagram_header(initial)
+    header = zttp.parse_datagram_header(bytearray(initial))
     assert isinstance(header, zttp.DatagramHeader)
     assert header.is_long_header
     assert header.is_initial
@@ -1139,6 +1139,14 @@ def test_handshake_emits_a_flight() -> None:
     assert isinstance(datagrams, list)
     assert len(datagrams) >= 1
     assert all(isinstance(d, bytes) and d for d in datagrams)
+
+
+def test_receive_datagram_accepts_memoryview_input() -> None:
+    conn = make_server()
+
+    conn.receive_datagram(memoryview(CLIENT_HELLO), 1000)
+
+    assert conn.data_to_send()
 
 
 def test_receive_datagram_accepts_peer_address_key() -> None:

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -20,6 +20,27 @@ def test_receive_event_feeds_and_returns_first_available_http1_event() -> None:
     assert isinstance(conn.next_event(), zttp.EndOfMessage)
 
 
+def test_receive_event_accepts_bytearray_input() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    incoming = bytearray(b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+
+    event = conn.receive_event(incoming)
+    incoming[-5:] = b"other"
+
+    assert isinstance(event, zttp.Request)
+    data = conn.next_event()
+    assert isinstance(data, zttp.Data)
+    assert data.data == b"hello"
+
+
+def test_receive_data_accepts_memoryview_input() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+
+    conn.receive_data(memoryview(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n"))
+
+    assert isinstance(conn.next_event(), zttp.Request)
+
+
 def test_receive_event_returns_need_data_for_partial_http1_input() -> None:
     conn = zttp.Connection(zttp.SERVER)
     assert conn.receive_event(b"GET / HTTP/1.1\r\nHost:") is zttp.NEED_DATA

--- a/uv.lock
+++ b/uv.lock
@@ -1402,7 +1402,7 @@ fuzz = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "typing-extensions", specifier = ">=4.0" }]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.6" }]
 
 [package.metadata.requires-dev]
 bench = [

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Final, Literal, TypeVar, final, overload
 
-from typing_extensions import disjoint_base
+from typing_extensions import Buffer, disjoint_base
 
 from zttp.config import QuicTransportParameters, SessionResumption, TlsCredentials
 from zttp.results import CloseInfo, DatagramHeader, LocalConnectionId, OutboundDatagram, SessionTicket
@@ -31,7 +31,7 @@ def _build_retry(
 ) -> bytes:
     """Build a stateless QUIC v1 Retry packet for `QuicEndpoint`."""
 
-def parse_datagram_header(datagram: bytes, /) -> DatagramHeader:
+def parse_datagram_header(datagram: Buffer, /) -> DatagramHeader:
     """Parse the routable prefix of a received QUIC datagram (RFC 9000 17).
 
     Reads no connection state and does not decrypt - it just exposes the form bit,
@@ -327,11 +327,11 @@ class Connection:
 class H1Connection(Connection):
     """An HTTP/1.1 connection: a byte-stream transport with a message-scoped API."""
 
-    def receive_data(self, data: bytes, /) -> None:
-        """Append received bytes to the parse buffer (empty bytes signals EOF)."""
+    def receive_data(self, data: Buffer, /) -> None:
+        """Append a contiguous buffer to the parse buffer (an empty buffer signals EOF)."""
 
-    def receive_event(self, data: bytes, /) -> Request | Response | Data | EndOfMessage | NeedData | ConnectionClosed:
-        """Feed received bytes and return the first available event, or `NEED_DATA`."""
+    def receive_event(self, data: Buffer, /) -> Request | Response | Data | EndOfMessage | NeedData | ConnectionClosed:
+        """Feed a contiguous buffer and return the first available event, or `NEED_DATA`."""
 
     def data_to_send(self) -> bytes:
         """Return and clear the bytes queued to send."""
@@ -370,8 +370,8 @@ class H2Connection(Connection):
     """
 
     send_window: int
-    def receive_data(self, data: bytes, /) -> None:
-        """Append received bytes to the parse buffer (empty bytes signals EOF)."""
+    def receive_data(self, data: Buffer, /) -> None:
+        """Append a contiguous buffer to the parse buffer (an empty buffer signals EOF)."""
 
     def data_to_send(self) -> bytes:
         """Return and clear the HTTP/2 frames queued to send."""
@@ -422,7 +422,7 @@ class H3Connection(Connection):
         and non-DATA frames are credited internally.
         """
 
-    def receive_datagram(self, datagram: bytes, now: int = ..., peer_address: bytes | None = ..., /) -> None:
+    def receive_datagram(self, datagram: Buffer, now: int = ..., peer_address: bytes | None = ..., /) -> None:
         """Feed one received UDP datagram. `peer_address` is an opaque key for path validation."""
 
     def data_to_send_with_addresses(self) -> list[OutboundDatagram]:

--- a/zttp/endpoint.py
+++ b/zttp/endpoint.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import secrets
 from dataclasses import dataclass, field
 
-from typing_extensions import Protocol, TypedDict
+from typing_extensions import Buffer, Protocol, TypedDict
 
 from zttp._tokens import AddressValidationContext, RetryContext, TokenCodec
 from zttp._zttp import (
@@ -85,8 +85,9 @@ class QuicEndpoint:
         self._connections: list[_ConnectionState] = []
         self._outgoing: list[OutboundDatagram] = []
 
-    def receive_datagram(self, datagram: bytes, peer_address: bytes, now: int) -> H3Connection | None:
+    def receive_datagram(self, datagram: Buffer, peer_address: bytes, now: int) -> H3Connection | None:
         """Route a datagram and return its connection, or `None` when dropped."""
+        datagram = bytes(datagram)
         if not datagram:
             return None
         if not datagram[0] & 0x80:


### PR DESCRIPTION
## Summary

- accept contiguous buffer-protocol inputs in HTTP/1, HTTP/2, HTTP/3, QUIC endpoint, and datagram header receive paths
- retain the allocation-free `bytes` fast path while copying mutable HTTP/1 inputs before releasing their buffer export
- type the receive APIs with `Buffer` and document `bytearray` and `memoryview` support

Closes #196.

## Validation

- `scripts/check`
- `zig build test`
- `scripts/test -q` - 401 passed, 1 optional interoperability test skipped
- 100% Python coverage

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts any contiguous buffer (bytes, bytearray, memoryview) in all receive paths instead of only bytes. This improves ergonomics while keeping HTTP/1 performance by retaining the zero-copy fast path for bytes and safely copying mutable inputs.

- Receive APIs are now typed as `Buffer` and accept buffer-protocol inputs across: HTTP/1 `receive_data` and `receive_event`, HTTP/2 `receive_data`, HTTP/3 `receive_datagram`, QUIC endpoint `receive_datagram`, and `parse_datagram_header`.
- HTTP/1 behavior: `bytes` remain zero-copy and may be retained; mutable buffers are copied before releasing their export to avoid aliasing; `receive_event` continues to feed and return the next event.
- Requires `typing-extensions>=4.6`; preserves Python 3.10 extension builds. Docs and stubs updated; `zttp.endpoint` now accepts `Buffer` for datagrams and coerces to bytes for routing; tests cover `bytearray` and `memoryview`.

<sup>Written for commit 1c5a47a8b71caf414438f3c96b436fe83929482d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

