### PR TITLE
Stabilize the HTTP/3 server ticket store

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -50,7 +50,13 @@ const DEFAULT_CLIENT_TRANSPORT_PARAMS = [_]u8{
     0x09, 0x01, 0x10, // initial_max_streams_uni = 16
 };
 
-var server_ticket_store: std.ArrayListUnmanaged(ResumptionCredential) = .empty;
+// Fixed backing keeps per-handshake slices valid while tickets rotate.
+var server_ticket_store: [MAX_SERVER_TICKET_STORE]ResumptionCredential = undefined;
+var server_ticket_store_len: usize = 0;
+
+fn serverTickets() []ResumptionCredential {
+    return server_ticket_store[0..server_ticket_store_len];
+}
 
 /// A Python-owned receive span retained outside the pure-Zig reader. Keeping
 /// the owner and slice behind one adapter state centralises every reference
@@ -413,7 +419,7 @@ fn randomSigner() ?Signer {
 
 fn rememberServerTicket(identity: []const u8, psk: [32]u8, lifetime: u32, age_add: u32, issued_at_ms: u64, max_early_data_size: ?u32) !void {
     if (lifetime == 0) return;
-    for (server_ticket_store.items) |*entry| {
+    for (serverTickets()) |*entry| {
         if (std.mem.eql(u8, entry.identity, identity)) {
             entry.psk = psk;
             entry.ticket_lifetime = lifetime;
@@ -426,18 +432,25 @@ fn rememberServerTicket(identity: []const u8, psk: [32]u8, lifetime: u32, age_ad
     }
     const owned_identity = try gpa.dupe(u8, identity);
     errdefer gpa.free(owned_identity);
-    if (server_ticket_store.items.len == MAX_SERVER_TICKET_STORE) {
-        const oldest = server_ticket_store.orderedRemove(0);
+    if (server_ticket_store_len == MAX_SERVER_TICKET_STORE) {
+        const oldest = server_ticket_store[0];
+        std.mem.copyForwards(
+            ResumptionCredential,
+            server_ticket_store[0 .. MAX_SERVER_TICKET_STORE - 1],
+            server_ticket_store[1..MAX_SERVER_TICKET_STORE],
+        );
+        server_ticket_store_len -= 1;
         gpa.free(oldest.identity);
     }
-    try server_ticket_store.append(gpa, .{
+    server_ticket_store[server_ticket_store_len] = .{
         .identity = owned_identity,
         .psk = psk,
         .ticket_lifetime = lifetime,
         .ticket_age_add = age_add,
         .issued_at_ms = issued_at_ms,
         .max_early_data_size = max_early_data_size,
-    });
+    };
+    server_ticket_store_len += 1;
 }
 
 /// The HTTP/1.1 engine: the pull-API reader, the writer, and the per-connection
@@ -759,7 +772,7 @@ const ServerConfig = struct {
             .alpn = self.alpn,
             .transport_params = self.transport_params,
             .resumption = if (self.resumption_identity) |identity| .{ .identity = identity, .psk = self.resumption_psk.? } else null,
-            .resumption_store = server_ticket_store.items,
+            .resumption_store = serverTickets(),
             .now_ms = now / std.time.us_per_ms,
         };
     }

--- a/src/python/module.zig
+++ b/src/python/module.zig
@@ -37,8 +37,7 @@ fn PyInit__zttp() callconv(.c) ?*c.PyObject {
     }
     // Deliberately NOT declaring Py_MOD_GIL_NOT_USED: the module-global
     // server_ticket_store (connection_obj.zig) is mutated and read across
-    // connections with no synchronization, so a free-threaded build would race it
-    // (a use-after-free even under the intended one-connection-per-thread usage).
+    // connections with no synchronization, so a free-threaded build would race it.
     // Without the declaration CPython re-enables the compatibility GIL on
     // free-threaded builds, which serializes these accesses and keeps the cp314t/
     // cp315t wheels correct. Re-enable once the extension is synchronized (#151).

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -532,6 +532,45 @@ def test_http3_received_session_ticket_psk_resumes_later_connection() -> None:
     assert req.path == b"/ticket-resumed"
 
 
+def test_http3_server_ticket_store_remains_valid_after_eviction() -> None:
+    first_client = make_client()
+    first_server = make_server()
+
+    assert transfer(first_client, first_server, 1000)
+    assert transfer(first_server, first_client, 2000)
+    assert transfer(first_client, first_server, 3000)
+    assert transfer(first_server, first_client, 4000)
+
+    identity = b""
+    psk = b""
+    age_add = 0x01020304
+    for index in range(65):
+        identity = f"store-rotation-{index}".encode()
+        issued = first_server.send_session_ticket(identity, 7200, age_add, bytes([index]), b"", 4096)
+        assert isinstance(issued, bytes)
+        psk = issued
+
+    client_config: ResumedClientConfig = CLIENT_CONFIG.copy()
+    client_config.update(
+        {
+            "connection_id": b"\x11\x22\x33\x57",
+            "resumption": zttp.SessionResumption(identity=identity, psk=psk),
+            "obfuscated_ticket_age": obfuscated_ticket_age(age_add, 3000, 6000),
+            "early_data": True,
+            "remembered_transport_params": SERVER_TRANSPORT_PARAMS,
+        }
+    )
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **client_config)
+    server = make_server()
+    client.send_request(b"GET", b"/after-rotation", b"3", [(b"host", b"example.test")])
+
+    for datagram in client.data_to_send():
+        server.receive_datagram(datagram, 6000)
+
+    events = drain_events(server)
+    assert any(isinstance(event, zttp.Request) and event.path == b"/after-rotation" for event in events)
+
+
 def test_http3_ticket_age_mismatch_does_not_accept_zero_rtt() -> None:
     first_client = make_client()
     first_server = make_server()


### PR DESCRIPTION
## Summary

- Store server resumption credentials in fixed backing memory.
- Rotate the bounded 64-ticket window without invalidating slices retained by in-progress handshakes.
- Keep 0-RTT replay accounting attached to the authoritative live credential entry.

## Tests

- `uv run pytest tests/test_http3.py`
- `zig build test`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
