### PR TITLE
Reconcile HTTP/2 authority and host fields

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -710,6 +710,7 @@ pub const Connection = struct {
         var path: ?[]const u8 = null;
         var scheme: ?[]const u8 = null;
         var authority: ?[]const u8 = null;
+        var host: ?[]const u8 = null;
         var content_length: ?u64 = null;
         var seen_regular = false;
 
@@ -739,6 +740,12 @@ pub const Connection = struct {
             if (!fields.isValidFieldName(h.name)) return error.Malformed; // uppercase / non-token byte
             if (fields.isConnectionSpecific(h.name)) return error.Malformed;
             if (eql(h.name, "te") and !eql(h.value, "trailers")) return error.Malformed;
+            if (eql(h.name, "host")) {
+                if (host) |previous| {
+                    if (!eql(previous, h.value)) return error.Malformed;
+                } else host = h.value;
+                continue;
+            }
             if (eql(h.name, "content-length")) {
                 const cl = ascii.parseDecimal(u64, h.value) orelse return error.Malformed;
                 // A repeated content-length is malformed unless it agrees (RFC 9110).
@@ -757,12 +764,15 @@ pub const Connection = struct {
         const q = std.mem.indexOfScalar(u8, target, '?');
         const req_path = if (q) |i| target[0..i] else target;
         const req_query = if (q) |i| target[i + 1 ..] else target[target.len..];
-        // Synthesize a host header from :authority (copied into req_scratch).
         if (authority) |a| {
+            if (host) |h| if (!eql(a, h)) return error.Malformed;
+        }
+        const canonical_host: ?[]const u8 = if (authority) |a| a else host;
+        if (canonical_host) |value| {
             const start = self.req_scratch.items.len;
-            self.req_scratch.appendSlice(self.gpa, a) catch return error.OutOfMemory;
-            const host_val = self.req_scratch.items[start..];
-            self.req_headers.append(self.gpa, .{ .name = "host", .value = host_val }) catch return error.OutOfMemory;
+            self.req_scratch.appendSlice(self.gpa, value) catch return error.OutOfMemory;
+            const host_value = self.req_scratch.items[start..];
+            self.req_headers.append(self.gpa, .{ .name = "host", .value = host_value }) catch return error.OutOfMemory;
         }
 
         return .{

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -674,6 +674,25 @@ def _request_block(*extra: tuple[bytes, bytes], method: bytes = b"GET") -> bytes
     return block
 
 
+def test_h2_rejects_conflicting_authority_and_host() -> None:
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, _request_block((b"host", b"other.example"))))
+
+    events = list(drain_h2(conn))
+
+    assert not any(isinstance(event, zttp.Request) for event in events)
+    reset = next(event for event in events if isinstance(event, zttp.RstStream))
+    assert reset.stream_id == 1
+    assert reset.error_code == 0x01
+
+
+def test_h2_emits_one_host_for_matching_authority_and_host() -> None:
+    conn = server_with(frame(0x01, END_HEADERS | END_STREAM, 1, _request_block((b"host", b"x"))))
+
+    request = next(event for event in drain_h2(conn) if isinstance(event, zttp.Request))
+
+    assert sum(1 for name, value in request.headers if name == b"host" and value == b"x") == 1
+
+
 def test_h2_bodyless_request_with_content_length_is_reset() -> None:
     # A request declaring content-length but sending no DATA is an h2->h1 smuggling
     # vector (the downgraded h1 request advertises a body that never arrives). It


### PR DESCRIPTION
## Summary

- Reject received HTTP/2 requests whose `:authority` and `host` values conflict.
- Collapse matching authority and host values into one canonical `host` field.
- Collapse repeated matching host fields instead of surfacing an ambiguous list.

This follows the request authority rules in RFC 9113 Section 8.3.1.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
