### PR TITLE
Accept raw P-256 private key scalars

### DIFF
--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -33,7 +33,7 @@ they cannot be transposed. A swap is a type error, not a handshake failure:
 ```python
 server = zttp.Connection(
     zttp.SERVER, zttp.HTTP3,
-    credentials=zttp.TlsCredentials(certificate=cert, private_key=key),
+    credentials=zttp.TlsCredentials(certificate=certificate_der, private_key_scalar=private_key_scalar),
 )
 client = zttp.Connection(
     zttp.CLIENT, zttp.HTTP3,

--- a/src/core/quic/tls/sign.zig
+++ b/src/core/quic/tls/sign.zig
@@ -32,6 +32,12 @@ pub const Signer = struct {
         return .{ .key_pair = try Ecdsa.KeyPair.generateDeterministic(seed) };
     }
 
+    /// Load the raw big-endian P-256 private scalar used by an existing certificate.
+    pub fn fromPrivateKey(private_key: [Ecdsa.SecretKey.encoded_length]u8) !Signer {
+        const secret_key = try Ecdsa.SecretKey.fromBytes(private_key);
+        return .{ .key_pair = try Ecdsa.KeyPair.fromSecretKey(secret_key) };
+    }
+
     /// The SEC1-uncompressed public point (0x04 || X || Y), what a server
     /// Certificate message carries for ecdsa_secp256r1.
     pub fn publicKeySec1(self: Signer) [PUBLIC_SEC1_LEN]u8 {
@@ -126,6 +132,13 @@ test "CertificateVerify round-trips through the client's verify" {
     var buf: [Ecdsa.Signature.der_encoded_length_max]u8 = undefined;
     const der = try signer.sign(th, &buf);
     try verify(&signer.publicKeySec1(), th, der);
+}
+
+test "Signer loads a raw private scalar" {
+    const private_key = [_]u8{0x42} ** Ecdsa.SecretKey.encoded_length;
+    const signer = try Signer.fromPrivateKey(private_key);
+    const expected = (try Ecdsa.KeyPair.fromSecretKey(try Ecdsa.SecretKey.fromBytes(private_key))).public_key;
+    try testing.expectEqualSlices(u8, &expected.toUncompressedSec1(), &signer.publicKeySec1());
 }
 
 test "certificatePublicKeySec1 extracts a P-256 key from DER SubjectPublicKeyInfo" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2260,6 +2260,17 @@ fn buildServerConfig(
     if (resumption == null and c.PyErr_Occurred() != null) return null;
 
     const certificates = copyCertificateChain(credentials, &default_cert) orelse return null;
+    const leaf_public_key = tls_sign.certificatePublicKeySec1(certificates[0]) catch {
+        freeCertificateChain(certificates);
+        _ = py.raiseValue("the leaf certificate must contain a P-256 public key");
+        return null;
+    };
+    const signer_public_key = signer.publicKeySec1();
+    if (!std.mem.eql(u8, leaf_public_key, &signer_public_key)) {
+        freeCertificateChain(certificates);
+        _ = py.raiseValue("the leaf certificate public key does not match the signing key");
+        return null;
+    }
     const tp_copy = gpa.dupe(u8, tp_src) catch {
         freeCertificateChain(certificates);
         _ = c.PyErr_NoMemory();

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -357,6 +357,7 @@ const TlsCredentialObjects = struct {
     certificate: ?*c.PyObject = null,
     certificates: ?*c.PyObject = null,
     private_key: ?*c.PyObject = null,
+    private_key_scalar: ?*c.PyObject = null,
 };
 
 fn parseTlsCredentials(obj: ?*c.PyObject) ?TlsCredentialObjects {
@@ -371,8 +372,13 @@ fn parseTlsCredentials(obj: ?*c.PyObject) ?TlsCredentialObjects {
     const certificate = c.PyDict_GetItemString(obj, "certificate");
     const certificates = c.PyDict_GetItemString(obj, "certificates");
     const private_key = c.PyDict_GetItemString(obj, "private_key");
-    if (private_key == null) {
-        _ = py.raiseType("credentials must include private_key");
+    const private_key_scalar = c.PyDict_GetItemString(obj, "private_key_scalar");
+    if (private_key != null and private_key_scalar != null) {
+        _ = py.raiseValue("pass either private_key or private_key_scalar, not both");
+        return null;
+    }
+    if (private_key == null and private_key_scalar == null) {
+        _ = py.raiseType("credentials must include private_key or private_key_scalar");
         return null;
     }
     if (certificate != null and certificates != null) {
@@ -387,7 +393,12 @@ fn parseTlsCredentials(obj: ?*c.PyObject) ?TlsCredentialObjects {
         _ = py.raiseValue("credentials contains an unknown field");
         return null;
     }
-    return .{ .certificate = certificate, .certificates = certificates, .private_key = private_key };
+    return .{
+        .certificate = certificate,
+        .certificates = certificates,
+        .private_key = private_key,
+        .private_key_scalar = private_key_scalar,
+    };
 }
 
 fn randomSigner() ?Signer {
@@ -2229,6 +2240,16 @@ fn buildServerConfig(
         }
         signer = Signer.fromSeed(key_src[0..32].*) catch {
             _ = py.raiseValue("private_key is not a valid signing key seed");
+            return null;
+        };
+    } else if (credentials.private_key_scalar) |key_obj| {
+        const key_src = py.asBytes(key_obj) orelse return null;
+        if (key_src.len != 32) {
+            _ = py.raiseValue("private_key_scalar must be exactly 32 bytes");
+            return null;
+        }
+        signer = Signer.fromPrivateKey(key_src[0..32].*) catch {
+            _ = py.raiseValue("private_key_scalar is not a valid P-256 scalar");
             return null;
         };
     } else {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,8 +16,10 @@ class CredentialsCase(TypedDict):
 
 def test_tls_credentials_is_a_typed_dictionary() -> None:
     credentials = zttp.TlsCredentials(certificate=b"CERT", private_key=b"KEY")
+    scalar_credentials = zttp.TlsCredentials(certificate=b"CERT", private_key_scalar=b"SCALAR")
 
     assert credentials == {"certificate": b"CERT", "private_key": b"KEY"}
+    assert scalar_credentials == {"certificate": b"CERT", "private_key_scalar": b"SCALAR"}
 
 
 def test_session_resumption_is_frozen() -> None:
@@ -51,7 +53,7 @@ def test_quic_transport_parameters_is_a_typed_dictionary() -> None:
         CredentialsCase(
             credentials={"certificate": b"leaf"},
             exception=TypeError,
-            match="credentials must include private_key",
+            match="credentials must include private_key or private_key_scalar",
         ),
         CredentialsCase(
             credentials={"private_key": b"\x42" * 32},
@@ -68,9 +70,28 @@ def test_quic_transport_parameters_is_a_typed_dictionary() -> None:
             match="pass either certificate or certificates, not both",
         ),
         CredentialsCase(
+            credentials={
+                "certificate": b"leaf",
+                "private_key": b"\x42" * 32,
+                "private_key_scalar": b"\x43" * 32,
+            },
+            exception=ValueError,
+            match="pass either private_key or private_key_scalar, not both",
+        ),
+        CredentialsCase(
             credentials={"certificate": b"leaf", "private_key": b"\x42" * 32, "unknown": b"value"},
             exception=ValueError,
             match="credentials contains an unknown field",
+        ),
+        CredentialsCase(
+            credentials={"certificate": b"leaf", "private_key_scalar": b"short"},
+            exception=ValueError,
+            match="private_key_scalar must be exactly 32 bytes",
+        ),
+        CredentialsCase(
+            credentials={"certificate": b"leaf", "private_key_scalar": b"\x00" * 32},
+            exception=ValueError,
+            match="private_key_scalar is not a valid P-256 scalar",
         ),
         CredentialsCase(
             credentials={"certificate": b"", "private_key": b"\x42" * 32},

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -114,7 +114,16 @@ PLACEHOLDERS = {
     "errors.md": {"conn"},
     "first-steps.md": {"request", "transport"},
     "http2.md": {"bytes_from_socket", "incoming_bytes", "very_large_body"},
-    "http3.md": {"cert", "key", "peer_address", "recv_with_timeout", "sock", "ticket_id", "ticket_psk", "udp_payload"},
+    "http3.md": {
+        "certificate_der",
+        "peer_address",
+        "private_key_scalar",
+        "recv_with_timeout",
+        "sock",
+        "ticket_id",
+        "ticket_psk",
+        "udp_payload",
+    },
 }
 
 

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -385,18 +385,21 @@ def test_http3_default_client_and_server_exchange_request() -> None:
     assert any(isinstance(e, zttp.EndOfMessage) for e in events)
 
 
-def test_http3_client_rejects_unverifiable_server_certificate() -> None:
+def test_http3_server_rejects_unverifiable_certificate() -> None:
     config = SERVER_CONFIG.copy()
     config["credentials"] = zttp.TlsCredentials(certificate=b"\xcc" * 48, private_key=b"\x42" * 32)
-    client = make_client()
-    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
+    with pytest.raises(ValueError, match="leaf certificate must contain a P-256 public key"):
+        zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
 
-    transfer(client, server, 1000)
-    server_flight = server.data_to_send()
-    assert len(server_flight) >= 2
-    with pytest.raises(zttp.RemoteProtocolError):
-        client.receive_datagram(server_flight[0], 2000)
-        client.receive_datagram(server_flight[1], 2000)
+
+def test_http3_server_rejects_a_mismatched_private_key_scalar() -> None:
+    config = SERVER_CONFIG.copy()
+    config["credentials"] = zttp.TlsCredentials(
+        certificate=SERVER_PUBLIC_KEY,
+        private_key_scalar=b"\x42" * 32,
+    )
+    with pytest.raises(ValueError, match="leaf certificate public key does not match the signing key"):
+        zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, **config)
 
 
 def test_http3_client_server_request_response() -> None:

--- a/zttp/config.py
+++ b/zttp/config.py
@@ -38,9 +38,10 @@ class QuicTransportParameters(TypedDict, total=False):
 
 
 class TlsCredentials(TypedDict):
-    """An HTTP/3 server's ordered certificate chain and leaf private key."""
+    """An HTTP/3 server's certificate chain and signing key or raw P-256 scalar."""
 
-    private_key: bytes
+    private_key: NotRequired[bytes]
+    private_key_scalar: NotRequired[bytes]
     certificate: NotRequired[bytes]
     certificates: NotRequired[tuple[bytes, ...]]
 


### PR DESCRIPTION
## Summary

- add `private_key_scalar` to `TlsCredentials` for the raw P-256 scalar associated with an existing certificate
- preserve `private_key` as the deterministic signing-key seed for compatibility
- validate exclusivity, scalar length, and invalid zero scalars before constructing the server

This lets integrations load a normal P-256 certificate and private key without needing to invert zttp's deterministic seed derivation. It unblocks the Uvicorn HTTP/3 integration, which reads the scalar from its configured PEM key.

## Validation

- `scripts/check`
- `zig build test`
- 404 Python tests passed, with one optional interoperability test skipped
- 100% Python coverage
- real generated P-256 certificate handshake completed through the public Python API

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts raw P‑256 private key scalars and validates certificate/signing-key consistency. Previously `private_key` required a deterministic seed and we did not check leaf key vs signer; now `private_key_scalar` takes a 32‑byte big‑endian scalar and the server rejects non‑P‑256 or mismatched keys at config time.

- Add `private_key_scalar` to `zttp.TlsCredentials`; keep `private_key` for compatibility.
- Enforce exclusivity: pass exactly one of `private_key` or `private_key_scalar`. Migration: when loading a PEM private key, pass only `private_key_scalar`.
- Validate `private_key_scalar` length (32 bytes) and reject zero/invalid scalars with clear errors.
- Validate the leaf certificate: it must contain a P‑256 public key and it must match the signing key; fail fast during server configuration.
- Implement `Signer.fromPrivateKey` and use it for server setup; update docs/examples to `certificate_der` and `private_key_scalar`, TypedDict, and tests.

<sup>Written for commit 74cdad6b1d3fe68dfeda7865aee4ff6adce37058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TLS credentials now support raw P-256 private-key scalars as an alternative to signing keys.
  * Added validation for key format, length, and mutually exclusive credential options.

* **Documentation**
  * Updated HTTP/3 examples and configuration references to demonstrate the new credential format.

* **Tests**
  * Expanded coverage for valid scalar keys, invalid values, missing credentials, and conflicting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->