### PR TITLE
Verify pinned HTTP/3 server certificates

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -254,9 +254,10 @@ materialized.
 
 The QUIC transport (RFC 9000/9001/9002) - handshake, packet protection,
 amplification limits, loss recovery, and flow control - is in scope and held to
-the strict-reject bar, but its threat surface is broad and has had far less
-adversarial exposure than the H1/H2 paths. Treat HTTP/3 as experimental from a
-security standpoint.
+the strict-reject bar. HTTP/3 clients pin the exact server certificate or raw
+P-256 public key before accepting its TLS flight. The transport's threat surface
+is broad and has had far less adversarial exposure than the H1/H2 paths. Treat
+HTTP/3 as experimental from a security standpoint.
 
 ## Integrator responsibilities
 

--- a/benchmarks/http3.py
+++ b/benchmarks/http3.py
@@ -101,7 +101,7 @@ Runner = Callable[[int], None]
 _TMP = tempfile.TemporaryDirectory()
 
 
-def _make_cert() -> tuple[str, str]:
+def _make_cert() -> tuple[str, str, bytes, bytes]:
     key = ec.generate_private_key(ec.SECP256R1())
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, AUTHORITY.decode())])
     now = dt.datetime.now(dt.timezone.utc)
@@ -126,15 +126,26 @@ def _make_cert() -> tuple[str, str]:
             serialization.NoEncryption(),
         )
     )
-    return str(cert_path), str(key_path)
+    private_scalar = key.private_numbers().private_value.to_bytes(32, "big")
+    return str(cert_path), str(key_path), cert.public_bytes(serialization.Encoding.DER), private_scalar
 
 
 # -- zttp ---------------------------------------------------------------------
 
 
 def make_zttp(w: Workload) -> Runner:
-    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, server_name=AUTHORITY)
-    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+    _cert_path, _key_path, certificate, private_key = _make_cert()
+    client = zttp.Connection(
+        zttp.CLIENT,
+        protocol=zttp.HTTP3,
+        server_name=AUTHORITY,
+        server_certificate=certificate,
+    )
+    server = zttp.Connection(
+        zttp.SERVER,
+        protocol=zttp.HTTP3,
+        credentials=zttp.TlsCredentials(certificate=certificate, private_key_scalar=private_key),
+    )
     now = [1000]
 
     def transfer(src: zttp.H3Connection, dst: zttp.H3Connection) -> None:
@@ -178,7 +189,7 @@ def make_zttp(w: Workload) -> Runner:
 
 
 def make_aioquic(w: Workload) -> Runner:
-    cert_path, key_path = _make_cert()
+    cert_path, key_path, _certificate, _private_key = _make_cert()
     server_config = QuicConfiguration(is_client=False, alpn_protocols=["h3"])
     server_config.load_cert_chain(cert_path, key_path)
     client_config = QuicConfiguration(is_client=True, alpn_protocols=["h3"])

--- a/docs/usage/http3.md
+++ b/docs/usage/http3.md
@@ -16,6 +16,7 @@ client = zttp.Connection(
     zttp.CLIENT,
     protocol=zttp.HTTP3,
     server_name=b"example.com",
+    server_certificate=certificate_der,
 )
 ```
 
@@ -38,12 +39,15 @@ server = zttp.Connection(
 client = zttp.Connection(
     zttp.CLIENT, zttp.HTTP3,
     server_name=b"example.com",
+    server_certificate=certificate_der,
     resumption=zttp.SessionResumption(identity=ticket_id, psk=ticket_psk),
 )
 ```
 
 Omit `credentials` and the server uses an ephemeral local identity (development
-only).
+only). A client pins the exact certificate or raw P-256 public key with
+`server_certificate`. The handshake fails if the peer presents anything else or
+if you omit the pin.
 
 !!! warning "Scope"
     HTTP/3 support is still experimental. The public surface is intentionally
@@ -243,8 +247,19 @@ def transfer(src, dst, now):
         dst.receive_datagram(datagram, now)
 
 
-client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"example.test")
-server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+certificate = bytes.fromhex(
+    "04"
+    "2ca00e33928e5b66cc63a70e91c78f5d9e0db34711f9108778151912d389c5"
+    "89c6c886572fd6dad9d01e0b98c5fec3276e9a2e4b89705140f564f7eb65016b95"
+)
+credentials = zttp.TlsCredentials(certificate=certificate, private_key=b"\x42" * 32)
+client = zttp.Connection(
+    zttp.CLIENT,
+    protocol=zttp.HTTP3,
+    server_name=b"example.test",
+    server_certificate=certificate,
+)
+server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3, credentials=credentials)
 
 transfer(client, server, 1000)  # ClientHello
 transfer(server, client, 2000)  # ServerHello and the rest of the server's flight

