### PR TITLE
Discard duplicate QUIC packets before dispatch

### DIFF
--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -3406,7 +3406,7 @@ test "the event arena is reclaimed when the queue drains" {
     // without corrupting the decode path).
     try testing.expect(h3.nextEvent() == .need_data);
 
-    const dgram2 = try buildRequest(gpa, &dcid, 4, h3_bytes.items); // stream 4 (client bidi)
+    const dgram2 = try buildRequestOnFin(gpa, &dcid, 4, 1, h3_bytes.items); // stream 4 (client bidi)
     defer gpa.free(dgram2);
     try qc.receiveDatagram(dgram2, 2000);
     try h3.pump(4);
@@ -4658,7 +4658,7 @@ test "a rejected dynamic request sends QPACK stream cancellation" {
     var h3_bytes: std.ArrayListUnmanaged(u8) = .empty;
     defer h3_bytes.deinit(gpa);
     try h3_frame.append(&h3_bytes, gpa, .headers, &qpack_block);
-    const req_dgram = try buildRequest(gpa, &dcid, 0, h3_bytes.items);
+    const req_dgram = try buildRequestOnFin(gpa, &dcid, 0, 1, h3_bytes.items);
     defer gpa.free(req_dgram);
     try qc.receiveDatagram(req_dgram, 2000);
     try h3.pump(0);
@@ -4670,7 +4670,7 @@ test "a rejected dynamic request sends QPACK stream cancellation" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
-    quic_conn.testSetAppNextPn(&peer, 1);
+    quic_conn.testSetAppNextPn(&peer, 2);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
     for (qc.datagramLengths()) |len| {

--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -13,6 +13,7 @@ pub const AckRanges = struct {
     /// disjoint and non-adjacent. An ACK frame rarely needs more than a handful;
     /// the list is capped so a pathological gap pattern cannot grow it unbounded.
     ranges: std.ArrayListUnmanaged(Range) = .empty,
+    ignore_below: u64 = 0,
 
     pub const MAX_RANGES: usize = 32;
 
@@ -41,8 +42,7 @@ pub const AckRanges = struct {
     /// evicted duplicate, so they are ignored rather than dispatched twice.
     pub fn shouldIgnore(self: *const AckRanges, pn: u64) bool {
         if (self.contains(pn)) return true;
-        if (self.ranges.items.len < MAX_RANGES) return false;
-        return pn < self.ranges.items[self.ranges.items.len - 1].lo;
+        return pn < self.ignore_below;
     }
 
     /// Record that packet number `pn` was received. Extends or merges an existing
@@ -74,6 +74,9 @@ pub const AckRanges = struct {
             _ = self.ranges.pop(); // evict the current smallest to make room
         }
         try self.ranges.insert(gpa, i, .{ .lo = pn, .hi = pn });
+        if (self.ranges.items.len == MAX_RANGES) {
+            self.ignore_below = @max(self.ignore_below, self.ranges.items[MAX_RANGES - 1].lo);
+        }
     }
 
     /// After growing range `i`, coalesce it with the neighbour it may now touch.
@@ -183,4 +186,9 @@ test "packets older than full ACK history are ignored" {
     try testing.expect(a.shouldIgnore(2));
     try testing.expect(a.shouldIgnore(1));
     try testing.expect(!a.shouldIgnore(3));
+
+    try a.add(gpa, (AckRanges.MAX_RANGES + 1) * 2);
+    try a.add(gpa, 5);
+    try testing.expectEqual(AckRanges.MAX_RANGES - 1, a.ranges.items.len);
+    try testing.expect(a.shouldIgnore(2));
 }

--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -36,6 +36,15 @@ pub const AckRanges = struct {
         return false;
     }
 
+    /// Return whether a packet was already recorded or is older than the bounded
+    /// ACK history. Packets below a full range set cannot be distinguished from an
+    /// evicted duplicate, so they are ignored rather than dispatched twice.
+    pub fn shouldIgnore(self: *const AckRanges, pn: u64) bool {
+        if (self.contains(pn)) return true;
+        if (self.ranges.items.len < MAX_RANGES) return false;
+        return pn < self.ranges.items[self.ranges.items.len - 1].lo;
+    }
+
     /// Record that packet number `pn` was received. Extends or merges an existing
     /// range, or inserts a new one in descending order. If the list is at capacity
     /// the oldest (smallest) range is dropped - the peer will simply re-send those
@@ -163,4 +172,15 @@ test "a duplicate pn is a no-op" {
     try testing.expectEqual(@as(usize, 1), a.ranges.items.len);
     try testing.expect(a.contains(5));
     try testing.expect(!a.contains(4));
+}
+
+test "packets older than full ACK history are ignored" {
+    const gpa = testing.allocator;
+    var a = AckRanges{};
+    defer a.deinit(gpa);
+    for (1..AckRanges.MAX_RANGES + 1) |index| try a.add(gpa, @intCast(index * 2));
+
+    try testing.expect(a.shouldIgnore(2));
+    try testing.expect(a.shouldIgnore(1));
+    try testing.expect(!a.shouldIgnore(3));
 }

--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -28,6 +28,14 @@ pub const AckRanges = struct {
         return if (self.ranges.items.len == 0) null else self.ranges.items[0].hi;
     }
 
+    /// Return whether `pn` is already recorded in a retained range.
+    pub fn contains(self: *const AckRanges, pn: u64) bool {
+        for (self.ranges.items) |range| {
+            if (pn >= range.lo and pn <= range.hi) return true;
+        }
+        return false;
+    }
+
     /// Record that packet number `pn` was received. Extends or merges an existing
     /// range, or inserts a new one in descending order. If the list is at capacity
     /// the oldest (smallest) range is dropped - the peer will simply re-send those
@@ -153,4 +161,6 @@ test "a duplicate pn is a no-op" {
     try a.add(gpa, 5);
     try a.add(gpa, 5);
     try testing.expectEqual(@as(usize, 1), a.ranges.items.len);
+    try testing.expect(a.contains(5));
+    try testing.expect(!a.contains(4));
 }

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2462,7 +2462,7 @@ pub const Connection = struct {
         // (RFC 9000 8.1).
         if (space == .handshake) self.validateCurrentPath();
 
-        if (st.recv_ranges.contains(opened.pn)) return;
+        if (st.recv_ranges.shouldIgnore(opened.pn)) return;
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
         st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
         try self.dispatchFrames(opened.payload, space, long, now);

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -3546,6 +3546,9 @@ test "PATH_CHALLENGE elicits a matching PATH_RESPONSE" {
 
     try conn.receiveDatagram(dgram, 1000);
     try testing.expect(conn.datagramLengths().len >= 1);
+    const response_count = conn.datagramLengths().len;
+    try conn.receiveDatagram(dgram, 1001);
+    try testing.expectEqual(response_count, conn.datagramLengths().len);
 
     const response = conn.datagramsToSend()[0..conn.datagramLengths()[0]];
     var work = try gpa.dupe(u8, response);

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2462,6 +2462,7 @@ pub const Connection = struct {
         // (RFC 9000 8.1).
         if (space == .handshake) self.validateCurrentPath();
 
+        if (st.recv_ranges.contains(opened.pn)) return;
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
         st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
         try self.dispatchFrames(opened.payload, space, long, now);
@@ -2703,7 +2704,7 @@ pub const Connection = struct {
 
     fn onPathResponse(self: *Connection, data: [8]u8) Error!void {
         const token = pathToken(data);
-        const pending = self.pending_path_challenges.get(token) orelse return error.ProtocolViolation;
+        const pending = self.pending_path_challenges.get(token) orelse return;
         if (pending.path_token) |pt| {
             if (self.current_path_token == null or self.current_path_token.? != pt) return error.ProtocolViolation;
         }
@@ -3555,6 +3556,12 @@ test "challengePath emits PATH_CHALLENGE and matching PATH_RESPONSE validates th
     try testing.expectEqual(@as(usize, 0), conn.pending_path_challenges.count());
     try testing.expectEqual(@as(usize, 0), conn.path_challenge_inflight.count());
     try expectFirstQueuedAppFrameTag(&conn, .ack);
+
+    try conn.receiveDatagram(dgram, 2001);
+    const late = try testBuildApp(gpa, &dcid, 1, frames.items);
+    defer gpa.free(late);
+    try conn.receiveDatagram(late, 2002);
+    try testing.expect(!conn.closed);
 }
 
 test "address-aware PATH_RESPONSE validates only the challenged path" {
@@ -3839,7 +3846,7 @@ test "PATH_RESPONSE is ack-eliciting" {
     try expectFirstQueuedAppFrameTag(&conn, .ack);
 }
 
-test "unmatched PATH_RESPONSE is a protocol violation" {
+test "unmatched PATH_RESPONSE is ignored" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
     var conn = try Connection.init(gpa, .server, &dcid);
@@ -3852,7 +3859,8 @@ test "unmatched PATH_RESPONSE is a protocol violation" {
     const dgram = try testBuildApp(gpa, &dcid, 0, frames.items);
     defer gpa.free(dgram);
 
-    try testing.expectError(error.ProtocolViolation, conn.receiveDatagram(dgram, 1000));
+    try conn.receiveDatagram(dgram, 1000);
+    try testing.expect(!conn.closed);
 }
 
 test "NEW_TOKEN received by a server is a protocol violation" {

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -148,12 +148,18 @@ def test_quic_endpoint_updates_connection_timeouts() -> None:
     first_deadline = endpoint.next_timeout()
     assert first_deadline is not None
 
-    assert endpoint.receive_datagram(initial, b"address", 2000) is connection
+    client_deadline = client.next_timeout()
+    assert client_deadline is not None
+    client.handle_timeout(client_deadline)
+    assert endpoint.receive_datagram(client.data_to_send()[0], b"address", 2000) is connection
     later_deadline = endpoint.next_timeout()
     assert later_deadline is not None
     assert later_deadline > first_deadline
 
-    assert endpoint.receive_datagram(initial, b"address", 500) is connection
+    client_deadline = client.next_timeout()
+    assert client_deadline is not None
+    client.handle_timeout(client_deadline)
+    assert endpoint.receive_datagram(client.data_to_send()[0], b"address", 500) is connection
     earlier_deadline = endpoint.next_timeout()
     assert earlier_deadline is not None
     assert earlier_deadline < later_deadline
@@ -194,7 +200,10 @@ def test_quic_endpoint_orders_connection_timeouts() -> None:
     assert second is not None
     assert third is not None
     assert endpoint.next_timeout() == 2000
-    assert endpoint.receive_datagram(second_initial, b"second", 1500) is second
+    client_deadline = second_client.next_timeout()
+    assert client_deadline is not None
+    second_client.handle_timeout(client_deadline)
+    assert endpoint.receive_datagram(second_client.data_to_send()[0], b"second", 1500) is second
     assert endpoint.next_timeout() == 2500
 
     endpoint.discard(second)


### PR DESCRIPTION
## Summary

- Detect received packet numbers before dispatching their frames again.
- Ignore duplicate and late `PATH_RESPONSE` frames after a path is validated.
- Give multi-packet HTTP/3 tests distinct packet numbers.

This follows RFC 9000 Section 12.3 and prevents duplicated datagrams from repeating non-idempotent frame effects.

## Tests

- `zig build test`
- `zig fmt --check src/core/quic/ack_ranges.zig src/core/quic/connection.zig src/core/h3/connection.zig`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
