### PR TITLE
Require HTTP/2 response headers before data

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -441,6 +441,10 @@ pub const Connection = struct {
             },
             .connection_error => return error.ProtocolError,
         }
+        if (self.role == .client and !s.headers_done) {
+            try self.resetStream(s, f.header.stream_id, .protocol_error);
+            return;
+        }
         const wt = s.debitRecvWindow(f.header.length);
         if (wt.action == .stream_error) {
             self.pushRst(f.header.stream_id, .flow_control_error);
@@ -538,7 +542,7 @@ pub const Connection = struct {
             if (id <= self.highest_local_id) {
                 ignored = true;
             } else {
-                try self.openPeerStream(id);
+                return error.ProtocolError;
             }
         } else {
             // A new request stream. Its id must be odd and exceed the highest peer
@@ -1808,6 +1812,7 @@ test "client rejects a body on a bodyless (HEAD) response" {
 // A client's inbound handshake is just the server's SETTINGS - no preface to
 // consume - so it differs from the server `handshook` helper.
 fn clientHandshook(c: *Connection, extra: []const u8) !void {
+    try c.registerSendStream(1);
     var input: std.ArrayList(u8) = .empty;
     defer input.deinit(testing.allocator);
     try frameBytes(&input, .settings, 0, 0, &.{});

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -218,6 +218,8 @@ STATUS_200 = bytes([0x88])
 def client_with(*extra: bytes) -> zttp.H2Connection:
     """A client sees only the server's SETTINGS (no preface to consume)."""
     conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    conn.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])
+    conn.data_to_send()
     conn.receive_data(frame(0x04, 0, 0, b"") + b"".join(extra))
     return conn
 
@@ -231,6 +233,24 @@ def test_client_reads_a_response() -> None:
     assert resp.http_version == b"2"
     assert resp.stream_id == 1
     assert isinstance(eom, zttp.EndOfMessage)
+
+
+def test_client_rejects_data_before_response_headers() -> None:
+    conn = client_with(frame(0x00, END_STREAM, 1, b"body"))
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, (zttp.Response, zttp.Data, zttp.EndOfMessage)) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
+def test_client_rejects_a_response_on_an_unopened_stream() -> None:
+    conn = client_with(frame(0x01, END_HEADERS | END_STREAM, 3, STATUS_200))
+
+    with pytest.raises(zttp.RemoteProtocolError):
+        list(drain_h2(conn))
 
 
 def test_client_reads_a_response_with_a_body() -> None:
@@ -471,6 +491,8 @@ def test_full_body_round_trips_across_window_updates() -> None:
     body = bytearray()
     # Read the head + first window's worth on a fresh client.
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    client.send_request(b"GET", b"/", b"2", [(b"host", b"example.com")])
+    client.data_to_send()
     client.receive_data(frame(0x04, 0, 0, b""))  # server SETTINGS stand-in
     # Feed the server output in, granting more window until the body completes.
     rounds = 0


### PR DESCRIPTION
## Summary

- Reset a client response stream that receives `DATA` before its response headers.
- Reject response headers on request stream IDs the client never opened.
- Update client tests to open their request streams before receiving responses.

This preserves the HTTP message order and stream ownership rules in RFC 9113 Sections 5.1.1 and 8.1.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
