### PR TITLE
Reject HTTP/2 switching protocols responses

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -806,9 +806,9 @@ pub const Connection = struct {
                     if (d < '0' or d > '9') return error.Malformed;
                     code = code * 10 + (d - '0');
                 }
-                // Only the defined status classes (1xx-5xx) are valid; 000-099 and
-                // 600-999 are impossible codes (RFC 9110 15).
-                if (code < 100 or code > 599) return error.Malformed;
+                // Only the defined status classes (1xx-5xx) are valid; HTTP/2
+                // does not support 101 Switching Protocols (RFC 9113 8.6).
+                if (code < 100 or code > 599 or code == 101) return error.Malformed;
                 status = code;
                 continue;
             }

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -233,6 +233,21 @@ def test_client_reads_a_response() -> None:
     assert isinstance(eom, zttp.EndOfMessage)
 
 
+def test_client_rejects_a_switching_protocols_response() -> None:
+    conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    conn.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])
+    conn.data_to_send()
+    status = bytes([0x00, 0x07]) + b":status" + bytes([0x03]) + b"101"
+    conn.receive_data(frame(0x04, 0, 0, b"") + frame(0x01, END_HEADERS, 1, status))
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, zttp.Response) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
 def test_client_reads_a_response_with_a_body() -> None:
     conn = client_with(
         frame(0x01, END_HEADERS, 1, STATUS_200),


### PR DESCRIPTION
## Summary

- Reject received HTTP/2 `101 Switching Protocols` response headers.
- Reset only the malformed response stream with `PROTOCOL_ERROR`.
- Preserve valid informational response handling.

HTTP/2 has no connection-wide protocol switch. RFC 9113 Section 8.6 explicitly excludes status 101.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
