### PR TITLE
Reject forbidden HTTP trailer fields consistently

### DIFF
--- a/src/core/fields.zig
+++ b/src/core/fields.zig
@@ -5,6 +5,7 @@
 //! allows inner HTAB, while the write side is stricter and rejects it.
 
 const std = @import("std");
+const ascii = @import("ascii.zig");
 const tables = @import("tables.zig");
 
 /// A valid HTTP/2 field name: a non-empty RFC 9110 token (so no SP, NUL, ':',
@@ -41,6 +42,43 @@ pub fn isConnectionSpecific(name: []const u8) bool {
         if (std.mem.eql(u8, name, f)) return true;
     }
     return false;
+}
+
+/// Return whether a field may appear in a trailer section (RFC 9110 6.5.1).
+pub fn trailerFieldAllowed(name: []const u8) bool {
+    inline for (.{
+        "content-length",
+        "transfer-encoding",
+        "trailer",
+        "host",
+        "connection",
+        "upgrade",
+        "te",
+        "content-encoding",
+        "content-type",
+        "content-range",
+    }) |forbidden| {
+        if (ascii.eqIgnoreCase(name, forbidden)) return false;
+    }
+    return true;
+}
+
+test "trailerFieldAllowed rejects framing, routing, and payload metadata" {
+    for ([_][]const u8{
+        "content-length",
+        "transfer-encoding",
+        "trailer",
+        "host",
+        "connection",
+        "upgrade",
+        "te",
+        "content-encoding",
+        "content-type",
+        "content-range",
+    }) |name| {
+        try std.testing.expect(!trailerFieldAllowed(name));
+    }
+    try std.testing.expect(trailerFieldAllowed("x-checksum"));
 }
 
 test "isValidFieldName accepts lowercase token, rejects uppercase and empty" {

--- a/src/core/h1/headers.zig
+++ b/src/core/h1/headers.zig
@@ -5,8 +5,8 @@
 
 const std = @import("std");
 const tables = @import("../tables.zig");
-const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
+const fields = @import("../fields.zig");
 const scanner = @import("../scanner.zig");
 const Scanner = scanner.Scanner;
 const trimTrailingOws = scanner.trimTrailingOws;
@@ -93,27 +93,8 @@ fn parseVersion(tok: []const u8) ParseError![]const u8 {
     return num;
 }
 
-/// Whether a field-name is allowed in a chunked trailer section. Trailers cannot
-/// carry message framing, connection routing, or payload-processing metadata.
-pub fn trailerFieldAllowed(name: []const u8) bool {
-    inline for (.{
-        // Message framing / connection routing fields.
-        "content-length",
-        "transfer-encoding",
-        "trailer",
-        "host",
-        "connection",
-        "upgrade",
-        "te",
-        // Payload-processing metadata that RFC 9110 forbids in trailers.
-        "content-encoding",
-        "content-type",
-        "content-range",
-    }) |forbidden| {
-        if (ascii.eqIgnoreCase(name, forbidden)) return false;
-    }
-    return true;
-}
+/// Whether a field-name is allowed in a chunked trailer section.
+pub const trailerFieldAllowed = fields.trailerFieldAllowed;
 
 /// Parse one header field-line into a (name, value) pair. The name is the raw
 /// token (case preserved); the value has surrounding OWS stripped. A line with

--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -1226,6 +1226,7 @@ fn validTrailers(headers: []const events.Header) bool {
         if (!fields.isValidFieldName(h.name)) return false;
         if (!fields.validValue(h.value)) return false;
         if (fields.isConnectionSpecific(h.name)) return false;
+        if (!fields.trailerFieldAllowed(h.name)) return false;
     }
     return true;
 }

--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -1245,7 +1245,7 @@ pub const Connection = struct {
             if (!fields.isValidFieldName(h.name)) return self.failStream(.message_error);
             if (!fields.validValue(h.value)) return self.failStream(.message_error);
             if (fields.isConnectionSpecific(h.name)) return self.failStream(.message_error);
-            if (eql(h.name, "te") or eql(h.name, "content-length")) return self.failStream(.message_error);
+            if (!fields.trailerFieldAllowed(h.name)) return self.failStream(.message_error);
             const name = self.gpa.dupe(u8, h.name) catch return error.OutOfMemory;
             errdefer self.gpa.free(name);
             const value = self.gpa.dupe(u8, h.value) catch return error.OutOfMemory;
@@ -1631,7 +1631,7 @@ fn validateTrailerHeader(h: Header) Error!void {
     if (!fields.isValidFieldName(h.name)) return error.H3Error;
     try validateSendValue(h.value);
     if (fields.isConnectionSpecific(h.name)) return error.H3Error;
-    if (eql(h.name, "te") or eql(h.name, "content-length")) return error.H3Error;
+    if (!fields.trailerFieldAllowed(h.name)) return error.H3Error;
 }
 
 fn fieldSectionSize(headers: []const Header) Error!u64 {

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -674,6 +674,35 @@ def _request_block(*extra: tuple[bytes, bytes], method: bytes = b"GET") -> bytes
     return block
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        b"content-length",
+        b"transfer-encoding",
+        b"trailer",
+        b"host",
+        b"connection",
+        b"upgrade",
+        b"te",
+        b"content-encoding",
+        b"content-type",
+        b"content-range",
+    ],
+)
+def test_h2_rejects_forbidden_trailer_fields(name: bytes) -> None:
+    conn = server_with(
+        frame(0x01, END_HEADERS, 1, _request_block(method=b"POST")),
+        frame(0x01, END_HEADERS | END_STREAM, 1, _lit(name, b"value")),
+    )
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, zttp.EndOfMessage) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
 def test_h2_bodyless_request_with_content_length_is_reset() -> None:
     # A request declaring content-length but sending no DATA is an h2->h1 smuggling
     # vector (the downgraded h1 request advertises a body that never arrives). It

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -1610,6 +1610,30 @@ def test_http3_rejects_a_pseudo_header_in_trailers() -> None:
         stream.end_message([(b":status", b"200")])
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        b"content-length",
+        b"transfer-encoding",
+        b"trailer",
+        b"host",
+        b"connection",
+        b"upgrade",
+        b"te",
+        b"content-encoding",
+        b"content-type",
+        b"content-range",
+    ],
+)
+def test_http3_rejects_forbidden_fields_in_trailers(name: bytes) -> None:
+    conn = _handshaken_with_request()
+    stream = conn.stream(0)
+    stream.send_response(200)
+
+    with pytest.raises(zttp.RemoteProtocolError):
+        stream.end_message([(name, b"value")])
+
+
 def test_http3_final_response_rejects_informational_status() -> None:
     conn = _handshaken_with_request()
 


### PR DESCRIPTION
## Summary

- Share one RFC 9110 trailer-field predicate across HTTP/1.1, HTTP/2, and HTTP/3.
- Reject framing, routing, and payload-processing metadata in HTTP/2 and HTTP/3 trailers.
- Keep valid extension trailer fields available in `EndOfMessage`.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py tests/test_http3.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
