### PR TITLE
Reject HTTP/1 cycle resets before message completion

### DIFF
--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -218,10 +218,9 @@ pub const Reader = struct {
     }
 
     /// Prepare to read the next message on the same connection (keep-alive).
-    /// A poisoned (`.failed`) connection stays poisoned: a parse error is
-    /// terminal, so reset cannot revive a desynchronized byte stream.
-    pub fn reset(self: *Reader) void {
-        if (self.state == .failed) return;
+    /// The current message must have surfaced its completion event.
+    pub fn reset(self: *Reader) error{MessageInProgress}!void {
+        if (self.state != .done) return error.MessageInProgress;
         self.state = .head;
         self.head_scanner.reset();
         self.headers.clearRetainingCapacity();
@@ -683,7 +682,7 @@ test "keep-alive: two requests via reset" {
     var e = try r.nextEvent();
     try t.expectEqualStrings("/a", e.request.target);
     try t.expect(e.request.end_stream);
-    r.reset();
+    try r.reset();
     e = try r.nextEvent();
     try t.expectEqualStrings("/b", e.request.target);
 }
@@ -694,7 +693,7 @@ test "reset cannot un-poison a failed connection" {
     // A malformed request followed by a smuggled one; the error must be terminal.
     try r.feed("GET / HTTP/1.1\nX: 1\n\nGET /smuggled HTTP/1.1\r\nHost: y\r\n\r\n");
     try t.expectError(error.InvalidLine, r.nextEvent());
-    r.reset(); // an attacker-influenced caller trying to recover
+    try t.expectError(error.MessageInProgress, r.reset());
     // Still poisoned: it must NOT parse /smuggled as a fresh request.
     try t.expectError(error.InvalidLine, r.nextEvent());
 }
@@ -955,7 +954,7 @@ test "feed rejects input past max_buffer" {
     try t.expectError(error.MessageTooLong, r.feed(big));
     try t.expectError(error.MessageTooLong, r.feed("GET / HTTP/1.1\r\n\r\n"));
     try t.expectError(error.MessageTooLong, r.nextEvent());
-    r.reset();
+    try t.expectError(error.MessageInProgress, r.reset());
     try t.expectError(error.MessageTooLong, r.nextEvent());
 }
 
@@ -1029,7 +1028,7 @@ fn driveReader(input: []const u8) void {
                 switch (ev) {
                     .need_data, .connection_closed => break,
                     .end_of_message => {
-                        r.reset();
+                        r.reset() catch break;
                         break;
                     },
                     else => {},

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2991,7 +2991,10 @@ fn next_message(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object 
     // Convenience for keep-alive: reset the reader for the next request/response.
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const e = h1(self) orelse return null;
-    e.reader.reset();
+    e.reader.reset() catch return py.raise(
+        exceptions.LocalProtocolError,
+        "cannot start the next cycle before the current message is complete",
+    );
     e.message.startNextCycle();
     return py.none();
 }

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -310,6 +310,22 @@ def test_body_buffer_with_pipelined_bytes_keeps_copy_path() -> None:
     assert next_request.target == b"/next"
 
 
+def test_start_next_cycle_rejects_a_stashed_body() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    prefix = b"GET /smuggled HTTP/1.1\r\nHost: example.com\r\n\r\n"
+    body = prefix + b"x" * (2048 - len(prefix))
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2048\r\n\r\n" + body)
+    assert isinstance(conn.next_event(), zttp.Request)
+
+    with pytest.raises(zttp.LocalProtocolError, match="before the current message is complete"):
+        conn.start_next_cycle()
+
+    event = conn.next_event()
+    assert isinstance(event, zttp.Data)
+    assert event.data == body
+    assert isinstance(conn.next_event(), zttp.EndOfMessage)
+
+
 def test_keep_alive_two_requests() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(b"GET /a HTTP/1.1\r\nHost: x\r\n\r\nGET /b HTTP/1.1\r\nHost: y\r\n\r\n")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -150,7 +150,8 @@ def test_start_next_cycle_cannot_unpoison_after_error() -> None:
     conn.receive_data(b"GET / HTTP/1.1\nX: 1\n\nGET /smuggled HTTP/1.1\r\nHost: y\r\n\r\n")
     with pytest.raises(zttp.RemoteProtocolError):
         drain_all(conn)
-    conn.start_next_cycle()
+    with pytest.raises(zttp.LocalProtocolError, match="before the current message is complete"):
+        conn.start_next_cycle()
     with pytest.raises(zttp.RemoteProtocolError):
         conn.next_event()
 


### PR DESCRIPTION
## Summary

- Allow the HTTP/1 reader to reset only after the current message completes.
- Raise `LocalProtocolError` when `start_next_cycle()` would abandon peer body framing.
- Preserve stashed body bytes after a rejected reset and deliver them as body data.

## Tests

- `zig build test`
- `uv run pytest tests/test_read.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
