### PR TITLE
Reject invalid HTTP response status codes

### DIFF
--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -62,6 +62,7 @@ pub fn parseStatusLine(line: []const u8) ParseError!StatusLine {
         if (d < '0' or d > '9') return error.InvalidLine;
         code = code * 10 + (d - '0');
     }
+    if (code < 100 or code > 599) return error.InvalidLine;
     // A space and reason phrase are optional after the code.
     var reason: []const u8 = "";
     if (sc.peek() == ' ') {

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -338,6 +338,17 @@ def test_response_parsing() -> None:
     assert data.data == b"xyz"
 
 
+@pytest.mark.parametrize("status", [b"000", b"099", b"600", b"999"])
+def test_response_rejects_an_out_of_range_status(status: bytes) -> None:
+    conn = zttp.Connection(zttp.CLIENT)
+    conn.receive_data(b"HTTP/1.1 " + status + b" Invalid\r\nContent-Length: 0\r\n\r\n")
+
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
 @pytest.mark.parametrize(
     ("method", "status", "reason"),
     [(b"GET", 204, b"No Content"), (b"CONNECT", 200, b"OK")],


### PR DESCRIPTION
## Summary

- Reject received HTTP/1.x status codes outside `100..599`.
- Keep the parse failure terminal so invalid responses cannot be resumed.
- Cover the lower and upper invalid ranges through the Python API.

This aligns the HTTP/1 reader with the HTTP/1 writer and the HTTP/2 and HTTP/3 readers.

## Tests

- `zig build test`
- `uv run pytest tests/test_read.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
