### PR TITLE
Close streams after invalid window updates

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -400,7 +400,7 @@ pub const Connection = struct {
         const t = s.creditSendWindow(increment);
         switch (t.action) {
             .ok => self.push(.{ .window_update = .{ .stream_id = f.header.stream_id, .increment = increment } }),
-            .stream_error => self.pushRst(f.header.stream_id, t.code),
+            .stream_error => try self.resetStream(s, f.header.stream_id, t.code),
             .connection_error => return error.FlowControlError,
         }
     }

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -136,6 +136,19 @@ def test_request_with_body() -> None:
     assert any(isinstance(e, zttp.EndOfMessage) for e in events)
 
 
+def test_invalid_stream_window_update_closes_the_stream() -> None:
+    conn = server_with(frame(0x01, END_HEADERS, 1, GET_BLOCK))
+    list(drain_h2(conn))
+    conn.receive_data(frame(0x08, 0, 1, b"\x00\x00\x00\x00") + frame(0x00, END_STREAM, 1, b"late"))
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, (zttp.Data, zttp.EndOfMessage)) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
 def test_two_multiplexed_streams_carry_their_ids() -> None:
     conn = server_with(
         frame(0x01, END_HEADERS | END_STREAM, 1, GET_BLOCK),


### PR DESCRIPTION
## Summary

- Apply the full stream reset path after an invalid stream `WINDOW_UPDATE`.
- Evict the stream and charge reset churn before emitting `RstStream`.
- Prevent later `Data` or `EndOfMessage` events for the reset stream.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
