### PR TITLE
Validate HPACK and QPACK tables against reference data

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: "0.16.0"
+          cache-key: "${{ matrix.python-version }}"
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/src/core/h2/hpack/huffman.zig
+++ b/src/core/h2/hpack/huffman.zig
@@ -7,6 +7,8 @@
 
 const std = @import("std");
 
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
 pub const HuffError = error{
     /// Padding longer than 7 bits, padding that is not all-ones, or an embedded
     /// EOS symbol (256) - all malformed per RFC 7541 5.2.
@@ -236,6 +238,27 @@ inline fn matchSymbol(acc: u32, nbits: u5) ?u16 {
 }
 
 const testing = std.testing;
+
+test "code table matches python-hpack 4.1.0" {
+    // REQUEST_CODES and REQUEST_CODES_LENGTH, serialized as big-endian u32 + u8.
+    const expected = [_]u8{
+        0x2c, 0xdc, 0x4c, 0x6f, 0xb1, 0xcc, 0x0a, 0xb4,
+        0x43, 0x43, 0xa2, 0x95, 0xf7, 0x3f, 0x5f, 0xf7,
+        0x80, 0xa0, 0x52, 0xd3, 0x09, 0xbd, 0xdf, 0x8f,
+        0x9c, 0xd2, 0x7f, 0x1e, 0x3d, 0xe8, 0xe6, 0x69,
+    };
+    var hasher = Sha256.init(.{});
+    for (CODES) |sym| {
+        var code: [4]u8 = undefined;
+        std.mem.writeInt(u32, &code, sym.code, .big);
+        hasher.update(&code);
+        hasher.update(&.{sym.bits});
+    }
+    var actual: [Sha256.digest_length]u8 = undefined;
+    hasher.final(&actual);
+
+    try testing.expectEqualSlices(u8, &expected, &actual);
+}
 
 fn decodeAlloc(src: []const u8) ![]u8 {
     var buf: [256]u8 = undefined;

--- a/src/core/h2/hpack/static_table.zig
+++ b/src/core/h2/hpack/static_table.zig
@@ -5,6 +5,8 @@
 
 const std = @import("std");
 
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
 pub const Entry = struct { name: []const u8, value: []const u8 };
 
 pub const LENGTH: usize = 61;
@@ -81,6 +83,27 @@ pub fn lookup(index: usize) ?Entry {
 }
 
 const testing = std.testing;
+
+test "static table matches python-hpack 4.1.0" {
+    // HeaderTable.STATIC_TABLE, serialized as name + NUL + value + NUL.
+    const expected = [_]u8{
+        0xbc, 0xb7, 0x87, 0x46, 0x5f, 0x10, 0xf8, 0x7a,
+        0xa1, 0x6f, 0x8f, 0x17, 0x00, 0x70, 0xc3, 0x27,
+        0xc6, 0x7f, 0x17, 0x41, 0x11, 0x3c, 0x1a, 0xd4,
+        0x4a, 0xeb, 0xd1, 0xd7, 0x16, 0xb0, 0x97, 0x26,
+    };
+    var hasher = Sha256.init(.{});
+    for (TABLE) |entry| {
+        hasher.update(entry.name);
+        hasher.update(&.{0});
+        hasher.update(entry.value);
+        hasher.update(&.{0});
+    }
+    var actual: [Sha256.digest_length]u8 = undefined;
+    hasher.final(&actual);
+
+    try testing.expectEqualSlices(u8, &expected, &actual);
+}
 
 test "static table has exactly 61 entries" {
     try testing.expectEqual(@as(usize, 61), TABLE.len);

--- a/src/core/h3/qpack/static_table.zig
+++ b/src/core/h3/qpack/static_table.zig
@@ -5,6 +5,8 @@
 
 const std = @import("std");
 
+const Sha256 = std.crypto.hash.sha2.Sha256;
+
 pub const Entry = struct { name: []const u8, value: []const u8 };
 
 /// RFC 9204 appendix A, indices 0-98.
@@ -131,6 +133,27 @@ pub fn nameIndex(name: []const u8) ?usize {
         if (std.mem.eql(u8, e.name, name)) return i;
     }
     return null;
+}
+
+test "static table matches RFC 9204 appendix A" {
+    // Entries are serialized in index order as name + NUL + value + NUL.
+    const expected = [_]u8{
+        0x2f, 0x57, 0x57, 0xc3, 0x7c, 0xec, 0x2b, 0xf4,
+        0x6c, 0x4d, 0x9d, 0x85, 0x69, 0xfc, 0x52, 0xa3,
+        0x89, 0x41, 0x42, 0xfe, 0x31, 0x1d, 0x07, 0xdc,
+        0xf6, 0xbd, 0x20, 0xcd, 0x17, 0xf0, 0x4d, 0x3e,
+    };
+    var hasher = Sha256.init(.{});
+    for (TABLE) |entry| {
+        hasher.update(entry.name);
+        hasher.update(&.{0});
+        hasher.update(entry.value);
+        hasher.update(&.{0});
+    }
+    var actual: [Sha256.digest_length]u8 = undefined;
+    hasher.final(&actual);
+
+    try std.testing.expectEqualSlices(u8, &expected, &actual);
 }
 
 test "the table has the RFC 9204 appendix A length" {


### PR DESCRIPTION
## Summary

- Validate every HPACK Huffman code and bit length against python-hpack 4.1.0.
- Validate HPACK and QPACK static table contents and index order against reference data.

Closes #228

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates the HPACK Huffman code table against python-hpack 4.1.0 and the HPACK/QPACK static tables against reference data (RFC 9204 appendix A). Also keys the Zig CI cache by Python version so parallel version jobs don't share cache entries. Closes #228.

<sup>Written for commit 9292d1e7e07386de3f0db78d2d5b62a99436cfc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

