### PR TITLE
Harden QUIC endpoint connection management

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -173,6 +173,11 @@ routing synchronized with active and retired IDs in the QUIC core.
 The endpoint does not own `udp_socket`, call `sendto`, read the clock, or schedule
 a timer. Call `next_timeout()` and `handle_timeout(now)` from your event loop.
 
+`data_to_send()` drains connections changed by `receive_datagram()`, endpoint timer
+handling, or endpoint control methods. If your application queues output on a
+connection after an earlier drain, pass that connection to
+`data_to_send(connection)`.
+
 ::: zttp.QuicEndpoint
 
 ::: zttp.ConnectionIDFactory

--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -413,6 +413,10 @@ Call `endpoint.next_timeout()` to get the earliest deadline across all
 connections. Call `endpoint.handle_timeout(now)` when it expires. The endpoint
 still does no I/O: your event loop owns the socket, clock, and timer scheduling.
 
+`endpoint.data_to_send()` drains connections changed by a receive, timer, or
+endpoint control method. Pass a connection as `endpoint.data_to_send(connection)`
+when your application queues output after it already drained that connection.
+
 See the [API reference](../reference/api.md#demultiplexing-a-shared-udp-socket)
 for every endpoint method and the lower-level `parse_datagram_header` API.
 

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2135,20 +2135,10 @@ pub const Connection = struct {
         const pn_len = packet.packetNumberLen(st.next_pn, st.rec.largest_acked);
         const token = self.initial_token orelse &.{};
         const room = self.framePayloadRoom(space);
-        var header: std.ArrayListUnmanaged(u8) = .empty;
-        defer header.deinit(self.gpa);
-        _ = packet.writeLongHeader(
-            &header,
-            self.gpa,
-            .initial,
-            constants.VERSION_1,
-            self.peer_scid,
-            self.scid,
-            token,
-            pn_len + room + crypto.TAG_LEN,
-            pn_len,
-        ) catch return error.OutOfMemory;
-        const overhead = header.items.len + pn_len + crypto.TAG_LEN;
+        const header_len = 1 + 4 + 1 + self.peer_scid.len + 1 + self.scid.len +
+            (varint.len(token.len) catch return error.ProtocolViolation) + token.len +
+            (varint.len(pn_len + room + crypto.TAG_LEN) catch return error.ProtocolViolation);
+        const overhead = header_len + pn_len + crypto.TAG_LEN;
         if (overhead >= constants.MIN_INITIAL_DATAGRAM) return 0;
         return constants.MIN_INITIAL_DATAGRAM - overhead;
     }

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -916,14 +916,8 @@ const H3Engine = struct {
         if (list == null) return null;
         var off: usize = 0;
         for (lengths, 0..) |len, i| {
-            const args = py.tupleNew(2);
-            if (args == null) {
-                py.decref(list);
-                return null;
-            }
             const data = py.fromBytes(flat[off .. off + len]);
             if (data == null) {
-                py.decref(args);
                 py.decref(list);
                 return null;
             }
@@ -936,14 +930,10 @@ const H3Engine = struct {
             } else py.none();
             if (peer_address == null) {
                 py.decref(data);
-                py.decref(args);
                 py.decref(list);
                 return null;
             }
-            py.tupleSet(args, 0, data);
-            py.tupleSet(args, 1, peer_address);
-            const result = c.PyObject_CallObject(result_type, args);
-            py.decref(args);
+            const result = newOutboundDatagram(result_type, data, peer_address);
             if (result == null) {
                 py.decref(list);
                 return null;
@@ -1076,7 +1066,17 @@ const H3Engine = struct {
         return list;
     }
 
-    fn issueConnectionId(self: *H3Engine, seq: u64, cid: []const u8, token: []const u8, retire_prior_to: u64) py.Object {
+    fn issueConnectionId(
+        self: *H3Engine,
+        seq: u64,
+        cid: []const u8,
+        token: []const u8,
+        retire_prior_to: u64,
+        endpoint: bool,
+    ) py.Object {
+        if (self.endpoint_server_cid != null and !endpoint) {
+            return py.raise(exceptions.LocalProtocolError, "use QuicEndpoint.issue_connection_id() for this connection");
+        }
         const q = self.qc orelse return py.raise(exceptions.LocalProtocolError, "no datagram received yet: the HTTP/3 connection is not established");
         if (cid.len == 0 or cid.len > 20) return py.raiseValue("connection_id must be 1..20 bytes");
         if (token.len != 16) return py.raiseValue("stateless_reset_token must be exactly 16 bytes");
@@ -1439,6 +1439,8 @@ var close_info_type: py.Object = null;
 var datagram_header_type: py.Object = null;
 var local_connection_id_type: py.Object = null;
 var outbound_datagram_type: py.Object = null;
+var outbound_data_name: py.Object = null;
+var outbound_peer_address_name: py.Object = null;
 
 /// Module-level `parse_datagram_header(datagram) -> DatagramHeader`: the routable
 /// prefix of a received QUIC datagram, for demultiplexing a shared UDP socket onto
@@ -1553,6 +1555,35 @@ pub var module_methods = [_]c.PyMethodDef{
     .{ .ml_name = "_build_retry", .ml_meth = @ptrCast(&build_retry), .ml_flags = c.METH_VARARGS | c.METH_KEYWORDS, .ml_doc = "Build a stateless QUIC v1 Retry packet for QuicEndpoint." },
     .{ .ml_name = null, .ml_meth = null, .ml_flags = 0, .ml_doc = null },
 };
+
+fn newOutboundDatagram(result_type: py.Object, data: py.Object, peer_address: py.Object) py.Object {
+    if (outbound_data_name == null) outbound_data_name = c.PyUnicode_InternFromString("data");
+    if (outbound_peer_address_name == null) {
+        outbound_peer_address_name = c.PyUnicode_InternFromString("peer_address");
+    }
+    if (outbound_data_name == null or outbound_peer_address_name == null) {
+        py.decref(data);
+        py.decref(peer_address);
+        return null;
+    }
+    const result = py.allocInstance(result_type);
+    if (result == null) {
+        py.decref(data);
+        py.decref(peer_address);
+        return null;
+    }
+    if (c.PyObject_GenericSetAttr(result, outbound_data_name, data) < 0 or
+        c.PyObject_GenericSetAttr(result, outbound_peer_address_name, peer_address) < 0)
+    {
+        py.decref(data);
+        py.decref(peer_address);
+        py.decref(result);
+        return null;
+    }
+    py.decref(data);
+    py.decref(peer_address);
+    return result;
+}
 
 // Return the zttp.results dataclass named `name`, importing and caching it once.
 fn resultType(cache: *py.Object, name: [*c]const u8) py.Object {
@@ -2899,7 +2930,7 @@ fn h3_local_connection_ids(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c)
     return e.localConnectionIds();
 }
 
-fn h3_issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+fn issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject, endpoint: bool) py.Object {
     const e = h3(@ptrCast(self_obj.?)) orelse return null;
     var seq: c_ulonglong = 0;
     var cid_obj: ?*c.PyObject = null;
@@ -2908,7 +2939,15 @@ fn h3_issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.
     if (c.PyArg_ParseTuple(args, "KOO|K", &seq, &cid_obj, &token_obj, &retire_prior_to) == 0) return null;
     const cid = py.asBytes(cid_obj) orelse return null;
     const token = py.asBytes(token_obj) orelse return null;
-    return e.issueConnectionId(@intCast(seq), cid, token, @intCast(retire_prior_to));
+    return e.issueConnectionId(@intCast(seq), cid, token, @intCast(retire_prior_to), endpoint);
+}
+
+fn h3_issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+    return issue_connection_id(self_obj, args, false);
+}
+
+fn h3_endpoint_issue_connection_id(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
+    return issue_connection_id(self_obj, args, true);
 }
 
 fn h3_request_key_update(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
@@ -3225,6 +3264,7 @@ var h3_methods = [_]py.MethodDef{
     .{ .ml_name = "use_peer_connection_id", .ml_meth = h3_use_peer_connection_id, .ml_flags = c.METH_O, .ml_doc = "Switch future QUIC packets to a peer-issued NEW_CONNECTION_ID sequence: use_peer_connection_id(sequence_number)." },
     .{ .ml_name = "local_connection_ids", .ml_meth = h3_local_connection_ids, .ml_flags = c.METH_NOARGS, .ml_doc = "Return every active local QUIC connection ID and sequence number." },
     .{ .ml_name = "issue_connection_id", .ml_meth = h3_issue_connection_id, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC NEW_CONNECTION_ID for a local CID: issue_connection_id(sequence_number, connection_id, stateless_reset_token, retire_prior_to=0). Drain with data_to_send." },
+    .{ .ml_name = "_endpoint_issue_connection_id", .ml_meth = h3_endpoint_issue_connection_id, .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC NEW_CONNECTION_ID owned by QuicEndpoint." },
     .{ .ml_name = "request_key_update", .ml_meth = h3_request_key_update, .ml_flags = c.METH_NOARGS, .ml_doc = "Advance QUIC 1-RTT send keys. The next application packet carries the new key phase." },
     .{ .ml_name = "send_request", .ml_meth = send_request, .ml_flags = c.METH_VARARGS, .ml_doc = "Open a request stream and return its Stream: send_request(method, target, version, headers). :authority is derived from a host header; the version arg is ignored." },
     .{ .ml_name = "stream", .ml_meth = stream, .ml_flags = c.METH_O, .ml_doc = "Return a Stream handle for stream_id (the request's stream_id). The handle is the stream-scoped send surface: send_response / send_data / end_message." },

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -79,6 +79,19 @@ def test_quic_endpoint_accepts_bytearray_input(initial: bytes) -> None:
     assert endpoint.receive_datagram(bytearray(initial), b"address", 0) is not None
 
 
+def test_quic_endpoint_drains_application_output_without_scanning_idle_connections(initial: bytes) -> None:
+    endpoint = zttp.QuicEndpoint(connection_id_factory=lambda length: b"s" * length)
+    connection = endpoint.receive_datagram(initial, b"address", 0)
+    assert connection is not None
+    assert endpoint.data_to_send()
+    assert endpoint.next_timeout() is not None
+
+    connection.close(app=False)
+    assert endpoint.data_to_send() == []
+    assert endpoint.data_to_send(connection)
+    assert endpoint.next_timeout() is None
+
+
 def test_quic_endpoint_does_not_retain_an_unauthenticated_initial(initial: bytes) -> None:
     corrupted = initial[:-1] + bytes((initial[-1] ^ 1,))
     endpoint = zttp.QuicEndpoint(
@@ -89,6 +102,18 @@ def test_quic_endpoint_does_not_retain_an_unauthenticated_initial(initial: bytes
     assert endpoint.receive_datagram(corrupted, b"address", 0) is None
     assert endpoint.connections() == []
     assert endpoint.receive_datagram(initial, b"address", 0) is not None
+
+
+def test_quic_endpoint_drops_an_undersized_initial_before_retry() -> None:
+    endpoint = zttp.QuicEndpoint(
+        retry=True,
+        token_secret=b"s" * 32,
+        connection_id_factory=lambda length: b"r" * length,
+    )
+    datagram = b"\xc0\x00\x00\x00\x01\x08original\x00\x00"
+
+    assert endpoint.receive_datagram(datagram, b"address", 0) is None
+    assert endpoint.data_to_send() == []
 
 
 def test_quic_endpoint_sends_version_negotiation() -> None:
@@ -104,6 +129,77 @@ def test_quic_endpoint_sends_version_negotiation() -> None:
     assert header.version == 0
     assert header.destination_connection_id == b"peer"
     assert header.source_connection_id == b"original"
+
+
+def test_quic_endpoint_updates_connection_timeouts() -> None:
+    endpoint = zttp.QuicEndpoint(
+        transport_params=zttp.QuicTransportParameters(max_idle_timeout=1),
+        connection_id_factory=lambda length: b"s" * length,
+    )
+    client = zttp.Connection(
+        zttp.CLIENT,
+        zttp.HTTP3,
+        connection_id=b"original",
+        server_name=b"localhost",
+    )
+    initial = client.data_to_send()[0]
+    connection = endpoint.receive_datagram(initial, b"address", 1000)
+    assert connection is not None
+    first_deadline = endpoint.next_timeout()
+    assert first_deadline is not None
+
+    assert endpoint.receive_datagram(initial, b"address", 2000) is connection
+    later_deadline = endpoint.next_timeout()
+    assert later_deadline is not None
+    assert later_deadline > first_deadline
+
+    assert endpoint.receive_datagram(initial, b"address", 500) is connection
+    earlier_deadline = endpoint.next_timeout()
+    assert earlier_deadline is not None
+    assert earlier_deadline < later_deadline
+    endpoint.handle_timeout(earlier_deadline)
+    assert connection.is_closed()
+    assert endpoint.next_timeout() is None
+
+
+def test_quic_endpoint_orders_connection_timeouts() -> None:
+    connection_ids = iter((b"a" * 16, b"b" * 16, b"c" * 16))
+    endpoint = zttp.QuicEndpoint(
+        transport_params=zttp.QuicTransportParameters(max_idle_timeout=1),
+        connection_id_factory=lambda length: next(connection_ids),
+    )
+    first_client = zttp.Connection(
+        zttp.CLIENT,
+        zttp.HTTP3,
+        connection_id=b"first-id",
+        server_name=b"localhost",
+    )
+    second_client = zttp.Connection(
+        zttp.CLIENT,
+        zttp.HTTP3,
+        connection_id=b"secondid",
+        server_name=b"localhost",
+    )
+    third_client = zttp.Connection(
+        zttp.CLIENT,
+        zttp.HTTP3,
+        connection_id=b"third-id",
+        server_name=b"localhost",
+    )
+    first = endpoint.receive_datagram(first_client.data_to_send()[0], b"first", 2000)
+    second_initial = second_client.data_to_send()[0]
+    second = endpoint.receive_datagram(second_initial, b"second", 1000)
+    third = endpoint.receive_datagram(third_client.data_to_send()[0], b"third", 4000)
+    assert first is not None
+    assert second is not None
+    assert third is not None
+    assert endpoint.next_timeout() == 2000
+    assert endpoint.receive_datagram(second_initial, b"second", 1500) is second
+    assert endpoint.next_timeout() == 2500
+
+    endpoint.discard(second)
+    assert endpoint.next_timeout() == 3000
+    assert endpoint.connections() == [first, third]
 
 
 def test_quic_endpoint_uses_random_connection_ids_by_default(initial: bytes) -> None:
@@ -135,6 +231,15 @@ def test_quic_endpoint_rejects_an_active_generated_connection_id(initial: bytes)
     )
     with pytest.raises(RuntimeError, match="active connection ID"):
         endpoint.receive_datagram(another.data_to_send()[0], b"address", 0)
+
+
+def test_quic_endpoint_requires_endpoint_connection_id_issuance(initial: bytes) -> None:
+    endpoint = zttp.QuicEndpoint(connection_id_factory=lambda length: b"s" * length)
+    connection = endpoint.receive_datagram(initial, b"address", 0)
+    assert connection is not None
+
+    with pytest.raises(zttp.LocalProtocolError, match="QuicEndpoint.issue_connection_id"):
+        connection.issue_connection_id(1, b"replacement-cid", b"t" * 16)
 
 
 def test_quic_endpoint_rejects_connections_from_another_endpoint() -> None:

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -238,7 +238,7 @@ def test_quic_endpoint_requires_endpoint_connection_id_issuance(initial: bytes) 
     connection = endpoint.receive_datagram(initial, b"address", 0)
     assert connection is not None
 
-    with pytest.raises(zttp.LocalProtocolError, match="QuicEndpoint.issue_connection_id"):
+    with pytest.raises(zttp.LocalProtocolError, match=r"QuicEndpoint\.issue_connection_id"):
         connection.issue_connection_id(1, b"replacement-cid", b"t" * 16)
 
 

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -897,7 +897,7 @@ def test_http3_client_request_trailers() -> None:
     eom = next(e for e in events if isinstance(e, zttp.EndOfMessage))
     assert eom.trailers == [(b"x-checksum", b"abc")]
     server.consume_data(data.stream_id, len(data.data))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown stream or length exceeds its unconsumed DATA"):
         server.consume_data(data.stream_id, 1)
 
 
@@ -946,7 +946,7 @@ def test_http3_receive_credit_waits_for_application_consumption() -> None:
     transfer(client, server, 8000)
     assert stream.pending_bytes == pending
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown stream or length exceeds its unconsumed DATA"):
         server.consume_data(request.stream_id, len(data) + 1)
     server.consume_data(request.stream_id, len(data))
     transfer(server, client, 9000)
@@ -1417,7 +1417,7 @@ def test_local_connection_ids_route_two_connections_on_one_endpoint() -> None:
         client.use_peer_connection_id(1)
         pairs.append((client, server, rotated))
 
-    for index, (client, _server, _rotated) in enumerate(pairs, start=1):
+    for index, (client, _server, rotated) in enumerate(pairs, start=1):
         client.send_request(b"GET", f"/connection-{index}".encode(), b"3", [(b"host", b"example.test")])
         for datagram in client.data_to_send():
             connection_id_length = len(rotated)
@@ -1650,7 +1650,7 @@ def test_http3_reset_reclaims_unconsumed_data() -> None:
 
     server.stream(data.stream_id).reset()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown stream or length exceeds its unconsumed DATA"):
         server.consume_data(data.stream_id, 1)
 
 

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -442,6 +442,16 @@ class H3Connection(Connection):
     def _endpoint_connection_id_generation(self) -> int:
         """Return the active local connection ID generation."""
 
+    def _endpoint_issue_connection_id(
+        self,
+        sequence_number: int,
+        connection_id: bytes,
+        stateless_reset_token: bytes,
+        retire_prior_to: int = ...,
+        /,
+    ) -> None:
+        """Queue a connection ID owned by `QuicEndpoint`."""
+
     def challenge_path(self, peer_address: bytes, data: bytes, /) -> None:
         """Queue a QUIC `PATH_CHALLENGE` to a peer address (`data` must be 8 unpredictable bytes)."""
 

--- a/zttp/endpoint.py
+++ b/zttp/endpoint.py
@@ -41,13 +41,16 @@ class _AcceptanceParameters(TypedDict):
     address_validated: bool
 
 
-@dataclass
+@dataclass(eq=False)
 class _ConnectionState:
     connection: H3Connection
     initial_destination_connection_id: bytes
     peer_address: bytes
     connection_id_generation: int = -1
     connection_ids: set[bytes] = field(default_factory=set)
+    timer_deadline: int | None = None
+    timer_index: int = -1
+    active: bool = True
 
 
 class QuicEndpoint:
@@ -82,7 +85,10 @@ class QuicEndpoint:
         self._token_codec = TokenCodec(token_secret if token_secret is not None else secrets.token_bytes(32), token_ttl)
         self._long_routes: dict[bytes, _ConnectionState] = {}
         self._short_routes: dict[bytes, _ConnectionState] = {}
-        self._connections: list[_ConnectionState] = []
+        self._connections: dict[H3Connection, _ConnectionState] = {}
+        self._ready: dict[_ConnectionState, None] = {}
+        self._timer_dirty: dict[_ConnectionState, None] = {}
+        self._timeouts: list[_ConnectionState] = []
         self._outgoing: list[OutboundDatagram] = []
 
     def receive_datagram(self, datagram: Buffer, peer_address: bytes, now: int) -> H3Connection | None:
@@ -113,6 +119,8 @@ class QuicEndpoint:
             self._outgoing.append(OutboundDatagram(packet, peer_address))
             return None
         if not header.is_initial or len(self._connections) >= self._max_connections:
+            return None
+        if len(datagram) < 1200:
             return None
 
         context = self._token_codec.validate(peer_address, header.token, now) if header.token else None
@@ -180,50 +188,71 @@ class QuicEndpoint:
         """Issue and route a new connection ID for an accepted connection."""
         state = self._connection_state(connection)
         connection_id = self._new_connection_id()
-        connection.issue_connection_id(sequence_number, connection_id, secrets.token_bytes(16), retire_prior_to)
+        connection._endpoint_issue_connection_id(
+            sequence_number,
+            connection_id,
+            secrets.token_bytes(16),
+            retire_prior_to,
+        )
         self._sync_routes(state)
+        self._mark_ready(state)
+        self._mark_timer_dirty(state)
         return connection_id
 
     def issue_token(self, connection: H3Connection, now: int) -> None:
         """Queue a NEW_TOKEN bound to the connection's current peer address."""
         state = self._connection_state(connection)
         connection.send_new_token(self._token_codec.create_address_token(state.peer_address, now))
+        self._mark_ready(state)
+        self._mark_timer_dirty(state)
 
-    def data_to_send(self) -> list[OutboundDatagram]:
-        """Return and clear outbound QUIC datagrams."""
+    def data_to_send(self, connection: H3Connection | None = None) -> list[OutboundDatagram]:
+        """Drain ready connections, optionally marking `connection` as ready."""
+        if connection is not None:
+            self._mark_ready(self._connection_state(connection))
         outgoing = self._outgoing
         self._outgoing = []
-        for state in self._connections:
+        ready = list(self._ready)
+        self._ready.clear()
+        for state in ready:
             outgoing.extend(state.connection.data_to_send_with_addresses())
+            self._mark_timer_dirty(state)
         return outgoing
 
     def connections(self) -> list[H3Connection]:
         """Return the accepted HTTP/3 connections."""
-        return [state.connection for state in self._connections]
+        return list(self._connections)
 
     def discard(self, connection: H3Connection) -> None:
         """Remove a closed connection and all of its routes."""
         state = self._connection_state(connection)
-        self._connections.remove(state)
-        self._long_routes = {cid: item for cid, item in self._long_routes.items() if item is not state}
-        self._short_routes = {cid: item for cid, item in self._short_routes.items() if item is not state}
+        del self._connections[connection]
+        state.active = False
+        self._remove_timeout(state)
+        self._ready.pop(state, None)
+        self._timer_dirty.pop(state, None)
+        for connection_id in state.connection_ids | {state.initial_destination_connection_id}:
+            self._long_routes.pop(connection_id, None)
+            self._short_routes.pop(connection_id, None)
 
     def next_timeout(self) -> int | None:
         """Return the earliest connection deadline, or `None`."""
-        deadlines = [
-            deadline for state in self._connections if (deadline := state.connection.next_timeout()) is not None
-        ]
-        return min(deadlines, default=None)
+        self._sync_timeouts()
+        return self._timeouts[0].timer_deadline if self._timeouts else None
 
     def handle_timeout(self, now: int) -> None:
         """Fire every connection timer due at `now`."""
-        for state in self._connections:
-            deadline = state.connection.next_timeout()
-            if deadline is not None and deadline <= now:
+        while (deadline := self.next_timeout()) is not None and deadline <= now:
+            state = self._timeouts[0]
+            self._remove_timeout(state)
+            try:
                 state.connection.handle_timeout(now)
+            finally:
+                self._mark_ready(state)
+                self._mark_timer_dirty(state)
 
     def _connection_state(self, connection: H3Connection) -> _ConnectionState:
-        state = next((item for item in self._connections if item.connection is connection), None)
+        state = self._connections.get(connection)
         if state is None:
             raise LocalProtocolError("connection does not belong to this endpoint")
         return state
@@ -258,8 +287,10 @@ class QuicEndpoint:
             parameters["initial_destination_connection_id"],
             parameters["peer_address"],
         )
-        self._connections.append(state)
+        self._connections[connection] = state
         self._sync_routes(state)
+        self._mark_ready(state)
+        self._mark_timer_dirty(state)
         return connection
 
     def _receive(
@@ -269,11 +300,90 @@ class QuicEndpoint:
         peer_address: bytes,
         now: int,
     ) -> H3Connection:
-        state.connection.receive_datagram(datagram, now, peer_address)
         state.peer_address = peer_address
-        if state.connection_id_generation != state.connection._endpoint_connection_id_generation():
-            self._sync_routes(state)
+        try:
+            state.connection.receive_datagram(datagram, now, peer_address)
+        finally:
+            if state.connection_id_generation != state.connection._endpoint_connection_id_generation():
+                self._sync_routes(state)
+            self._mark_ready(state)
+            self._mark_timer_dirty(state)
         return state.connection
+
+    def _mark_ready(self, state: _ConnectionState) -> None:
+        self._ready[state] = None
+
+    def _mark_timer_dirty(self, state: _ConnectionState) -> None:
+        self._timer_dirty[state] = None
+
+    def _sync_timeouts(self) -> None:
+        dirty = list(self._timer_dirty)
+        self._timer_dirty.clear()
+        for state in dirty:
+            self._schedule_timeout(state)
+
+    def _schedule_timeout(self, state: _ConnectionState) -> None:
+        deadline = state.connection.next_timeout() if state.active else None
+        if deadline == state.timer_deadline:
+            return
+        if deadline is None:
+            self._remove_timeout(state)
+            return
+        previous = state.timer_deadline
+        state.timer_deadline = deadline
+        if state.timer_index < 0:
+            state.timer_index = len(self._timeouts)
+            self._timeouts.append(state)
+            self._sift_timeout_up(state.timer_index)
+        elif previous is not None and deadline < previous:
+            self._sift_timeout_up(state.timer_index)
+        else:
+            self._sift_timeout_down(state.timer_index)
+
+    def _remove_timeout(self, state: _ConnectionState) -> None:
+        index = state.timer_index
+        state.timer_index = -1
+        state.timer_deadline = None
+        if index < 0:
+            return
+        last = self._timeouts.pop()
+        if index == len(self._timeouts):
+            return
+        self._timeouts[index] = last
+        last.timer_index = index
+        self._sift_timeout_up(index)
+        self._sift_timeout_down(last.timer_index)
+
+    def _sift_timeout_up(self, index: int) -> None:
+        while index > 0:
+            parent = (index - 1) // 2
+            if self._timeout_before(self._timeouts[parent], self._timeouts[index]):
+                return
+            self._swap_timeouts(parent, index)
+            index = parent
+
+    def _sift_timeout_down(self, index: int) -> None:
+        size = len(self._timeouts)
+        while (left := 2 * index + 1) < size:
+            right = left + 1
+            child = (
+                right if right < size and self._timeout_before(self._timeouts[right], self._timeouts[left]) else left
+            )
+            if self._timeout_before(self._timeouts[index], self._timeouts[child]):
+                return
+            self._swap_timeouts(index, child)
+            index = child
+
+    def _swap_timeouts(self, first: int, second: int) -> None:
+        self._timeouts[first], self._timeouts[second] = self._timeouts[second], self._timeouts[first]
+        self._timeouts[first].timer_index = first
+        self._timeouts[second].timer_index = second
+
+    @staticmethod
+    def _timeout_before(first: _ConnectionState, second: _ConnectionState) -> bool:
+        assert first.timer_deadline is not None
+        assert second.timer_deadline is not None
+        return first.timer_deadline <= second.timer_deadline
 
     def _sync_routes(self, state: _ConnectionState) -> None:
         connection_ids = {item.connection_id for item in state.connection.local_connection_ids()}


### PR DESCRIPTION
Follow-up to [#204](https://github.com/Kludex/zttp/pull/204).

## Summary

- Track ready connections and deadlines without scanning every active connection.
- Keep endpoint-owned connection IDs synchronized and reject direct issuance.
- Reject undersized Initial datagrams and reduce outbound datagram allocation overhead.
- Include the outstanding HTTP/3 review corrections.

## Tests

- `scripts/check`
- `scripts/build`
- `GITHUB_ACTIONS=1 scripts/test`
- `scripts/coverage` - 100%

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens QUIC endpoint connection management to avoid scanning all connections and to enforce endpoint ownership of local connection IDs. The endpoint now drains only ready connections, maintains per-connection timers efficiently, and drops non-compliant Initials, cutting CPU and allocation overhead.

- `QuicEndpoint.data_to_send()` drains only ready connections and accepts `data_to_send(connection)` to drain app-queued output.
- `next_timeout()`/`handle_timeout()` track deadlines per connection without scanning; timers are ordered by earliest deadline.
- Initial datagrams smaller than 1200 bytes are dropped before Retry; no response is sent for undersized Initials.
- Endpoint-issued CIDs are synchronized; direct `connection.issue_connection_id()` now raises `LocalProtocolError` on endpoint-owned connections.
- QUIC Initial header sizing avoids extra allocation, reducing outbound datagram overhead.
- Docs clarify `data_to_send()` behavior for endpoint and HTTP/3 usage.

**Migration**
- When queuing application data after a prior drain, call `endpoint.data_to_send(connection)`.
- For accepted connections, use `endpoint.issue_connection_id(seq, cid, token, retire_prior_to=0)` instead of `connection.issue_connection_id(...)`.
- Ensure client Initials are at least 1200 bytes; undersized Initials are dropped.

<sup>Written for commit eb5f16c9c6cd9d075a928c4beda4504bb4431a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved endpoint output handling, including targeted draining for a specific connection.
  * Added endpoint-managed connection ID issuance for HTTP/3 connections.
  * Improved connection timeout tracking and processing.

* **Bug Fixes**
  * Rejects undersized initial datagrams before retry handling.
  * Ensures closed connections and expired connections are properly removed from endpoint state.

* **Documentation**
  * Documented endpoint output draining behavior and targeted connection draining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->