### PR TITLE
Replenish HTTP/2 credit for discarded data

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -423,6 +423,9 @@ pub const Connection = struct {
         // Connection-window accounting against the FULL frame payload length.
         if (@as(i64, self.conn_recv_window) - @as(i64, f.header.length) < 0) return error.FlowControlError;
         self.conn_recv_window -= @intCast(f.header.length);
+        // Return connection credit even when stream validation later discards the payload.
+        self.conn_recv_window += @intCast(f.header.length);
+        self.conn_recv_credit +|= f.header.length;
 
         const s = self.streams.getPtr(f.header.stream_id) orelse {
             // No live stream: an idle id (never opened) is a connection error;
@@ -447,10 +450,7 @@ pub const Connection = struct {
             return;
         }
         s.recordData(content.len);
-        // Refill the receive windows immediately (the data is surfaced now) and
-        // accumulate the consumed length to advertise back via WINDOW_UPDATE.
-        self.conn_recv_window += @intCast(f.header.length);
-        self.conn_recv_credit +|= f.header.length;
+        // Refill the stream receive window immediately because the data is surfaced now.
         s.creditRecvWindow(f.header.length);
         // A response the request marked bodyless (HEAD, or a 204/304) must carry no
         // DATA; surfacing a body here would let a proxy forward one where none is

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -136,6 +136,31 @@ def test_request_with_body() -> None:
     assert any(isinstance(e, zttp.EndOfMessage) for e in events)
 
 
+def test_discarded_data_replenishes_the_connection_window() -> None:
+    discarded = b"".join(frame(0x00, 0, 1, b"x" * length) for length in (16384, 16384, 16384, 16383))
+    conn = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP2)
+    conn.receive_data(
+        PREFACE
+        + frame(0x04, 0, 0, b"")
+        + frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK)
+        + discarded
+        + frame(0x01, END_HEADERS, 3, GET_BLOCK)
+        + frame(0x00, END_STREAM, 3, b"y")
+    )
+
+    events = list(drain_h2(conn))
+
+    data = next(event for event in events if isinstance(event, zttp.Data))
+    assert data.stream_id == 3
+    assert data.data == b"y"
+    updates = [
+        payload
+        for frame_type, _, stream_id, payload in _frames(conn.data_to_send())
+        if frame_type == 0x08 and stream_id == 0
+    ]
+    assert sum(int.from_bytes(payload, "big") for payload in updates) == 65535
+
+
 def test_two_multiplexed_streams_carry_their_ids() -> None:
     conn = server_with(
         frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK),


### PR DESCRIPTION
## Summary

- Return connection-level receive credit for every accepted `DATA` frame.
- Preserve the connection window when stream validation discards in-flight data.
- Verify a full window of late data cannot block a separate live stream.

The peer still receives `RST_STREAM` for invalid stream traffic, while connection-level flow control remains usable.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP/2 connection flow control so discarded data on closed or invalid streams still restores available connection capacity.
  * Ensured subsequent requests continue to receive data correctly after discarded payloads.

* **Tests**
  * Added coverage verifying discarded data triggers the expected connection-level window updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->