### PR TITLE
Document pull request description guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,30 @@
 1. When testing `pytest.raises(ValueError)`, always use the `match` parameter (`match=...`).
 2. Avoid small wrapper functions in tests, such as `make_client` and `make_server`.
 3. Use `TypedDict` for parameters and dataclasses for output data.
+
+# Pull Request Guidelines
+
+Use this structure for every pull request description:
+
+```markdown
+## Summary
+
+<Briefly explain the behavior changed by this PR and why it should change.>
+
+## Other HTTP Parsers
+
+| Parser | Language | Behavior | Reference |
+| --- | --- | --- | --- |
+| <implementation> | <language> | <behavior for the same case> | <direct link> |
+
+## AI Disclaimer
+
+This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
+```
+
+- Keep `Summary` short and focused on observable behavior.
+- For HTTP behavior changes, compare the same protocol rule or edge case with relevant parsers in at least three different languages.
+- For other changes, keep the table and use one `Not applicable` row that explains why no parser behavior is affected.
+- Link directly to the implementation, test, or documentation that supports each comparison.
+- State meaningful differences instead of implying that all parsers behave alike.
+- Do not include a `Tests` section. CI and the changed test files provide the test evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,29 +2,10 @@
 2. Avoid small wrapper functions in tests, such as `make_client` and `make_server`.
 3. Use `TypedDict` for parameters and dataclasses for output data.
 
-# Pull Request Guidelines
+# Pull Requests
 
-Use this structure for every pull request description:
-
-```markdown
-## Summary
-
-<Briefly explain the behavior changed by this PR and why it should change.>
-
-## Other HTTP Parsers
-
-| Parser | Language | Behavior | Reference |
-| --- | --- | --- | --- |
-| <implementation> | <language> | <behavior for the same case> | <direct link> |
-
-## AI Disclaimer
-
-This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
-```
-
-- Keep `Summary` short and focused on observable behavior.
-- For HTTP behavior changes, compare the same protocol rule or edge case with relevant parsers in at least three different languages.
-- For other changes, keep the table and use one `Not applicable` row that explains why no parser behavior is affected.
-- Link directly to the implementation, test, or documentation that supports each comparison.
-- State meaningful differences instead of implying that all parsers behave alike.
-- Do not include a `Tests` section. CI and the changed test files provide the test evidence.
+- Include a concise `## Summary`.
+- For relevant HTTP behavior changes, add `## Other HTTP Parsers` with a `Parser | Language | Behavior | Reference` table. Link exact evidence.
+- Omit `## Other HTTP Parsers` when the comparison is not useful.
+- Do not include a `## Tests` section.
+- End with `## AI Disclaimer` and: `This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,4 +8,3 @@
 - For relevant HTTP behavior changes, add `## Other HTTP Parsers` with a `Parser | Language | Behavior | Reference` table. Link exact evidence.
 - Omit `## Other HTTP Parsers` when the comparison is not useful.
 - Do not include a `## Tests` section.
-- End with `## AI Disclaimer` and: `This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.`


### PR DESCRIPTION
## Summary

Define concise pull request description rules in `AGENTS.md`. Keep the summary, make HTTP parser comparisons optional, and omit a Tests section.
