### PR TITLE
Reject invalid HTTP/1.1 Host field counts

### DIFF
--- a/docs/usage/http1.md
+++ b/docs/usage/http1.md
@@ -54,6 +54,7 @@ import zttp
 conn = zttp.Connection(zttp.SERVER)
 conn.receive_data(
     b"POST / HTTP/1.1\r\n"
+    b"Host: example.com\r\n"
     b"Content-Length: 11\r\n"
     b"\r\n"
     b"hello world"
@@ -129,6 +130,7 @@ ending with a `0` chunk; you never see it, you get the decoded `hello world`:
 conn = zttp.Connection(zttp.SERVER)
 conn.receive_data(
     b"POST / HTTP/1.1\r\n"
+    b"Host: example.com\r\n"
     b"Transfer-Encoding: chunked\r\n"
     b"\r\n"
     b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
@@ -157,6 +159,7 @@ the `EndOfMessage` event:
 conn = zttp.Connection(zttp.SERVER)
 conn.receive_data(
     b"POST / HTTP/1.1\r\n"
+    b"Host: example.com\r\n"
     b"Transfer-Encoding: chunked\r\n"
     b"\r\n"
     b"3\r\nabc\r\n"

--- a/src/core/h1/connection.zig
+++ b/src/core/h1/connection.zig
@@ -35,11 +35,14 @@ pub const HeadSemantics = struct {
     has_upgrade_token: bool = false,
     upgrade_value: ?[]const u8 = null,
     expect_continue: bool = false,
+    host_count: usize = 0,
 
     pub fn add(self: *HeadSemantics, h: Header) ParseError!void {
         try self.framing.add(h);
 
-        if (eqIgnoreCase(h.name, "connection")) {
+        if (eqIgnoreCase(h.name, "host")) {
+            self.host_count += 1;
+        } else if (eqIgnoreCase(h.name, "connection")) {
             var it = std.mem.splitScalar(u8, h.value, ',');
             while (it.next()) |raw| {
                 const token = trimOws(raw);
@@ -61,6 +64,11 @@ pub const HeadSemantics = struct {
     pub fn shouldClose(self: HeadSemantics, http_version: []const u8) bool {
         if (self.has_close) return true;
         return eqIgnoreCase(http_version, "1.0") and !self.has_keep_alive;
+    }
+
+    /// Reject HTTP/1.1 requests without exactly one Host field (RFC 9112 3.2).
+    pub fn validateRequestHost(self: HeadSemantics, http_version: []const u8) ParseError!void {
+        if (eqIgnoreCase(http_version, "1.1") and self.host_count != 1) return error.InvalidHeader;
     }
 
     pub fn upgrade(self: HeadSemantics) ?[]const u8 {

--- a/src/core/h1/reader.zig
+++ b/src/core/h1/reader.zig
@@ -374,6 +374,7 @@ pub const Reader = struct {
 
         if (self.role == .server) {
             const rl = try headers_mod.parseRequestLine(first);
+            try semantics.validateRequestHost(rl.http_version);
             const framing = try semantics.framing.finish(.{ .until_close_default = false });
             const end_stream = framing == .none;
             if (end_stream) {
@@ -606,8 +607,34 @@ test "simple GET no body" {
     try t.expectEqual(EvTag.request, r.ev.items[0]);
 }
 
+test "HTTP/1.1 request requires exactly one Host field" {
+    const invalid = [_][]const u8{
+        "GET / HTTP/1.1\r\nUser-Agent: zttp\r\n\r\n",
+        "GET / HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+    };
+    for (invalid) |request| {
+        var r = Reader.init(t.allocator, .server);
+        defer r.deinit();
+        try r.feed(request);
+        try t.expectError(error.InvalidHeader, r.nextEvent());
+    }
+}
+
+test "Host requirement permits empty HTTP/1.1 and missing HTTP/1.0 values" {
+    const valid = [_][]const u8{
+        "GET / HTTP/1.1\r\nHost:\r\n\r\n",
+        "GET / HTTP/1.0\r\n\r\n",
+    };
+    for (valid) |request| {
+        var r = Reader.init(t.allocator, .server);
+        defer r.deinit();
+        try r.feed(request);
+        try expectTag(.request, try r.nextEvent());
+    }
+}
+
 test "POST content-length body" {
-    var r = try drainServer("POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello");
+    var r = try drainServer("POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello");
     defer r.ev.deinit(t.allocator);
     defer r.body.deinit(t.allocator);
     try t.expectEqualStrings("hello", r.body.items);
@@ -615,7 +642,7 @@ test "POST content-length body" {
 }
 
 test "POST chunked body with trailers" {
-    var r = try drainServer("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\nX-T: v\r\n\r\n");
+    var r = try drainServer("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\nX-T: v\r\n\r\n");
     defer r.ev.deinit(t.allocator);
     defer r.body.deinit(t.allocator);
     try t.expectEqualStrings("abc", r.body.items);
@@ -664,7 +691,7 @@ test "EOF during an incomplete head is a terminal protocol error" {
 test "split body across feeds" {
     var r = Reader.init(t.allocator, .server);
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhel");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nhel");
     _ = try r.nextEvent(); // request
     const d1 = try r.nextEvent();
     try t.expectEqualStrings("hel", d1.data.data);
@@ -813,7 +840,7 @@ test "client exposes response connection close signal" {
 test "server head info is an immediate one-shot snapshot" {
     var r = Reader.init(t.allocator, .server);
     defer r.deinit();
-    try r.feed("GET / HTTP/1.1\r\nConnection: close, Upgrade\r\nUpgrade: websocket\r\n\r\n");
+    try r.feed("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close, Upgrade\r\nUpgrade: websocket\r\n\r\n");
     try expectTag(.request, try r.nextEvent());
 
     const info = r.takeHeadInfo();
@@ -844,7 +871,7 @@ test "client marks close-delimited response as closing" {
 test "truncated content-length body errors at EOF" {
     var r = Reader.init(t.allocator, .server);
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nshort");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nshort");
     _ = try r.nextEvent();
     _ = try r.nextEvent(); // "short"
     try r.feed("");
@@ -859,7 +886,7 @@ test "H-1: trailer survives buffer realloc across feeds" {
     // trailer must still read back correctly (was a use-after-free).
     var r = Reader.init(t.allocator, .server);
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n");
     try expectTag(.request, try r.nextEvent());
     try r.feed("0\r\nX-Trailer: SECRET\r\n");
     try expectTag(.need_data, try r.nextEvent()); // trailer stored, no blank line yet
@@ -874,7 +901,7 @@ test "H-1: trailer survives buffer realloc across feeds" {
 test "H-1: multiple trailers survive trailer_store growth" {
     var r = Reader.init(t.allocator, .server);
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
     try expectTag(.request, try r.nextEvent());
     try r.feed("A: 1\r\nBee: 22\r\nCee: 333\r\n\r\n");
     var eom: Event = undefined;
@@ -900,7 +927,7 @@ test "H-4: trailer count cap rejected" {
     var r = Reader.init(t.allocator, .server);
     r.limits.max_trailers = 4;
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
     _ = try r.nextEvent();
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(t.allocator);
@@ -917,7 +944,7 @@ test "H-4: trailer byte cap rejected" {
     var r = Reader.init(t.allocator, .server);
     r.limits.max_trailer_bytes = 32;
     defer r.deinit();
-    try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
+    try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n");
     _ = try r.nextEvent();
     try r.feed("X-Long-Trailer-Header: aaaaaaaaaaaaaaaaaaaaaaaaa\r\n");
     try t.expectError(error.MessageTooLong, r.nextEvent());
@@ -927,7 +954,7 @@ test "prohibited trailers are rejected" {
     inline for (.{ "Content-Length: 0", "Trailer: Content-Length", "Content-Type: text/plain" }) |trailer| {
         var r = Reader.init(t.allocator, .server);
         defer r.deinit();
-        try r.feed("POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n" ++ trailer ++ "\r\n\r\n");
+        try r.feed("POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n" ++ trailer ++ "\r\n\r\n");
         try expectTag(.request, try r.nextEvent());
         try t.expectError(error.InvalidHeader, r.nextEvent());
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,7 +52,7 @@ def test_request_path_without_query() -> None:
 
 def test_endofmessage_and_data_repr() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nhi")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2\r\n\r\nhi")
     conn.next_event()  # Request
     assert repr(conn.next_event()) == "Data(data=b'hi')"
     assert repr(conn.next_event()) == "EndOfMessage(trailers=[])"

--- a/tests/test_free_threading.py
+++ b/tests/test_free_threading.py
@@ -25,7 +25,7 @@ def test_free_threaded_build_keeps_gil_disabled() -> None:  # pragma: no cover -
 
 def test_shared_connection_serializes_calls() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    request = b"GET / HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+    request = b"GET / HTTP/1.1\r\nHost: example.com\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
     count = 300
     conn.receive_data(request * count)
     barrier = threading.Barrier(2)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -11,7 +11,7 @@ from tests.conftest import drain, drain_all, parse_request
 
 def test_receive_event_feeds_and_returns_first_available_http1_event() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    event = conn.receive_event(b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+    event = conn.receive_event(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello")
 
     assert isinstance(event, zttp.Request)
     data = conn.next_event()
@@ -22,7 +22,7 @@ def test_receive_event_feeds_and_returns_first_available_http1_event() -> None:
 
 def test_receive_event_accepts_bytearray_input() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    incoming = bytearray(b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+    incoming = bytearray(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello")
 
     event = conn.receive_event(incoming)
     incoming[-5:] = b"other"
@@ -79,8 +79,39 @@ def test_simple_get() -> None:
     assert req.end_stream is True
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"GET / HTTP/1.1\r\nUser-Agent: x\r\n\r\n",
+        b"GET / HTTP/1.1\r\nHost: one.example\r\nHost: two.example\r\n\r\n",
+    ],
+)
+@pytest.mark.parametrize("fragmented", [False, True])
+def test_http11_rejects_missing_or_duplicate_host(raw: bytes, fragmented: bool) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    for chunk in [raw] if not fragmented else (raw[index : index + 1] for index in range(len(raw))):
+        conn.receive_data(chunk)
+
+    with pytest.raises(zttp.RemoteProtocolError):
+        conn.next_event()
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"GET / HTTP/1.1\r\nHost:\r\n\r\n",
+        b"GET / HTTP/1.0\r\n\r\n",
+    ],
+)
+def test_host_requirement_accepts_empty_http11_host_and_missing_http10_host(raw: bytes) -> None:
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(raw)
+
+    assert isinstance(conn.next_event(), zttp.Request)
+
+
 def test_post_content_length() -> None:
-    events = parse_request(b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello")
+    events = parse_request(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nhello")
     assert isinstance(events[0], zttp.Request)
     body = b"".join(e.data for e in events if isinstance(e, zttp.Data))
     assert body == b"hello"
@@ -88,7 +119,7 @@ def test_post_content_length() -> None:
 
 
 def test_zero_content_length_has_no_data() -> None:
-    events = parse_request(b"POST / HTTP/1.1\r\nContent-Length: 0\r\n\r\n")
+    events = parse_request(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 0\r\n\r\n")
     assert not any(isinstance(e, zttp.Data) for e in events)
     request = events[-1]
     assert isinstance(request, zttp.Request)
@@ -105,7 +136,8 @@ def test_no_body_get_completes_on_request() -> None:
 
 def test_chunked_body() -> None:
     events = parse_request(
-        b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
+        b"POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n"
+        b"5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
     )
     body = b"".join(e.data for e in events if isinstance(e, zttp.Data))
     assert body == b"hello world"
@@ -113,7 +145,9 @@ def test_chunked_body() -> None:
 
 def test_chunked_with_trailers() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\nX-T: v\r\n\r\n")
+    conn.receive_data(
+        b"POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n3\r\nabc\r\n0\r\nX-T: v\r\n\r\n"
+    )
     events = list(drain(conn))
     eom = events[-1]
     assert isinstance(eom, zttp.EndOfMessage)
@@ -121,10 +155,10 @@ def test_chunked_with_trailers() -> None:
 
 
 def test_multiple_headers_preserved_in_order() -> None:
-    events = parse_request(b"GET / HTTP/1.1\r\nA: 1\r\nB: 2\r\nA: 3\r\n\r\n")
+    events = parse_request(b"GET / HTTP/1.1\r\nHost: example.com\r\nA: 1\r\nB: 2\r\nA: 3\r\n\r\n")
     req = events[0]
     assert isinstance(req, zttp.Request)
-    assert req.headers == [(b"A", b"1"), (b"B", b"2"), (b"A", b"3")]
+    assert req.headers == [(b"Host", b"example.com"), (b"A", b"1"), (b"B", b"2"), (b"A", b"3")]
 
 
 def test_headers_are_owned_and_sequence_compatible() -> None:
@@ -198,10 +232,10 @@ def test_h1_headers_are_immutable_by_default() -> None:
 
 
 def test_header_value_whitespace_stripped() -> None:
-    events = parse_request(b"GET / HTTP/1.1\r\nX:   spaced   \r\n\r\n")
+    events = parse_request(b"GET / HTTP/1.1\r\nHost: example.com\r\nX:   spaced   \r\n\r\n")
     req = events[0]
     assert isinstance(req, zttp.Request)
-    assert req.headers == [(b"X", b"spaced")]
+    assert req.headers == [(b"Host", b"example.com"), (b"X", b"spaced")]
 
 
 def test_partial_head_then_complete() -> None:
@@ -216,7 +250,7 @@ def test_partial_head_then_complete() -> None:
 
 def test_body_split_across_feeds() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhel")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nhel")
     assert isinstance(conn.next_event(), zttp.Request)
     first = conn.next_event()
     assert isinstance(first, zttp.Data)
@@ -244,7 +278,7 @@ def test_large_content_length_body_reuses_exact_received_bytes() -> None:
 
 def test_pending_body_owner_is_released_with_the_connection() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 1024\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 1024\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
     body = bytes(bytearray(b"x" * 1024))
     before = sys.getrefcount(body)
@@ -256,7 +290,7 @@ def test_pending_body_owner_is_released_with_the_connection() -> None:
 
 def test_pending_body_owner_is_released_when_a_second_feed_flushes_it() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
     first = bytes(bytearray(b"hello"))
     before = sys.getrefcount(first)
@@ -281,7 +315,7 @@ def test_pending_input_owner_is_released_after_a_head_parse_error() -> None:
 def test_small_content_length_body_keeps_copy_path() -> None:
     conn = zttp.Connection(zttp.SERVER)
     body = b"small body"
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
 
     conn.receive_data(body)
@@ -295,7 +329,9 @@ def test_body_buffer_with_pipelined_bytes_keeps_copy_path() -> None:
     conn = zttp.Connection(zttp.SERVER)
     body = b"x" * 1024
     conn.receive_data(
-        b"POST / HTTP/1.1\r\nContent-Length: 1024\r\n\r\n" + body + b"GET /next HTTP/1.1\r\nHost: x\r\n\r\n"
+        b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 1024\r\n\r\n"
+        + body
+        + b"GET /next HTTP/1.1\r\nHost: x\r\n\r\n"
     )
     assert isinstance(conn.next_event(), zttp.Request)
     event = conn.next_event()
@@ -314,7 +350,7 @@ def test_start_next_cycle_rejects_a_stashed_body() -> None:
     conn = zttp.Connection(zttp.SERVER)
     prefix = b"GET /smuggled HTTP/1.1\r\nHost: example.com\r\n\r\n"
     body = prefix + b"x" * (2048 - len(prefix))
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2048\r\n\r\n" + body)
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2048\r\n\r\n" + body)
     assert isinstance(conn.next_event(), zttp.Request)
 
     with pytest.raises(zttp.LocalProtocolError, match="before the current message is complete"):
@@ -448,6 +484,10 @@ def test_drain_reaches_need_data_on_partial() -> None:
     assert list(drain(conn)) == []
     drain_all(conn)  # returns cleanly (NEED_DATA), no exception
 
+    conn = zttp.Connection(zttp.SERVER)
+    conn.receive_data(b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+    drain_all(conn)
+
 
 def test_invalid_role_rejected() -> None:
     with pytest.raises(ValueError):
@@ -462,7 +502,8 @@ def test_remote_is_subclass_of_protocol_error() -> None:
 def test_body_and_pipelined_request_in_one_feed() -> None:
     conn = zttp.Connection(zttp.SERVER)
     conn.receive_data(
-        b"POST /a HTTP/1.1\r\nContent-Length: 5\r\n\r\nfirstPOST /b HTTP/1.1\r\nContent-Length: 6\r\n\r\nsecond"
+        b"POST /a HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\nfirst"
+        b"POST /b HTTP/1.1\r\nHost: example.com\r\nContent-Length: 6\r\n\r\nsecond"
     )
     events = list(drain(conn))
     first = events[0]
@@ -479,7 +520,7 @@ def test_body_and_pipelined_request_in_one_feed() -> None:
 
 def test_second_feed_arrives_before_first_is_drained() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 10\r\n\r\nhello")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\n\r\nhello")
     conn.receive_data(b"world")
     events = list(drain(conn))
     assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == b"helloworld"
@@ -488,7 +529,7 @@ def test_second_feed_arrives_before_first_is_drained() -> None:
 
 def test_body_fed_in_pieces_with_draining_between() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 9\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 9\r\n\r\n")
     assert isinstance(next(drain(conn)), zttp.Request)
     body = b""
     for piece in (b"abc", b"def", b"ghi"):
@@ -499,7 +540,7 @@ def test_body_fed_in_pieces_with_draining_between() -> None:
 
 def test_garbage_after_complete_message_raises_on_next_cycle() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nokNOT HTTP\x00\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 2\r\n\r\nokNOT HTTP\x00\r\n\r\n")
     events = list(drain(conn))
     assert isinstance(events[-1], zttp.EndOfMessage)
     conn.start_next_cycle()
@@ -537,7 +578,7 @@ def test_standard_methods_are_interned() -> None:
 
 def test_large_body_round_trips_unchanged() -> None:
     body = bytes(range(256)) * 256  # 64KB, every byte value
-    raw = b"POST /up HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
+    raw = b"POST /up HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n" + body
     events = parse_request(raw)
     assert b"".join(e.data for e in events if isinstance(e, zttp.Data)) == body
     assert isinstance(events[-1], zttp.EndOfMessage)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -21,11 +21,14 @@ def test_h2_synthesizing_sequence_headers_roundtrip() -> None:
             self.n = n
 
         def __len__(self) -> int:
-            return self.n
+            return self.n + 1
 
         def __getitem__(self, i: int) -> tuple[bytes, bytes]:
-            if i >= self.n:  # pragma: no cover - sequence-protocol guard, not hit via __len__-bounded access
+            if i > self.n:  # pragma: no cover - sequence-protocol guard, not hit via __len__-bounded access
                 raise IndexError
+            if i == 0:
+                return (b"Host", b"example.com")
+            i -= 1
             return (b"Header-%02d" % i, b"value-%02d-%s" % (i, b"x" * 24))
 
     n = 40
@@ -60,7 +63,7 @@ def test_h3_split_transfer_encoding_rejected(headers: bytes) -> None:
 
 def test_h4_trailer_flood_rejected() -> None:
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
     flood = b"".join(b"X-%d: y\r\n" % i for i in range(500))
     conn.receive_data(flood)
@@ -71,7 +74,7 @@ def test_h4_trailer_flood_rejected() -> None:
 def test_trailer_survives_large_followup_feed() -> None:
     # H-1: store a trailer, then force a buffer realloc before EndOfMessage.
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n")
+    conn.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
     conn.receive_data(b"0\r\nX-Trailer: SECRET\r\n")
     assert conn.next_event() is zttp.NEED_DATA
@@ -115,7 +118,7 @@ def test_event_cycle_is_collectable() -> None:
 
     def make_cycle() -> None:
         c = zttp.Connection(zttp.SERVER)
-        c.receive_data(b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
+        c.receive_data(b"POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n")
         c.next_event()  # Request
         # HeaderBlock is immutable and holds only bytes, so put the cycle
         # through the still-mutable EndOfMessage.trailers list.
@@ -215,7 +218,9 @@ def test_content_length_fast_path_respects_max_buffer_on_single_feed() -> None:
 def test_content_length_fast_path_respects_max_buffer_on_later_body_feed() -> None:
     body = b"A" * (9 * 1024 * 1024)
     conn = zttp.Connection(zttp.SERVER)
-    conn.receive_data(b"POST / HTTP/1.1\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n")
+    conn.receive_data(
+        b"POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: " + str(len(body)).encode() + b"\r\n\r\n"
+    )
     assert isinstance(conn.next_event(), zttp.Request)
     with pytest.raises(zttp.RemoteProtocolError):
         conn.receive_data(body)


### PR DESCRIPTION
## Summary

- Reject inbound HTTP/1.1 requests without exactly one `Host` field before emitting `Request`.
- Preserve empty `Host` values and HTTP/1.0 behavior.
- Update valid request fixtures and examples to include the required field.

Closes #187.

## Other HTTP Parsers

| Parser | Language | Behavior | Reference |
| --- | --- | --- | --- |
| h11 | Python | Requires `Host` for HTTP/1.1 and rejects duplicate `Host` fields. | [Request validation](https://github.com/python-hyper/h11/blob/master/h11/_events.py#L109-L121) |
| `net/http` | Go | Rejects duplicate `Host` fields while parsing and missing HTTP/1.1 `Host` fields at the server boundary. | [Duplicate check](https://go.dev/src/net/http/request.go#L1160), [missing check](https://go.dev/src/net/http/server.go#L1069) |
| Node.js HTTP | JavaScript/C | Rejects a missing HTTP/1.1 `Host` by default, but normalizes duplicate `Host` fields instead of rejecting them. | [server option](https://github.com/nodejs/node/blob/main/doc/api/http.md#L2060-L2069), [duplicate handling](https://github.com/nodejs/node/blob/main/doc/api/http.md#L1638-L1649) |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects inbound HTTP/1.1 requests that don't have exactly one `Host` field, raising `InvalidHeader` before emitting `Request`. HTTP/1.0 requests and HTTP/1.1 requests with an empty `Host` value are still accepted. Closes #187.

- Updates documentation examples and existing tests to include a `Host` field where required.

<sup>Written for commit c959d78357240e142b0b33b16b9960447a1fcc71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

