### PR TITLE
Refresh performance benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,18 +147,18 @@ not a production server identity.
 
 ## Performance
 
-Against [httptools](https://github.com/MagicStack/httptools) — the C parser
-uvicorn uses — on the same requests, with both verified to extract identical
-data:
+Against [httptools](https://github.com/MagicStack/httptools), the C parser
+Uvicorn uses, on the same requests with each parser's default API:
 
 | Workload          | zttp         | httptools    | zttp vs httptools |
 | ----------------- | -----------: | -----------: | ----------------: |
-| Simple GET        | ~1.24M req/s | ~1.07M req/s | **~1.16x**        |
-| POST + JSON body  | ~1.42M req/s | ~1.25M req/s | **~1.14x**        |
+| Simple GET        | ~1.55M req/s | ~1.07M req/s | **~1.45x**        |
+| POST + JSON body  | ~1.40M req/s | ~1.24M req/s | **~1.13x**        |
 
-zttp beats httptools on 13 of the benchmark suite's 14 workloads while staying
-sans-IO and event-based, and is roughly 15x faster than the pure-Python
-alternative. Run it yourself with `./scripts/bench`.
+zttp beats httptools on all 14 workloads while staying sans-IO and event-based.
+It is roughly 22x faster than the pure-Python alternative. A Uvicorn-shaped
+benchmark that materializes equivalent ASGI scopes measures a 1.16x to 1.52x
+lead. Run the benchmarks yourself with `./scripts/bench`.
 
 These are parser microbenchmarks, and single-digit-percent edges are close to
 run-to-run noise — see
@@ -167,12 +167,10 @@ run-to-run noise — see
 
 ### Why it is fast
 
-- A SWAR newline scanner and comptime-built character-class tables in the Zig
-  core, so the hot loops are branch-light array lookups.
-- The body is emitted as a single `Data` event slicing the parse buffer, rather
-  than copied per callback the way httptools does.
-- The header list is built directly in Zig as `list[tuple[bytes, bytes]]`, with
-  no per-header Python callback.
+- SIMD-accelerated line and field scans with comptime-built character tables.
+- Headers stay in a compact `HeaderBlock` until you access their Python values.
+- The receive path emits one `Data` event per body span and can reuse
+  Python-owned input for large standalone bodies.
 
 ## Correctness & security
 

--- a/benchmarks/http1.py
+++ b/benchmarks/http1.py
@@ -269,7 +269,7 @@ def pieces_of(w: Workload) -> list[bytes]:
 def make_zttp(w: Workload) -> Runner:
     role = zttp.SERVER if w.kind == "request" else zttp.CLIENT
     pieces, messages = pieces_of(w), w.messages
-    Connection, NEED_DATA, EndOfMessage = zttp.Connection, zttp.NEED_DATA, zttp.EndOfMessage
+    Connection, NEED_DATA, Request, EndOfMessage = zttp.Connection, zttp.NEED_DATA, zttp.Request, zttp.EndOfMessage
 
     def run(n: int) -> None:
         for _ in range(n):
@@ -281,7 +281,7 @@ def make_zttp(w: Workload) -> Runner:
                     ev = conn.next_event()
                     if ev is NEED_DATA:
                         break
-                    if type(ev) is EndOfMessage:
+                    if (type(ev) is Request and ev.end_stream) or type(ev) is EndOfMessage:
                         done += 1
                         if done < messages:
                             conn.start_next_cycle()
@@ -493,7 +493,7 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
         for label, fn in parsers:
             samples[label].append(timed(fn, batch))
 
-    per_batch = {label: [batch / dt for dt in batches] for label, batches in samples.items()}
+    per_batch = {label: [batch * w.messages / dt for dt in batches] for label, batches in samples.items()}
     rates: dict[str, float] = {}
     for label, values in per_batch.items():
         p25, median, p75 = _quartiles(values)

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -16,24 +16,40 @@ Uvicorn. Both parsers extract the same request line or status, headers, and body
 
 | Workload | zttp | httptools | zttp vs httptools |
 | --- | ---: | ---: | ---: |
-| wrk default `GET` | 2.42M msg/s | 2.09M msg/s | **1.16x** |
-| httparse `REQ_SHORT` | 2.12M msg/s | 1.79M msg/s | **1.18x** |
-| TFB plaintext, 16x pipelined | 151k msg/s | 161k msg/s | 0.94x |
-| Small API `GET` | 1.24M msg/s | 1.07M msg/s | **1.16x** |
-| `POST` + JSON body | 1.42M msg/s | 1.25M msg/s | **1.14x** |
-| Real-world `GET` (pico/llhttp) | 947k msg/s | 831k msg/s | **1.14x** |
-| Chunked `POST` (llhttp bench) | 875k msg/s | 741k msg/s | **1.18x** |
-| Chrome navigation `GET` | 702k msg/s | 577k msg/s | **1.22x** |
-| k8s ingress proxied `GET` | 688k msg/s | 634k msg/s | **1.08x** |
-| 16KB upload `POST` | 1.11M msg/s | 1.05M msg/s | **1.06x** |
-| 16KB upload, MTU pieces | 441k msg/s | 214k msg/s | **2.06x** |
-| httparse `RESP_SHORT` | 1.79M msg/s | 1.60M msg/s | **1.12x** |
-| JSON API response | 1.46M msg/s | 1.31M msg/s | **1.12x** |
-| Chunked HTML response | 813k msg/s | 784k msg/s | **1.04x** |
+| wrk default `GET` | 2.68M msg/s | 2.02M msg/s | **1.32x** |
+| httparse `REQ_SHORT` | 2.48M msg/s | 1.77M msg/s | **1.41x** |
+| TFB plaintext, 16x pipelined | 3.15M msg/s | 2.52M msg/s | **1.25x** |
+| Small API `GET` | 1.55M msg/s | 1.07M msg/s | **1.45x** |
+| `POST` + JSON body | 1.40M msg/s | 1.24M msg/s | **1.13x** |
+| Real-world `GET` (pico/llhttp) | 1.19M msg/s | 787k msg/s | **1.52x** |
+| Chunked `POST` (llhttp bench) | 943k msg/s | 715k msg/s | **1.31x** |
+| Chrome navigation `GET` | 943k msg/s | 562k msg/s | **1.68x** |
+| k8s ingress proxied `GET` | 978k msg/s | 607k msg/s | **1.61x** |
+| 16KB upload `POST` | 1.08M msg/s | 1.01M msg/s | **1.07x** |
+| 16KB upload, MTU pieces | 510k msg/s | 201k msg/s | **2.55x** |
+| httparse `RESP_SHORT` | 1.88M msg/s | 1.57M msg/s | **1.20x** |
+| JSON API response | 1.47M msg/s | 1.33M msg/s | **1.09x** |
+| Chunked HTML response | 801k msg/s | 793k msg/s | **1.01x** |
 
-zttp is faster on thirteen of the fourteen HTTP/1.1 workloads. The remaining
-gap is the synthetic 16-messages-per-buffer pipelined read, where httptools
-amortizes its connection parser across the whole buffer.
+zttp is faster on all fourteen HTTP/1.1 workloads. The pipelined row counts all
+16 messages in each input buffer.
+
+## Uvicorn integration
+
+The parser benchmark uses each parser's default API. zttp keeps headers in a
+lazy `HeaderBlock`, while httptools delivers them through Python callbacks. The
+Uvicorn benchmark materializes equivalent ASGI scopes before counting a request.
+
+| Workload | Lifecycle | zttp | httptools | zttp vs httptools |
+| --- | --- | ---: | ---: | ---: |
+| Tiny `GET` | Isolated | 1.09M scope/s | 785k scope/s | **1.39x** |
+| Small API `GET` | Isolated | 749k scope/s | 494k scope/s | **1.52x** |
+| Chrome navigation `GET` | Isolated | 458k scope/s | 321k scope/s | **1.43x** |
+| k8s ingress proxied `GET` | Isolated | 483k scope/s | 342k scope/s | **1.41x** |
+| Tiny `GET` | Keep-alive | 1.21M scope/s | 1.04M scope/s | **1.16x** |
+| Small API `GET` | Keep-alive | 811k scope/s | 580k scope/s | **1.40x** |
+| Chrome navigation `GET` | Keep-alive | 498k scope/s | 372k scope/s | **1.34x** |
+| k8s ingress proxied `GET` | Keep-alive | 513k scope/s | 386k scope/s | **1.33x** |
 
 ## HTTP/2
 
@@ -90,8 +106,9 @@ zttp 0.0.24.dev5, h2 4.3.0, and aioquic 1.3.0. zttp used the safety-checked
 The interquartile ratio ranges were roughly 1% to 4% of the median for HTTP/2
 and 2% to 3% for HTTP/3.
 
-The HTTP/1.1 table used the same build mode on Apple Silicon with CPython 3.14
-and httptools 0.8.0. Its run-to-run spread was about 5%.
+The HTTP/1.1 and Uvicorn tables used the same build mode on Apple Silicon with
+CPython 3.14.3, zttp 0.0.27.dev38, and httptools 0.8.0. The HTTP/1.1 table uses
+15 batches. The Uvicorn table uses 11 batches.
 
 !!! info "These are protocol microbenchmarks"
     They measure protocol throughput in isolation, not a full server. In a real
@@ -100,11 +117,12 @@ and httptools 0.8.0. Its run-to-run spread was about 5%.
 
 ## Run the benchmarks
 
-The benchmarks live in `benchmarks/`, one file per protocol.
+The benchmark scripts live in `benchmarks/`.
 
 | File | Compares against |
 | --- | --- |
 | `benchmarks/http1.py` | httptools (C) and h11 (pure Python) |
+| `benchmarks/uvicorn.py` | Uvicorn-shaped ASGI scope construction with httptools |
 | `benchmarks/http2.py` | h2 (pure Python) |
 | `benchmarks/http3.py` | aioquic (Python QUIC with C QPACK) |
 
@@ -117,6 +135,7 @@ This runs all three suites. Run one protocol to forward options to its script:
 ```console
 ./scripts/bench http2 --repeats 5 --only multiplexed
 ./scripts/bench http3 --repeats 5 --only GET
+./scripts/bench uvicorn --lifecycle both
 ```
 
 Each suite verifies both implementations extract or exchange equivalent data
@@ -132,12 +151,12 @@ large uploads, and response parsing.
 
 ## Why it is fast
 
-* **A SWAR newline scan and comptime character tables.** The HTTP/1.1 hot loops
-  use branch-light array lookups instead of per-byte conditionals.
-* **One `Data` event per body span.** httptools copies the body per callback, and
-  Uvicorn then concatenates it. zttp slices the input buffer once.
-* **Headers are built in Zig.** There is no per-header Python callback. zttp
-  constructs the complete header block in the extension.
+* **SIMD scans and comptime character tables.** The HTTP/1.1 hot loops scan
+  lines and fields in native vector-sized blocks.
+* **One `Data` event per body span.** The receive path can reuse Python-owned
+  input for large standalone bodies.
+* **Headers stay compact.** zttp constructs one packed `HeaderBlock` in Zig and
+  materializes Python tuples only when you access them.
 * **Protocol state stays native.** HTTP/2 framing, HPACK, QUIC, and QPACK run in
   the Zig core instead of crossing the Python boundary for each frame or field.
 


### PR DESCRIPTION
## Summary

- Count every message in pipelined HTTP/1 benchmark buffers.
- Refresh the README and reference tables with current results.
- Document the Uvicorn-shaped ASGI scope benchmark and current implementation details.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the performance benchmark suite and published results. Pipelined HTTP/1.1 runs now count every message in the input buffer instead of whole buffers only, which fixes an undercount; on the refreshed runs, zttp beats httptools on all fourteen HTTP/1.1 workloads instead of thirteen.

- Documents the new Uvicorn-shaped ASGI scope benchmark with isolated and keep-alive lifecycle results.
- Updates the "Why it is fast" notes and the version and batch-count details in the reference docs.

<sup>Written for commit 536cd39b0d254ad9a1dddb1d8bc5ecbf50cde924. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

