### PR TITLE
Include Host in wheel smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ skip = "*_i686"
 # only guaranteed stable from rc1 onward.
 enable = ["cpython-prerelease"]
 build-frontend = "build[uv]"
-test-command = 'python -c "import zttp; c = zttp.Connection(zttp.SERVER); c.receive_data(b\"GET / HTTP/1.1\r\n\r\n\"); assert type(c.next_event()).__name__ == \"Request\""'
+test-command = 'python -c "import zttp; c = zttp.Connection(zttp.SERVER); c.receive_data(b\"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n\"); assert type(c.next_event()).__name__ == \"Request\""'
 
 [tool.cibuildwheel.linux]
 # Both glibc (manylinux) and musl (musllinux) on each native arch.


### PR DESCRIPTION
## Summary

Include the required `Host` field in the cibuildwheel installation smoke test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Includes the required `Host` header in the cibuildwheel installation smoke test request so the test passes against HTTP/1.1 servers.

<sup>Written for commit 24af7e44fa77594c79619e544caa688889a66965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

