### PR TITLE
Compare stateless reset tokens in constant time

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2397,21 +2397,17 @@ pub const Connection = struct {
 
     fn detectStatelessReset(self: *Connection, buf: []const u8) bool {
         if (buf.len < 21) return false;
-        const token = buf[buf.len - 16 ..];
+        const token = buf[buf.len - 16 ..][0..16].*;
+        var matched = false;
         if (self.peer_tp.stateless_reset_token) |t| {
-            if (std.mem.eql(u8, token, &t)) {
-                self.closed = true;
-                return true;
-            }
+            matched = std.crypto.timing_safe.eql([16]u8, token, t);
         }
         var it = self.peer_cids.valueIterator();
         while (it.next()) |cid| {
-            if (std.mem.eql(u8, token, &cid.token)) {
-                self.closed = true;
-                return true;
-            }
+            matched = std.crypto.timing_safe.eql([16]u8, token, cid.token) or matched;
         }
-        return false;
+        if (matched) self.closed = true;
+        return matched;
     }
 
     fn acceptsLocalCid(self: *const Connection, dcid: []const u8) bool {


### PR DESCRIPTION
## Summary

- Compare transport-parameter and connection-ID stateless reset tokens with `std.crypto.timing_safe.eql`.
- Check every available token before acting on a match.
- Follow the constant-time comparison requirement in RFC 9000 Section 10.3.1.

## Tests

- `zig build test`
- `zig fmt --check src/core/quic/connection.zig`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
