### PR TITLE
Authenticate peer connection IDs before adoption

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2271,20 +2271,12 @@ pub const Connection = struct {
         if (self.role == .server and hdr.ltype == .initial and datagram_len < constants.MIN_INITIAL_DATAGRAM) {
             return error.Dropped;
         }
-        // Adopt the peer's source connection id (from its first long header) as the
-        // destination of everything we send (RFC 9000 7.2). Until this, peer_scid
-        // defaults to the client dcid - fine for tests that use one shared id.
-        if (!self.peer_scid_set and hdr.scid.len > 0) {
-            const sc = self.gpa.dupe(u8, hdr.scid) catch return error.OutOfMemory;
-            self.gpa.free(self.peer_scid);
-            self.peer_scid = sc;
-            self.peer_scid_set = true;
-        }
         // A long header's length is known, so a packet we cannot decrypt (no keys
         // for the space yet, or a bad tag) is SKIPPED, not fatal: we return its
         // length so the caller keeps walking any coalesced packets behind it
         // (e.g. a Handshake packet coalesced after an Initial). RFC 9000 12.2.
-        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, now) catch |e| switch (e) {
+        const peer_scid_candidate = if (hdr.ltype == .initial) hdr.scid else null;
+        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, peer_scid_candidate, now) catch |e| switch (e) {
             error.Dropped => return total,
             else => return e,
         };
@@ -2367,7 +2359,7 @@ pub const Connection = struct {
         self.current_packet_local_cid_seq = parsed.local_cid_seq;
         defer self.current_packet_local_cid_seq = previous_cid_seq;
         // A short-header packet is the rest of the datagram (no length field).
-        self.decryptAndDispatch(buf, parsed.hdr.pn_offset, .application, false, now) catch |e| switch (e) {
+        self.decryptAndDispatch(buf, parsed.hdr.pn_offset, .application, false, null, now) catch |e| switch (e) {
             error.Dropped => {
                 if (self.detectStatelessReset(buf)) return buf.len;
                 return error.Dropped;
@@ -2445,7 +2437,15 @@ pub const Connection = struct {
         return count;
     }
 
-    fn decryptAndDispatch(self: *Connection, pkt: []const u8, pn_offset: usize, space: Space, long: bool, now: u64) Error!void {
+    fn decryptAndDispatch(
+        self: *Connection,
+        pkt: []const u8,
+        pn_offset: usize,
+        space: Space,
+        long: bool,
+        peer_scid_candidate: ?[]const u8,
+        now: u64,
+    ) Error!void {
         const st = &self.spaces[@intFromEnum(space)];
         const opened = if (space == .application and !long)
             try self.openApplicationPacket(pkt, pn_offset)
@@ -2455,6 +2455,15 @@ pub const Connection = struct {
             try self.openPacket(pkt, pn_offset, space, long, st.recv_keys orelse return error.Dropped, null);
         defer self.gpa.free(opened.work);
         defer self.gpa.free(opened.plaintext);
+        if (peer_scid_candidate) |candidate| {
+            // RFC 9000 7.2 permits adoption only after packet authentication.
+            if (!self.peer_scid_set and candidate.len > 0) {
+                const sc = self.gpa.dupe(u8, candidate) catch return error.OutOfMemory;
+                self.gpa.free(self.peer_scid);
+                self.peer_scid = sc;
+                self.peer_scid_set = true;
+            }
+        }
         if (space == .initial) self.initial_authenticated = true;
 
         // A decryptable Handshake packet proves the peer received our Initial/
@@ -5427,6 +5436,32 @@ test "server accepts a token-bearing Initial after Retry" {
     try server.receiveDatagramFrom(client.datagramsToSend(), 3000, "peer-address");
     try testing.expect(server.datagramsToSend().len > 0);
     try testing.expect(server.paths.get(std.hash.Wyhash.hash(0, "peer-address")).?.validated);
+}
+
+test "an unauthenticated long header cannot replace the peer connection id" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xe0, 0xe1, 0xe2, 0xe3 };
+    var client = try Connection.init(gpa, .client, &dcid);
+    defer client.deinit();
+
+    var forged: std.ArrayListUnmanaged(u8) = .empty;
+    defer forged.deinit(gpa);
+    _ = try packet.writeLongHeader(
+        &forged,
+        gpa,
+        .initial,
+        constants.VERSION_1,
+        client.scid,
+        "attacker-cid",
+        &.{},
+        21,
+        1,
+    );
+    try forged.appendNTimes(gpa, 0, 21);
+
+    try client.receiveDatagram(forged.items, 1000);
+    try testing.expectEqualSlices(u8, &dcid, client.peer_scid);
+    try testing.expect(!client.peer_scid_set);
 }
 
 test "server answers an unsupported long-header version with Version Negotiation" {


### PR DESCRIPTION
## Summary

- Decrypt and authenticate the peer's first Initial before adopting its source connection ID.
- Make the authenticated ID available before TLS transport-parameter validation.
- Leave connection routing unchanged after forged long-header packets with invalid tags.

## Tests

- `zig build test`
- `scripts/check`

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