--- a/scripts/interop_aioquic.py
+++ b/scripts/interop_aioquic.py
@@ -136,6 +136,9 @@ def obfuscated_ticket_age(age_add: int, issued_at: int, now: int) -> int:
 
 def assert_zttp_client_to_aioquic_server(tmp: Path) -> None:
     cert_path, key_path = make_cert_chain(tmp)
+    server_certificate = x509.load_pem_x509_certificate(cert_path.read_bytes()).public_bytes(
+        serialization.Encoding.DER
+    )
     server_config = QuicConfiguration(is_client=False, alpn_protocols=["h3"])
     server_config.load_cert_chain(str(cert_path), str(key_path))
     issued_tickets: list[object] = []
@@ -150,6 +153,7 @@ def assert_zttp_client_to_aioquic_server(tmp: Path) -> None:
         connection_id=dcid,
         alpn=b"h3",
         server_name=b"localhost",
+        server_certificate=server_certificate,
     )
 
     client_initial = client.data_to_send()[0]
@@ -193,6 +197,7 @@ def assert_zttp_client_to_aioquic_server(tmp: Path) -> None:
         connection_id=b"\x11\x22\x33\x45",
         alpn=b"h3",
         server_name=b"localhost",
+        server_certificate=server_certificate,
         resumption=zttp.SessionResumption(identity=ticket.ticket, psk=ticket.psk),
         obfuscated_ticket_age=obfuscated_ticket_age(ticket.age_add, 3_000, 10_000),
         early_data=True,
@@ -680,6 +685,9 @@ def assert_aioquic_client_to_zttp_server() -> None:
 
 def assert_udp_loopback_zttp_client_to_aioquic_server(tmp: Path, drop_first_server_datagram: bool = False) -> None:
     cert_path, key_path = make_cert_chain(tmp)
+    server_certificate = x509.load_pem_x509_certificate(cert_path.read_bytes()).public_bytes(
+        serialization.Encoding.DER
+    )
     server_config = QuicConfiguration(is_client=False, alpn_protocols=["h3"])
     server_config.load_cert_chain(str(cert_path), str(key_path))
 
@@ -692,6 +700,7 @@ def assert_udp_loopback_zttp_client_to_aioquic_server(tmp: Path, drop_first_serv
         connection_id=b"\x11\x22\x33\x46",
         alpn=b"h3",
         server_name=b"localhost",
+        server_certificate=server_certificate,
     )
 
     server_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -5239,12 +5239,15 @@ test "a client Initial carries a ClientHello the server can answer" {
         0x08, 0x01, 0x10, // initial_max_streams_bidi = 16
         0x09, 0x01, 0x10, // initial_max_streams_uni = 16
     };
+    const signer = tls.sign.Signer.fromSeed([_]u8{0x42} ** 32) catch unreachable;
+    const cert_pub = signer.publicKeySec1();
     var client = try Connection.initClient(gpa, &dcid, .{
         .random = [_]u8{0x44} ** 32,
         .ephemeral_seed = [_]u8{0x55} ** 32,
         .transport_params = &client_tp,
         .alpn = "h3",
         .server_name = "example.test",
+        .server_certificate = &cert_pub,
     }, 1000);
     defer client.deinit();
 
