### PR TITLE
Reject peer data on unopened local QUIC streams

### DIFF
--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -2212,6 +2212,7 @@ test "a request stream ending before HEADERS is request incomplete" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
@@ -2471,6 +2472,7 @@ test "a peer STOP_SENDING resets our send half" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
@@ -2569,6 +2571,7 @@ test "client decodes an HTTP/3 response over a request stream" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -2615,6 +2618,7 @@ test "a response stream ending with a truncated frame is a connection error" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -2684,6 +2688,7 @@ test "client rejects trailers on bodyless responses" {
         var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
         defer qc.deinit();
         quic_conn.testInstallAppKeys(&qc);
+        try qc.sendStreamData(0, &.{}, false);
         var h3 = Connection.init(gpa, &qc);
         defer h3.deinit();
 
@@ -2721,6 +2726,7 @@ test "client rejects trailers on bodyless responses" {
         var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
         defer qc.deinit();
         quic_conn.testInstallAppKeys(&qc);
+        try qc.sendStreamData(0, &.{}, false);
         var h3 = Connection.init(gpa, &qc);
         defer h3.deinit();
 
@@ -2757,6 +2763,7 @@ test "client rejects Content-Length on responses that cannot carry it" {
         var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
         defer qc.deinit();
         quic_conn.testInstallAppKeys(&qc);
+        try qc.sendStreamData(0, &.{}, false);
         var h3 = Connection.init(gpa, &qc);
         defer h3.deinit();
 
@@ -2873,6 +2880,7 @@ test "client decodes informational then final HTTP/3 response" {
     var client_qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer client_qc.deinit();
     quic_conn.testInstallAppKeys(&client_qc);
+    try client_qc.sendStreamData(0, &.{}, false);
     var client_h3 = Connection.init(gpa, &client_qc);
     defer client_h3.deinit();
 
@@ -2901,6 +2909,7 @@ test "client rejects 101 Switching Protocols in HTTP/3 response" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -2928,6 +2937,7 @@ test "client rejects a malformed PUSH_PROMISE as a frame error" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -2961,6 +2971,7 @@ test "client rejects PUSH_PROMISE when push is disabled" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -3005,6 +3016,7 @@ test "HTTP/3 response trailers flow into EndOfMessage" {
     var client_qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer client_qc.deinit();
     quic_conn.testInstallAppKeys(&client_qc);
+    try client_qc.sendStreamData(0, &.{}, false);
     var client_h3 = Connection.init(gpa, &client_qc);
     defer client_h3.deinit();
 
@@ -3045,6 +3057,7 @@ test "server dynamically encodes a response header when peer QPACK settings allo
     var client_qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer client_qc.deinit();
     quic_conn.testInstallAppKeys(&client_qc);
+    try client_qc.sendStreamData(0, &.{}, false);
     var client_h3 = Connection.init(gpa, &client_qc);
     defer client_h3.deinit();
 
@@ -3274,6 +3287,7 @@ test "client rejects request pseudo-headers in an HTTP/3 response" {
     var qc = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc);
+    try qc.sendStreamData(0, &.{}, false);
     var h3 = Connection.init(gpa, &qc);
     defer h3.deinit();
 
@@ -3436,6 +3450,7 @@ test "a server sends a response: HEADERS then DATA then FIN" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
@@ -3472,6 +3487,7 @@ test "the server resets a request stream" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
@@ -3539,6 +3555,7 @@ test "the server opens its control stream with a SETTINGS frame" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;
@@ -4670,6 +4687,7 @@ test "a rejected dynamic request sends QPACK stream cancellation" {
     var peer = try quic_conn.Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     quic_conn.testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     quic_conn.testSetAppNextPn(&peer, 1);
     const buf = qc.datagramsToSend();
     var off: usize = 0;

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1129,6 +1129,12 @@ pub const Connection = struct {
         return !st.isUni() or !self.isPeerInitiated(id);
     }
 
+    fn localStreamWasOpened(self: *const Connection, id: u64) bool {
+        if (self.isPeerInitiated(id)) return false;
+        const limit = if (stream.StreamType.of(id).isUni()) self.local_uni_streams else self.local_bidi_streams;
+        return id >> 2 < limit.opened;
+    }
+
     fn checkPeerStreamLimit(self: *Connection, id: u64) Error!void {
         if (!self.isPeerInitiated(id)) return;
         const st = stream.StreamType.of(id);
@@ -2831,6 +2837,7 @@ pub const Connection = struct {
     fn onStreamFrame(self: *Connection, id: u64, offset: u64, data: []const u8, fin: bool) Error!void {
         if (self.isRetired(id)) return; // a late frame for a completed-and-dropped stream
         if (!self.peerCanSendOn(id)) return error.StreamStateError;
+        if (!self.isPeerInitiated(id) and !self.localStreamWasOpened(id)) return error.StreamStateError;
         const existing = self.streams.get(id);
         const end = std.math.add(u64, offset, data.len) catch return error.FlowControlError;
         const old_high = if (existing) |s| s.highest_received else 0;
@@ -2859,6 +2866,7 @@ pub const Connection = struct {
     fn onReset(self: *Connection, id: u64, error_code: u64, final_size: u64) Error!void {
         if (self.isRetired(id)) return; // a reset for an already-completed-and-dropped stream
         if (!self.peerCanSendOn(id)) return error.StreamStateError;
+        if (!self.isPeerInitiated(id) and !self.localStreamWasOpened(id)) return error.StreamStateError;
         const s = try self.recvStream(id);
         const new_high = @max(s.highest_received, final_size);
         const delta = new_high - s.highest_received;
@@ -3259,6 +3267,36 @@ test "server decrypts a 1-RTT packet and reassembles a stream" {
     try conn.receiveDatagram(dgram, 1000);
     try testing.expectEqualStrings("hi", conn.streamData(0));
     try testing.expect(conn.streamFinished(0));
+}
+
+test "peer cannot use an unopened locally initiated stream" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x09 };
+
+    {
+        var client = try Connection.init(gpa, .client, &dcid);
+        defer client.deinit();
+        testInstallAppKeys(&client);
+        const datagram = try testBuildApp(gpa, &dcid, 0, &.{ 0x0A, 0x00, 0x01, 'x' });
+        defer gpa.free(datagram);
+
+        try testing.expectError(error.StreamStateError, client.receiveDatagram(datagram, 1000));
+        try testing.expectEqual(@as(u32, 0), client.streams.count());
+    }
+
+    {
+        var client = try Connection.init(gpa, .client, &dcid);
+        defer client.deinit();
+        testInstallAppKeys(&client);
+        var frames: std.ArrayListUnmanaged(u8) = .empty;
+        defer frames.deinit(gpa);
+        try frame.encodeResetStream(&frames, gpa, 0, 0, 0);
+        const datagram = try testBuildApp(gpa, &dcid, 0, frames.items);
+        defer gpa.free(datagram);
+
+        try testing.expectError(error.StreamStateError, client.receiveDatagram(datagram, 1000));
+        try testing.expectEqual(@as(u32, 0), client.streams.count());
+    }
 }
 
 test "client sends queued STREAM data in a 0-RTT long-header packet" {
@@ -5055,6 +5093,7 @@ test "consuming stream data advertises raised MAX_DATA and MAX_STREAM_DATA" {
     var conn = try Connection.init(gpa, .server, &dcid);
     defer conn.deinit();
     testInstallAppKeys(&conn);
+    try conn.sendStreamData(1, &.{}, false);
     conn.conn_recv_window.limit = 100; // a small window so consuming half trips the update
     conn.conn_recv_window.initial = 100;
     conn.local_tp.initial_max_stream_data_bidi_local = 100; // stream 1 is server-bidi
@@ -5822,6 +5861,7 @@ test "a STOP_SENDING before the send stream exists still resets it" {
     var peer = try Connection.init(gpa, .client, &dcid);
     defer peer.deinit();
     testInstallAppKeys(&peer);
+    try peer.sendStreamData(0, &.{}, false);
     try deliverAllExcept(&server, &peer, null, 3000);
     try testing.expect(peer.streamReset(0));
     try testing.expectEqualStrings("", peer.streamData(0)); // no data, just the reset


### PR DESCRIPTION
## Summary

- Track whether each locally initiated stream index was opened.
- Reject peer `STREAM` and `RESET_STREAM` frames for future local stream IDs with `STREAM_STATE_ERROR`.
- Prevent HTTP/3 clients from receiving fabricated responses for requests they have not opened.
- Correct protocol tests to open request streams before delivering responses or resets.

## Tests

- `zig build test`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
