### PR TITLE
Latch HTTP/2 auto-response allocation failures

### DIFF
--- a/src/core/h2/connection.zig
+++ b/src/core/h2/connection.zig
@@ -212,6 +212,14 @@ pub const Connection = struct {
         return e;
     }
 
+    /// Poison the connection after an adapter resource failure consumed an event.
+    pub fn poisonResourceFailure(self: *Connection) void {
+        if (self.phase == .failed) return;
+        self.phase = .failed;
+        self.failed_with = error.MessageTooLong;
+        self.goaway_owed = .enhance_your_calm;
+    }
+
     /// Produce the next event, or `.need_data`. A connection error poisons the
     /// engine: it is latched and re-raised on every later call (as H1 does). The
     /// first failure records the GOAWAY code in goaway_owed (RFC 9113 5.4.1); the
@@ -1468,6 +1476,17 @@ test "a fatal feed (max_buffer breach) poisons the connection and owes a GOAWAY"
     // A later feed re-raises the latched error without re-arming a GOAWAY.
     try testing.expectError(error.MessageTooLong, c.feed("more"));
     try testing.expectEqual(@as(?ErrorCode, null), c.takeGoAwayOwed());
+}
+
+test "an adapter resource failure poisons the connection" {
+    var c = Connection.init(testing.allocator, .server);
+    defer c.deinit();
+
+    c.poisonResourceFailure();
+
+    try testing.expectError(error.MessageTooLong, c.nextEvent());
+    try testing.expectError(error.MessageTooLong, c.nextEvent());
+    try testing.expectEqual(@as(?ErrorCode, .enhance_your_calm), c.takeGoAwayOwed());
 }
 
 test "localSettingsParams advertises the enforced limits" {

--- a/src/core/h2/frame.zig
+++ b/src/core/h2/frame.zig
@@ -153,6 +153,7 @@ pub fn writeHeader(out: *std.ArrayList(u8), gpa: std.mem.Allocator, header: Fram
 /// layer is expected to split payloads to the peer's max frame size first.
 pub fn write(out: *std.ArrayList(u8), gpa: std.mem.Allocator, ftype: FrameType, flags: u8, stream_id: u32, payload: []const u8) !void {
     if (payload.len > std.math.maxInt(u24)) return error.TooLarge;
+    try out.ensureUnusedCapacity(gpa, 9 + payload.len);
     try writeHeader(out, gpa, .{
         .length = @intCast(payload.len),
         .ftype = @intFromEnum(ftype),
@@ -291,6 +292,20 @@ test "checkLength passes variable-length frames" {
     try checkLength(.{ .length = 12345, .ftype = 0x00, .flags = 0, .stream_id = 1 }); // DATA
     try checkLength(.{ .length = 999, .ftype = 0x01, .flags = 0, .stream_id = 1 }); // HEADERS
     try checkLength(.{ .length = 50000, .ftype = 0xFE, .flags = 0, .stream_id = 1 }); // unknown
+}
+
+fn writeFrameUnderAllocationFailure(gpa: std.mem.Allocator) !void {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    write(&out, gpa, .data, 0, 1, &[_]u8{0xAA} ** 1024) catch |err| {
+        try testing.expectEqual(@as(usize, 0), out.items.len);
+        return err;
+    };
+    try testing.expectEqual(@as(usize, 9 + 1024), out.items.len);
+}
+
+test "frame writes are atomic on allocation failure" {
+    try testing.checkAllAllocationFailures(testing.allocator, writeFrameUnderAllocationFailure, .{});
 }
 
 test "write then parse round-trips" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2456,7 +2456,14 @@ fn nextEventImpl(self_obj: ?*c.PyObject, eager_headers: bool) py.Object {
                 e.emitGoAwayIfOwed(); // queue one GOAWAY for the next data_to_send
                 return exceptions.raiseH2(err);
             };
-            e.autoRespond(ev) catch |err| return h2RaiseWrite(err);
+            const handshake_sent = e.handshake_sent;
+            e.autoRespond(ev) catch |err| {
+                e.writer.clear();
+                e.handshake_sent = handshake_sent;
+                e.conn.poisonResourceFailure();
+                e.emitGoAwayIfOwed();
+                return h2RaiseWrite(err);
+            };
             return events_obj.fromH2Event(ev);
         },
         .h1 => |*e| {


### PR DESCRIPTION
## Summary

- Poison the HTTP/2 connection if automatic response serialization fails after an event is consumed.
- Clear partial output and emit a best-effort `GOAWAY` instead of exposing later events after a gap.
- Reserve complete HTTP/2 frame capacity before writing either its header or payload.

## Tests

- `zig build test`
- Allocation-failure coverage verifies frame writes remain atomic.
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