@@ -5253,8 +5256,6 @@ test "a client Initial carries a ClientHello the server can answer" {
 
     var server_cfg = testServerConfig();
     server_cfg.alpn = "h3";
-    const signer = tls.sign.Signer.fromSeed([_]u8{0x42} ** 32) catch unreachable;
-    const cert_pub = signer.publicKeySec1();
     server_cfg.cert_chain = &cert_pub;
     var server = try Connection.initServer(gpa, &dcid, server_cfg);
     defer server.deinit();

--- a/src/core/quic/tls/client.zig
+++ b/src/core/quic/tls/client.zig
@@ -31,6 +31,7 @@ pub const Config = struct {
     transport_params: []const u8,
     alpn: ?[]const u8 = null,
     server_name: ?[]const u8 = null,
+    server_certificate: []const u8 = &.{},
     resumption: ?ResumptionPsk = null,
     validation_token: ?[]const u8 = null,
 };
@@ -89,6 +90,8 @@ pub const Client = struct {
     resumption_master_secret: ?[schedule.SECRET_LEN]u8 = null,
     expected_alpn: [255]u8 = [_]u8{0} ** 255,
     expected_alpn_len: u8 = 0,
+    expected_certificate_hash: [Sha256.digest_length]u8 = [_]u8{0} ** Sha256.digest_length,
+    certificate_configured: bool = false,
 
     pub fn init() Client {
         return .{};
@@ -110,6 +113,8 @@ pub const Client = struct {
         } else {
             self.expected_alpn_len = 0;
         }
+        self.certificate_configured = cfg.server_certificate.len > 0;
+        Sha256.hash(cfg.server_certificate, &self.expected_certificate_hash, .{});
         self.transcript.update(out.items[before..]);
         self.early_traffic_secret = if (cfg.resumption) |psk|
             if (psk.early_data) schedule.clientEarlyTrafficSecret(psk.psk, self.transcript.hash()) else null
@@ -146,6 +151,12 @@ pub const Client = struct {
             if (!std.mem.eql(u8, selected, self.expected_alpn[0..self.expected_alpn_len])) return error.BadServerHello;
         }
         const cert = handshake.firstCertificate(scanned.cert.body) catch return error.BadServerHello;
+        if (!self.certificate_configured) return error.BadServerHello;
+        var certificate_hash: [Sha256.digest_length]u8 = undefined;
+        Sha256.hash(cert, &certificate_hash, .{});
+        if (!std.crypto.timing_safe.eql([Sha256.digest_length]u8, certificate_hash, self.expected_certificate_hash)) {
+            return error.BadServerHello;
+        }
 
         self.transcript.update(scanned.ee.raw);
         self.transcript.update(scanned.cert.raw);

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -1961,7 +1961,7 @@ fn new_h2(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
 
 // H3Connection(role, protocol=HTTP3, *, credentials=None, transport_params=None,
 // random=None, ephemeral_seed=None, alpn=None,
-// connection_id=None, server_name=None, resumption_identity=None,
+// connection_id=None, server_name=None, server_certificate=None, resumption_identity=None,
 // resumption_psk=None, obfuscated_ticket_age=0, early_data=False,
 // remembered_transport_params=None, validation_token=None).
 // role and protocol stay
@@ -1978,22 +1978,24 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
     var alpn_obj: ?*c.PyObject = null;
     var cid_obj: ?*c.PyObject = null;
     var sni_obj: ?*c.PyObject = null;
+    var server_certificate_obj: ?*c.PyObject = null;
     var resumption_obj: ?*c.PyObject = null;
     var obfuscated_ticket_age_obj: ?*c.PyObject = null;
     var early_data_obj: ?*c.PyObject = null;
     var remembered_tp_obj: ?*c.PyObject = null;
     var validation_token_obj: ?*c.PyObject = null;
     var kwlist = [_][*c]u8{
-        @constCast("role"),                        @constCast("protocol"),              @constCast("credentials"),
-        @constCast("transport_params"),            @constCast("random"),                @constCast("ephemeral_seed"),
-        @constCast("alpn"),                        @constCast("connection_id"),         @constCast("server_name"),
-        @constCast("resumption"),                  @constCast("obfuscated_ticket_age"), @constCast("early_data"),
-        @constCast("remembered_transport_params"), @constCast("validation_token"),      null,
+        @constCast("role"),               @constCast("protocol"),                    @constCast("credentials"),
+        @constCast("transport_params"),   @constCast("random"),                      @constCast("ephemeral_seed"),
+        @constCast("alpn"),               @constCast("connection_id"),               @constCast("server_name"),
+        @constCast("server_certificate"), @constCast("resumption"),                  @constCast("obfuscated_ticket_age"),
+        @constCast("early_data"),         @constCast("remembered_transport_params"), @constCast("validation_token"),
+        null,
     };
     if (c.PyArg_ParseTupleAndKeywords(
         args,
         kwds,
-        "l|l$OOOOOOOOOOOO",
+        "l|l$OOOOOOOOOOOOO",
         @ptrCast(&kwlist),
         &role_val,
         &protocol_val,
@@ -2004,6 +2006,7 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
         &alpn_obj,
         &cid_obj,
         &sni_obj,
+        &server_certificate_obj,
         &resumption_obj,
         &obfuscated_ticket_age_obj,
         &early_data_obj,
@@ -2034,6 +2037,10 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
     self.engine = null;
     const engine: *Engine = @ptrCast(@alignCast(&self.engine_storage));
     if (role_val == SERVER) {
+        if (server_certificate_obj != null and !py.isNone(server_certificate_obj)) {
+            py.decref(obj);
+            return py.raiseValue("server_certificate is only valid for HTTP/3 clients");
+        }
         if (obfuscated_ticket_age_obj != null and !py.isNone(obfuscated_ticket_age_obj)) {
             py.decref(obj);
             return py.raiseValue("obfuscated_ticket_age is only valid for HTTP/3 clients");
@@ -2079,6 +2086,7 @@ fn new_h3(tp: ?*c.PyTypeObject, args: ?*c.PyObject, kwds: ?*c.PyObject) callconv
             alpn_obj,
             cid_obj,
             sni_obj,
+            server_certificate_obj,
             resumption_identity_obj,
             resumption_psk_obj,
             obfuscated_ticket_age_obj,
@@ -2105,6 +2113,7 @@ fn buildClientH3(
     alpn_obj: ?*c.PyObject,
     cid_obj: ?*c.PyObject,
     sni_obj: ?*c.PyObject,
+    server_certificate_obj: ?*c.PyObject,
     resumption_identity_obj: ?*c.PyObject,
     resumption_psk_obj: ?*c.PyObject,
     obfuscated_ticket_age_obj: ?*c.PyObject,
@@ -2122,6 +2131,14 @@ fn buildClientH3(
     }
     const alpn = if (alpn_obj != null and !py.isNone(alpn_obj)) py.asBytes(alpn_obj) orelse return null else "h3";
     const server_name = if (sni_obj != null and !py.isNone(sni_obj)) py.asBytes(sni_obj) orelse return null else null;
+    const server_certificate = if (server_certificate_obj != null and !py.isNone(server_certificate_obj))
+        py.asBytes(server_certificate_obj) orelse return null
+    else
+        &.{};
+    if (server_certificate_obj != null and !py.isNone(server_certificate_obj) and server_certificate.len == 0) {
+        _ = py.raiseValue("server_certificate must not be empty");
+        return null;
+    }
     const validation_token = if (validation_token_obj != null and !py.isNone(validation_token_obj)) blk: {
         const token = py.asBytes(validation_token_obj) orelse return null;
         if (token.len == 0) {
@@ -2142,6 +2159,7 @@ fn buildClientH3(
         .transport_params = tp_src,
         .alpn = alpn,
         .server_name = server_name,
+        .server_certificate = server_certificate,
         .resumption = if (resumption) |r| .{
             .identity = r.identity,
             .obfuscated_ticket_age = r.obfuscated_ticket_age,

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -44,6 +44,7 @@ class ClientConfig(TypedDict):
     connection_id: bytes
     alpn: bytes
     server_name: bytes
+    server_certificate: bytes
 
 
 class ResumedClientConfig(ClientConfig, total=False):
@@ -84,6 +85,7 @@ CLIENT_CONFIG: ResumedClientConfig = {
     "connection_id": b"\x11\x22\x33\x44",
     "alpn": b"h3",
     "server_name": b"example.test",
+    "server_certificate": SERVER_PUBLIC_KEY,
 }
 
 
@@ -359,16 +361,29 @@ def test_http3_validation_token_is_client_only() -> None:
         )
 
 
-def test_http3_client_defaults_transport_settings_and_connection_id() -> None:
-    conn = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"example.test")
-    datagrams = conn.data_to_send()
-    assert len(datagrams) == 1
-    assert len(datagrams[0]) == 1200
-
-
-def test_http3_default_client_and_server_exchange_request() -> None:
+def test_http3_client_without_a_server_certificate_rejects_the_handshake() -> None:
     client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, server_name=b"example.test")
-    server = zttp.Connection(zttp.SERVER, protocol=zttp.HTTP3)
+    server = make_server()
+
+    assert transfer(client, server, 1000)
+    with pytest.raises(zttp.RemoteProtocolError):
+        transfer(server, client, 2000)
+
+
+def test_http3_client_rejects_an_unpinned_server_certificate() -> None:
+    config = CLIENT_CONFIG.copy()
+    config["server_certificate"] = b"other certificate"
+    client = zttp.Connection(zttp.CLIENT, protocol=zttp.HTTP3, **config)
+    server = make_server()
+
+    assert transfer(client, server, 1000)
+    with pytest.raises(zttp.RemoteProtocolError):
+        transfer(server, client, 2000)
+
+
+def test_http3_pinned_client_and_server_exchange_request() -> None:
+    client = make_client()
+    server = make_server()
 
     assert transfer(client, server, 1000)
     assert transfer(server, client, 2000)

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -310,6 +310,7 @@ class Connection:
         connection_id: bytes | None = ...,
         alpn: bytes | None = ...,
         server_name: bytes | None = ...,
+        server_certificate: bytes | None = ...,
         resumption: SessionResumption | None = ...,
         obfuscated_ticket_age: int = ...,
         early_data: bool = ...,


### PR DESCRIPTION
## Summary

- Add an optional `server_certificate` pin to HTTP/3 client construction.
- Refuse every server TLS flight when the pin is absent or does not match the presented leaf certificate or raw P-256 key.
- Compare certificate digests in constant time before accepting `CertificateVerify`.
- Update docs, benchmarks, deterministic tests, and aioquic interoperability coverage.

The exact certificate pin binds the peer identity without adding a hand-written X.509 chain validator. Supplying only `server_name` still sends SNI, but no longer authenticates the server by itself.

## Tests

- `zig build test`
- `uv run pytest` - 412 passed, 1 skipped
- `scripts/check`
- `scripts/build`
- `uv run python scripts/interop_aioquic.py`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
