### PR TITLE
Validate HTTP/2 request methods as tokens

### DIFF
--- a/src/core/fields.zig
+++ b/src/core/fields.zig
@@ -7,14 +7,22 @@
 const std = @import("std");
 const tables = @import("tables.zig");
 
+/// Return whether `value` is a non-empty RFC 9110 token.
+pub fn isValidToken(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |ch| {
+        if (!tables.is_tchar[ch]) return false;
+    }
+    return true;
+}
+
 /// A valid HTTP/2 field name: a non-empty RFC 9110 token (so no SP, NUL, ':',
 /// or other separators) with no uppercase ASCII (RFC 9113 8.2.1). `:` is
 /// excluded here, so this is only applied to regular (non-pseudo) names.
 pub fn isValidFieldName(name: []const u8) bool {
-    if (name.len == 0) return false;
+    if (!isValidToken(name)) return false;
     for (name) |ch| {
         if (ch >= 'A' and ch <= 'Z') return false;
-        if (!tables.is_tchar[ch]) return false;
     }
     return true;
 }

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -719,7 +719,7 @@ pub const Connection = struct {
             if (h.name[0] == ':') {
                 if (seen_regular) return error.Malformed; // pseudo after regular
                 if (eql(h.name, ":method")) {
-                    if (method != null) return error.Malformed;
+                    if (method != null or !fields.isValidToken(h.value)) return error.Malformed;
                     method = h.value;
                 } else if (eql(h.name, ":path")) {
                     if (path != null) return error.Malformed;

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -674,6 +674,18 @@ def _request_block(*extra: tuple[bytes, bytes], method: bytes = b"GET") -> bytes
     return block
 
 
+@pytest.mark.parametrize("method", [b"", b"GET /admin HTTP/1.1", b"GE\tT"])
+def test_h2_rejects_an_invalid_method(method: bytes) -> None:
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, _request_block(method=method)))
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, zttp.Request) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
 def test_h2_bodyless_request_with_content_length_is_reset() -> None:
     # A request declaring content-length but sending no DATA is an h2->h1 smuggling
     # vector (the downgraded h1 request advertises a body that never arrives). It


### PR DESCRIPTION
## Summary

- Validate received HTTP/2 `:method` values with the RFC 9110 token grammar.
- Reject empty methods and methods containing spaces or tabs with a stream `PROTOCOL_ERROR`.
- Keep invalid method bytes out of trusted `Request` events.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
