### PR TITLE
Correct HPACK Huffman symbol 208

### DIFF
--- a/src/core/h2/hpack/huffman.zig
+++ b/src/core/h2/hpack/huffman.zig
@@ -124,7 +124,7 @@ const CODES = [257]Sym{
     .{ .code = 0x3ffffe4, .bits = 26 },  .{ .code = 0x7ffffde, .bits = 27 },
     .{ .code = 0x7ffffdf, .bits = 27 },  .{ .code = 0x3ffffe5, .bits = 26 },
     .{ .code = 0xfffff1, .bits = 24 },   .{ .code = 0x1ffffed, .bits = 25 },
-    .{ .code = 0x5fff, .bits = 15 },     .{ .code = 0x1fffe3, .bits = 21 },
+    .{ .code = 0x7fff2, .bits = 19 },    .{ .code = 0x1fffe3, .bits = 21 },
     .{ .code = 0x3ffffe6, .bits = 26 },  .{ .code = 0x7ffffe0, .bits = 27 },
     .{ .code = 0x7ffffe1, .bits = 27 },  .{ .code = 0x3ffffe7, .bits = 26 },
     .{ .code = 0x7ffffe2, .bits = 27 },  .{ .code = 0xfffff2, .bits = 24 },

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -121,6 +121,15 @@ def test_simple_get_request() -> None:
     assert (b"host", b"www.example.com") in req.headers
 
 
+def test_hpack_decodes_symbol_208() -> None:
+    huffman_value = bytes([0x00, 0x03]) + b"x-a" + bytes([0x83, 0xFF, 0xFE, 0x5F])
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK + huffman_value))
+
+    request = next(event for event in drain_h2(conn) if isinstance(event, zttp.Request))
+
+    assert (b"x-a", b"\xd0") in request.headers
+
+
 def test_request_with_body() -> None:
     conn = server_with(
         frame(0x01, END_HEADERS, 1, GET_BLOCK),  # no END_STREAM


### PR DESCRIPTION
## Summary

- Correct the HPACK Huffman code for byte `0xD0` to the RFC 7541 Appendix B value.
- Decode conforming Huffman-encoded field values containing that byte.
- Cover the wire representation through the public HTTP/2 API.

The same table is shared by HPACK and QPACK.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
