### PR TITLE
Verify the OSS-Fuzz Zig toolchain checksum

### DIFF
--- a/.oss-fuzz/Dockerfile
+++ b/.oss-fuzz/Dockerfile
@@ -4,8 +4,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends xz-utils && \
     rm -rf /var/lib/apt/lists/*
 
 ENV ZIG_VERSION=0.16.0
-RUN curl -sSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
-        | tar -xJ -C /opt && \
+ENV ZIG_SHA256=70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
+RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+        -o /tmp/zig.tar.xz && \
+    echo "${ZIG_SHA256}  /tmp/zig.tar.xz" | sha256sum -c - && \
+    tar -xJf /tmp/zig.tar.xz -C /opt && \
+    rm /tmp/zig.tar.xz && \
     ln -s "/opt/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
 
 RUN git clone --depth 1 https://github.com/Kludex/zttp $SRC/zttp


### PR DESCRIPTION
## Summary

- Pin the published SHA-256 digest for the Zig 0.16.0 Linux archive.
- Download the archive to disk and verify it before extraction.
- Make HTTP download failures abort the OSS-Fuzz image build.

## Tests

- Downloaded the upstream archive and verified the pinned digest locally.
- `git diff --check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
