### PR TITLE
Accept HTTP/2 trailers after local stream closure

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -517,11 +517,11 @@ pub const Connection = struct {
         var refused = false;
         var ignored = false;
         if (existing) |s| {
-            // A second HEADERS block is a trailer ONLY while the stream is still
-            // open (body not yet ended). A HEADERS after the peer's END_STREAM
-            // (half-closed-remote) or on a closed stream is a protocol error.
+            // A second HEADERS block is a trailer while the peer can still send.
+            // A HEADERS after the peer's END_STREAM or on a closed stream is a
+            // protocol error.
             const client_reading = self.role == .client and (s.state == .open or s.state == .half_closed_local);
-            if (s.headers_done and s.state == .open) {
+            if (s.headers_done and (s.state == .open or s.state == .half_closed_local)) {
                 is_trailer = true;
             } else if (client_reading and !s.headers_done) {
                 // A client reading a response head: the stream is open, or

--- a/tests/test_http2.py
+++ b/tests/test_http2.py
@@ -674,6 +674,37 @@ def _request_block(*extra: tuple[bytes, bytes], method: bytes = b"GET") -> bytes
     return block
 
 
+def test_server_accepts_request_trailers_after_finishing_its_response() -> None:
+    conn = server_with(frame(0x01, END_HEADERS, 1, _request_block(method=b"POST")))
+    next(event for event in drain_h2(conn) if isinstance(event, zttp.Request))
+    stream = conn.stream(1)
+    stream.send_response(400)
+    stream.end_message()
+    conn.receive_data(frame(0x01, END_HEADERS | END_STREAM, 1, _lit(b"x-checksum", b"abc")))
+
+    events = list(drain_h2(conn))
+
+    end = next(event for event in events if isinstance(event, zttp.EndOfMessage))
+    assert end.trailers == [(b"x-checksum", b"abc")]
+
+
+def test_client_accepts_response_trailers_after_finishing_its_request() -> None:
+    conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP2)
+    conn.send_request(b"POST", b"/", b"2", [(b"host", b"example.com")]).end_message()
+    conn.data_to_send()
+    conn.receive_data(
+        frame(0x04, 0, 0, b"")
+        + frame(0x01, END_HEADERS, 1, STATUS_200)
+        + frame(0x00, 0, 1, b"body")
+        + frame(0x01, END_HEADERS | END_STREAM, 1, _lit(b"grpc-status", b"0"))
+    )
+
+    events = list(drain_h2(conn))
+
+    end = next(event for event in events if isinstance(event, zttp.EndOfMessage))
+    assert end.trailers == [(b"grpc-status", b"0")]
+
+
 def test_h2_bodyless_request_with_content_length_is_reset() -> None:
     # A request declaring content-length but sending no DATA is an h2->h1 smuggling
     # vector (the downgraded h1 request advertises a body that never arrives). It


### PR DESCRIPTION
## Summary

- Accept trailer `HEADERS` while a stream is half-closed locally.
- Support response trailers after a client finishes its request.
- Support request trailers after a server finishes an early response.

The peer may continue sending on a half-closed-local stream under RFC 9113 Section 5.1.

## Tests

- `zig build test`
- `uv run pytest tests/test_http2.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
