### PR TITLE
Reject ambiguous Content-Length duplicates

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -70,8 +70,8 @@ recursion, owned-copy event payloads) apply across all three.
 
 - **Content-Length + Transfer-Encoding together** → rejected outright
   (`framing.zig`), rather than the weaker "Transfer-Encoding wins, strip CL".
-- **Conflicting duplicate Content-Length** → rejected; identical duplicates are
-  accepted (RFC-permitted, unambiguous).
+- **Conflicting duplicate Content-Length** → field values must match byte-for-byte.
+  The parser accepts identical duplicates, but the writer never emits duplicates.
 - **Transfer-Encoding folding** → all `Transfer-Encoding` field-lines are combined
   into one ordered list; `chunked` must appear exactly once and be the final
   coding. `chunked, gzip`, `chunked` twice, or split across lines → rejected.

--- a/src/core/h1/framing.zig
+++ b/src/core/h1/framing.zig
@@ -95,6 +95,7 @@ pub const Analyzer = struct {
     transfer_encoding: TransferEncoding = .{},
     has_transfer_encoding: bool = false,
     content_length: ?u64 = null,
+    content_length_value: ?[]const u8 = null,
 
     pub fn add(self: *Analyzer, h: Header) ParseError!void {
         if (eqIgnoreCase(h.name, "transfer-encoding")) {
@@ -102,10 +103,11 @@ pub const Analyzer = struct {
             self.transfer_encoding.add(h.value);
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const n = try parseContentLength(h.value);
-            if (self.content_length) |prev| {
-                if (prev != n) return error.InvalidFraming;
+            if (self.content_length_value) |previous| {
+                if (!std.mem.eql(u8, previous, h.value)) return error.InvalidFraming;
             }
             self.content_length = n;
+            self.content_length_value = h.value;
         }
     }
 
@@ -204,6 +206,14 @@ test "conflicting duplicate content-length rejected" {
     const h = [_]Header{
         .{ .name = "Content-Length", .value = "10" },
         .{ .name = "Content-Length", .value = "20" },
+    };
+    try std.testing.expectError(error.InvalidFraming, determine(&h, .{}));
+}
+
+test "numerically equal content-length values must match textually" {
+    const h = [_]Header{
+        .{ .name = "Content-Length", .value = "010" },
+        .{ .name = "Content-Length", .value = "10" },
     };
     try std.testing.expectError(error.InvalidFraming, determine(&h, .{}));
 }

--- a/src/core/h1/writer.zig
+++ b/src/core/h1/writer.zig
@@ -187,7 +187,7 @@ fn hasHeader(hdrs: []const Header, name: []const u8) bool {
 /// Refuse to serialize ambiguous framing - the send-side mirror of the reader's
 /// smuggling guards. A message carrying both Transfer-Encoding and
 /// Content-Length, multiple Transfer-Encoding fields, unsupported TE codings, or
-/// conflicting duplicate Content-Lengths would let a downstream parser disagree
+/// duplicate Content-Lengths would let a downstream parser disagree
 /// about message boundaries (response splitting).
 fn validateFraming(hdrs: []const Header) WriteError!void {
     var has_te = false;
@@ -202,9 +202,7 @@ fn validateFraming(hdrs: []const Header) WriteError!void {
         } else if (eqIgnoreCase(h.name, "content-length")) {
             const v = trimOws(h.value);
             if (ascii.parseDecimal(u64, v) == null) return error.InvalidField; // non-empty digits, no overflow
-            if (content_length) |prev| {
-                if (!eqIgnoreCase(prev, v)) return error.InvalidField; // conflicting duplicate
-            }
+            if (content_length != null) return error.InvalidField;
             content_length = v;
         }
     }
@@ -770,6 +768,16 @@ test "send rejects conflicting duplicate Content-Length" {
     const h = [_]Header{
         .{ .name = "Content-Length", .value = "5" },
         .{ .name = "Content-Length", .value = "6" },
+    };
+    try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
+}
+
+test "send rejects identical duplicate Content-Length" {
+    var wr = Writer.init(t.allocator);
+    defer wr.deinit();
+    const h = [_]Header{
+        .{ .name = "Content-Length", .value = "5" },
+        .{ .name = "Content-Length", .value = "5" },
     };
     try t.expectError(error.InvalidField, wr.sendResponse("1.1", 200, "OK", &h, "GET"));
 }

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -160,6 +160,7 @@ def test_start_next_cycle_cannot_unpoison_after_error() -> None:
     [
         [(b"Transfer-Encoding", b"chunked"), (b"Content-Length", b"5")],  # TE + CL
         [(b"Content-Length", b"5"), (b"Content-Length", b"6")],  # conflicting dup CL
+        [(b"Content-Length", b"5"), (b"Content-Length", b"5")],  # senders emit one CL at most
         [(b"Content-Length", b"5x")],  # non-digit CL
     ],
 )
@@ -167,6 +168,16 @@ def test_send_rejects_ambiguous_framing(headers: list[tuple[bytes, bytes]]) -> N
     conn = zttp.Connection(zttp.SERVER)
     with pytest.raises(zttp.LocalProtocolError):
         conn.send_response(200, headers)
+
+
+def test_numerically_equal_content_lengths_must_match_textually() -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 010\r\nContent-Length: 10\r\n\r\n")
+
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
 
 
 @pytest.mark.parametrize("version", [b"GET / HTTP/2.0\r\n\r\n", b"GET / HTTP/0.9\r\n\r\n"])


### PR DESCRIPTION
## Summary

- Require duplicate received `Content-Length` field values to match byte-for-byte.
- Reject every duplicate `Content-Length` on the send path so the writer emits at most one.
- Keep identical read-side duplicates compatible while preventing leading-zero differentials from crossing a proxy boundary.

## Tests

- `zig build test`
- `uv run pytest tests/test_security.py`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP/1.1 handling of duplicate `Content-Length` headers.
  * Conflicting or textually inconsistent duplicate lengths are now rejected when received.
  * Outbound messages no longer emit duplicate `Content-Length` headers.

* **Tests**
  * Added coverage for matching, conflicting, and differently formatted duplicate length values to ensure consistent request and response framing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->