### PR TITLE
Authenticate QUIC paths before retaining state

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -338,6 +338,8 @@ pub const Connection = struct {
     /// The unauthenticated route for queued Version Negotiation output. It is
     /// bounded to one address and released when the output queue is drained.
     provisional_path: ?ProvisionalPath = null,
+    /// The single peer path awaiting automatic validation after migration.
+    peer_candidate_path_token: ?u64 = null,
     current_path_token: ?u64 = null,
     default_path_token: ?u64 = null,
     /// Local CID sequence number matched by the short-header packet currently
@@ -957,6 +959,24 @@ pub const Connection = struct {
         self.out_path_tokens.clearRetainingCapacity();
         if (self.provisional_path) |path| self.gpa.free(path.state.address);
         self.provisional_path = null;
+        while (true) {
+            var removed = false;
+            var iterator = self.paths.iterator();
+            while (iterator.next()) |entry| {
+                const token = entry.key_ptr.*;
+                if (self.default_path_token == token or self.peer_candidate_path_token == token or
+                    self.pathHasPendingChallenge(token))
+                {
+                    continue;
+                }
+                const address = entry.value_ptr.address;
+                _ = self.paths.remove(token);
+                self.gpa.free(address);
+                removed = true;
+                break;
+            }
+            if (!removed) break;
+        }
     }
 
     // ---- STREAM send -----------------------------------------------------------
@@ -2496,6 +2516,7 @@ pub const Connection = struct {
             try self.openPacket(pkt, pn_offset, space, long, st.recv_keys orelse return error.Dropped, null);
         defer self.gpa.free(opened.work);
         defer self.gpa.free(opened.plaintext);
+        if (st.recv_ranges.shouldIgnore(opened.pn)) return;
         try self.recordAuthenticatedPath(context);
         if (peer_scid_candidate) |candidate| {
             // RFC 9000 7.2 permits adoption only after packet authentication.
@@ -2515,7 +2536,6 @@ pub const Connection = struct {
         // (RFC 9000 8.1).
         if (space == .handshake) self.validateCurrentPath();
 
-        if (st.recv_ranges.shouldIgnore(opened.pn)) return;
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
         st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
         try self.dispatchFrames(opened.payload, space, long, context.now);
@@ -2528,14 +2548,39 @@ pub const Connection = struct {
     fn recordAuthenticatedPath(self: *Connection, context: *ReceiveContext) Error!void {
         if (context.path_recorded) return;
         const addr = context.peer_address orelse return;
+        const candidate = std.hash.Wyhash.hash(0, addr);
+        if (!self.paths.contains(candidate) and self.default_path_token != null and
+            self.default_path_token.? != candidate)
+        {
+            if (self.peer_candidate_path_token) |previous| {
+                if (previous != candidate) {
+                    for (self.out_path_tokens.items) |queued| {
+                        if (queued == previous) return error.Dropped;
+                    }
+                    self.removePendingPathChallengesFor(previous);
+                    if (self.paths.fetchRemove(previous)) |entry| self.gpa.free(entry.value.address);
+                    self.peer_candidate_path_token = null;
+                }
+            }
+        }
         const pt = try self.pathTokenForAddress(addr);
         const new_peer_path = self.default_path_token != null and self.default_path_token.? != pt;
         self.current_path_token = pt;
         const p = self.paths.getPtr(pt).?;
-        p.recv_bytes += context.datagram_len;
+        if (self.provisional_path) |*provisional| {
+            if (provisional.token == pt and std.mem.eql(u8, provisional.state.address, addr)) {
+                p.recv_bytes = p.recv_bytes +| provisional.state.recv_bytes;
+                p.sent_bytes = p.sent_bytes +| provisional.state.sent_bytes;
+                provisional.state.recv_bytes = 0;
+                provisional.state.sent_bytes = 0;
+            }
+        }
+        p.recv_bytes = p.recv_bytes +| context.datagram_len;
         if (self.default_path_token == null) {
             self.default_path_token = pt;
             if (self.address_validated) p.validated = true;
+        } else if (new_peer_path and !p.validated and self.peer_candidate_path_token == null) {
+            self.peer_candidate_path_token = pt;
         }
         if (self.handshake_confirmed and new_peer_path and !p.validated) {
             try self.queueAutomaticPathChallenge(pt, context.now);
@@ -2844,6 +2889,7 @@ pub const Connection = struct {
         if (self.current_path_token) |pt| {
             if (self.paths.getPtr(pt)) |p| p.validated = true;
             self.default_path_token = pt;
+            if (self.peer_candidate_path_token == pt) self.peer_candidate_path_token = null;
         }
         self.address_validated = true;
     }
@@ -3657,6 +3703,88 @@ test "unauthenticated datagram does not retain path state" {
     try conn.receiveDatagramFrom(dgram, 1000, peer_address);
     const token = std.hash.Wyhash.hash(0, peer_address);
     try testing.expect(conn.pathAddress(token) == null);
+}
+
+test "replayed authenticated datagrams do not retain new path state" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x09 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+
+    const frames = [_]u8{0x01} ++ [_]u8{0x00} ** 19;
+    const datagram = try testBuildApp(gpa, &dcid, 0, &frames);
+    defer gpa.free(datagram);
+
+    try conn.receiveDatagramFrom(datagram, 1000, "203.0.113.1:4433");
+    conn.clearSend();
+    try conn.receiveDatagramFrom(datagram, 2000, "203.0.113.2:4433");
+    try conn.receiveDatagramFrom(datagram, 3000, "203.0.113.3:4433");
+
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, "203.0.113.1:4433")) != null);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, "203.0.113.2:4433")) == null);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, "203.0.113.3:4433")) == null);
+}
+
+test "authenticated migration retains one unvalidated peer path" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x0a };
+    const addr_a = "198.51.100.1:4433";
+    const addr_b = "198.51.100.2:4433";
+    const addr_c = "198.51.100.3:4433";
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.handshake_confirmed = true;
+
+    const frames = [_]u8{0x01} ++ [_]u8{0x00} ** 19;
+    const first = try testBuildApp(gpa, &dcid, 0, &frames);
+    defer gpa.free(first);
+    const second = try testBuildApp(gpa, &dcid, 1, &frames);
+    defer gpa.free(second);
+    const third = try testBuildApp(gpa, &dcid, 2, &frames);
+    defer gpa.free(third);
+
+    try conn.receiveDatagramFrom(first, 1000, addr_a);
+    conn.clearSend();
+    try conn.receiveDatagramFrom(second, 2000, addr_b);
+    try conn.receiveDatagramFrom(third, 3000, addr_c);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, addr_b)) != null);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, addr_c)) == null);
+
+    conn.clearSend();
+    try conn.receiveDatagramFrom(third, 4000, addr_c);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, addr_b)) == null);
+    try testing.expect(conn.pathAddress(std.hash.Wyhash.hash(0, addr_c)) != null);
+}
+
+test "authenticated path promotion preserves provisional amplification credit" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xe1, 0xe2, 0xe3, 0xe4 };
+    const peer_address = "203.0.113.1:4433";
+    var server = try Connection.init(gpa, .server, &dcid);
+    defer server.deinit();
+    testInstallAppKeys(&server);
+    server.address_validated = false;
+
+    var unsupported: std.ArrayListUnmanaged(u8) = .empty;
+    defer unsupported.deinit(gpa);
+    _ = try packet.writeLongHeader(&unsupported, gpa, .initial, 0x0a0a_0a0a, &dcid, "cli", "", 1, 1);
+    try unsupported.appendNTimes(gpa, 0, constants.MIN_INITIAL_DATAGRAM - unsupported.items.len);
+    try server.receiveDatagramFrom(unsupported.items, 1000, peer_address);
+
+    const frames = [_]u8{0x01} ++ [_]u8{0x00} ** 19;
+    const authenticated = try testBuildApp(gpa, &dcid, 0, &frames);
+    defer gpa.free(authenticated);
+    try server.receiveDatagramFrom(authenticated, 2000, peer_address);
+
+    const before = server.datagramLengths().len;
+    try server.sendStreamData(1, &([_]u8{0x42} ** 1000), false);
+    try server.flushSend(3000);
+    try testing.expect(server.datagramLengths().len > before);
+    var sent_bytes: usize = 0;
+    for (server.datagramLengths()) |len| sent_bytes += len;
+    try testing.expect(sent_bytes <= (unsupported.items.len + authenticated.len) * constants.AMPLIFICATION_FACTOR);
 }
 
 test "PATH_CHALLENGE elicits a matching PATH_RESPONSE" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -171,6 +171,7 @@ const ReceiveContext = struct {
     datagram_len: usize,
     peer_address: ?[]const u8,
     path_recorded: bool = false,
+    provisional_path_recorded: bool = false,
     auto_path_challenge_queued: bool = false,
 };
 
@@ -201,6 +202,11 @@ const PathState = struct {
     recv_bytes: u64 = 0,
     sent_bytes: u64 = 0,
     validated: bool = false,
+};
+
+const ProvisionalPath = struct {
+    token: u64,
+    state: PathState,
 };
 
 /// A connection id the peer issued in NEW_CONNECTION_ID, retained for future path
@@ -329,6 +335,9 @@ pub const Connection = struct {
     /// retains the most recent peer path so application writes queued after
     /// receive_datagram still have a routable destination.
     paths: std.AutoHashMapUnmanaged(u64, PathState) = .empty,
+    /// The unauthenticated route for queued Version Negotiation output. It is
+    /// bounded to one address and released when the output queue is drained.
+    provisional_path: ?ProvisionalPath = null,
     current_path_token: ?u64 = null,
     default_path_token: ?u64 = null,
     /// Local CID sequence number matched by the short-header packet currently
@@ -685,6 +694,7 @@ pub const Connection = struct {
         var path_it = self.paths.valueIterator();
         while (path_it.next()) |p| self.gpa.free(p.address);
         self.paths.deinit(self.gpa);
+        if (self.provisional_path) |path| self.gpa.free(path.state.address);
         if (self.initial_token) |t| self.gpa.free(t);
         for (self.new_tokens.items) |t| self.gpa.free(t);
         self.new_tokens.deinit(self.gpa);
@@ -865,8 +875,10 @@ pub const Connection = struct {
     /// Resolve an address-aware path token to the opaque peer address supplied by
     /// the integrator.
     pub fn pathAddress(self: *const Connection, token: u64) ?[]const u8 {
-        const p = self.paths.get(token) orelse return null;
-        return p.address;
+        if (self.paths.get(token)) |path| return path.address;
+        const provisional = self.provisional_path orelse return null;
+        if (provisional.token != token) return null;
+        return provisional.state.address;
     }
 
     /// Switch subsequent packets to a peer-issued connection id (RFC 9000 5.1).
@@ -943,6 +955,8 @@ pub const Connection = struct {
         self.out.clearRetainingCapacity();
         self.out_lengths.clearRetainingCapacity();
         self.out_path_tokens.clearRetainingCapacity();
+        if (self.provisional_path) |path| self.gpa.free(path.state.address);
+        self.provisional_path = null;
     }
 
     // ---- STREAM send -----------------------------------------------------------
@@ -2258,7 +2272,7 @@ pub const Connection = struct {
         const prefix = packet.parseLongPrefix(buf) catch return error.Dropped;
         if (prefix.version == 0) return self.receiveVersionNegotiation(prefix, buf);
         if (prefix.version != constants.VERSION_1) {
-            if (self.role == .server) try self.sendVersionNegotiation(prefix);
+            if (self.role == .server) try self.sendVersionNegotiation(prefix, context);
             return buf.len;
         }
         const hdr = packet.parseLong(buf) catch return error.Dropped;
@@ -2286,11 +2300,37 @@ pub const Connection = struct {
         return total;
     }
 
-    fn sendVersionNegotiation(self: *Connection, prefix: packet.LongPrefix) Error!void {
+    fn sendVersionNegotiation(self: *Connection, prefix: packet.LongPrefix, context: *ReceiveContext) Error!void {
         var out: std.ArrayListUnmanaged(u8) = .empty;
         defer out.deinit(self.gpa);
         packet.writeVersionNegotiation(&out, self.gpa, prefix.scid, prefix.dcid) catch return error.OutOfMemory;
+        var provisional_created = false;
+        if (context.peer_address) |address| {
+            const token = self.current_path_token.?;
+            if (!self.paths.contains(token)) {
+                if (self.provisional_path) |*path| {
+                    if (path.token != token or !std.mem.eql(u8, path.state.address, address)) return;
+                    if (!context.provisional_path_recorded) path.state.recv_bytes += context.datagram_len;
+                } else {
+                    const owned = self.gpa.dupe(u8, address) catch return error.OutOfMemory;
+                    self.provisional_path = .{
+                        .token = token,
+                        .state = .{ .address = owned, .recv_bytes = context.datagram_len },
+                    };
+                    provisional_created = true;
+                }
+                context.provisional_path_recorded = true;
+            }
+        }
+        errdefer if (provisional_created) {
+            self.gpa.free(self.provisional_path.?.state.address);
+            self.provisional_path = null;
+        };
         if (!self.canSendDatagram(out.items.len)) {
+            if (provisional_created) {
+                self.gpa.free(self.provisional_path.?.state.address);
+                self.provisional_path = null;
+            }
             return;
         }
         self.out.appendSlice(self.gpa, out.items) catch return error.OutOfMemory;
@@ -2774,7 +2814,11 @@ pub const Connection = struct {
     fn canSendDatagram(self: *Connection, datagram_len: usize) bool {
         if (self.role != .server) return true;
         if (self.sendPathToken()) |pt| {
-            const p = self.paths.get(pt) orelse return false;
+            const p = self.paths.get(pt) orelse blk: {
+                const provisional = self.provisional_path orelse return false;
+                if (provisional.token != pt) return false;
+                break :blk provisional.state;
+            };
             if (p.validated) return true;
             return withinAmplificationBudget(p.sent_bytes, p.recv_bytes, datagram_len);
         }
@@ -2784,7 +2828,11 @@ pub const Connection = struct {
 
     fn recordPathSent(self: *Connection, datagram_len: usize) void {
         if (self.sendPathToken()) |pt| {
-            if (self.paths.getPtr(pt)) |p| p.sent_bytes += datagram_len;
+            if (self.paths.getPtr(pt)) |p| {
+                p.sent_bytes += datagram_len;
+            } else if (self.provisional_path) |*path| {
+                if (path.token == pt) path.state.sent_bytes += datagram_len;
+            }
         }
     }
 
@@ -5597,6 +5645,7 @@ test "an unauthenticated long header cannot replace the peer connection id" {
 test "server answers an unsupported long-header version with Version Negotiation" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0xe1, 0xe2, 0xe3, 0xe4 };
+    const peer_address = "203.0.113.1:4433";
     var server = try Connection.initServer(gpa, &dcid, testServerConfig());
     defer server.deinit();
 
@@ -5604,9 +5653,11 @@ test "server answers an unsupported long-header version with Version Negotiation
     defer bad.deinit(gpa);
     _ = try packet.writeLongHeader(&bad, gpa, .initial, 0x0a0a_0a0a, &dcid, "cli", "", 1, 1);
     try bad.append(gpa, 0x00);
-    try server.receiveDatagram(bad.items, 1000);
+    try server.receiveDatagramFrom(bad.items, 1000, peer_address);
 
     try testing.expectEqual(@as(usize, 1), server.datagramLengths().len);
+    const token = server.datagramPathTokens()[0].?;
+    try testing.expectEqualStrings(peer_address, server.pathAddress(token).?);
     const vn = server.datagramsToSend()[0..server.datagramLengths()[0]];
     const p = try packet.parseLongPrefix(vn);
     try testing.expectEqual(@as(u32, 0), p.version);
@@ -5614,6 +5665,31 @@ test "server answers an unsupported long-header version with Version Negotiation
     try testing.expectEqualSlices(u8, &dcid, p.scid);
     try testing.expectEqual(@as(usize, 4), vn[p.header_len..].len);
     try testing.expectEqual(constants.VERSION_1, std.mem.readInt(u32, vn[p.header_len..][0..4], .big));
+
+    server.clearSend();
+    try testing.expect(server.pathAddress(token) == null);
+}
+
+test "server bounds provisional Version Negotiation routes until send clear" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xe1, 0xe2, 0xe3, 0xe4 };
+    var server = try Connection.initServer(gpa, &dcid, testServerConfig());
+    defer server.deinit();
+
+    var bad: std.ArrayListUnmanaged(u8) = .empty;
+    defer bad.deinit(gpa);
+    _ = try packet.writeLongHeader(&bad, gpa, .initial, 0x0a0a_0a0a, &dcid, "cli", "", 1, 1);
+    try bad.append(gpa, 0x00);
+
+    try server.receiveDatagramFrom(bad.items, 1000, "203.0.113.1:4433");
+    try server.receiveDatagramFrom(bad.items, 2000, "203.0.113.2:4433");
+    try testing.expectEqual(@as(usize, 1), server.datagramLengths().len);
+
+    server.clearSend();
+    try server.receiveDatagramFrom(bad.items, 3000, "203.0.113.2:4433");
+    try testing.expectEqual(@as(usize, 1), server.datagramLengths().len);
+    const token = server.datagramPathTokens()[0].?;
+    try testing.expectEqualStrings("203.0.113.2:4433", server.pathAddress(token).?);
 }
 
 test "client ignores Version Negotiation that still advertises QUIC v1" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -166,6 +166,14 @@ const OpenedPacket = struct {
     key_phase: bool,
 };
 
+const ReceiveContext = struct {
+    now: u64,
+    datagram_len: usize,
+    peer_address: ?[]const u8,
+    path_recorded: bool = false,
+    auto_path_challenge_queued: bool = false,
+};
+
 /// A STOP_SENDING owed to the peer: the error code, and whether a frame carrying it is
 /// currently in flight (so flushSend does not re-send while one is unacked).
 const StopSending = struct { code: u64, in_flight: bool = false };
@@ -2212,26 +2220,13 @@ pub const Connection = struct {
         self.recv_bytes += datagram.len;
         const previous_path = self.current_path_token;
         defer self.current_path_token = previous_path;
-        var auto_path_challenge_queued = false;
+        var context = ReceiveContext{ .now = now, .datagram_len = datagram.len, .peer_address = peer_address };
         if (peer_address) |addr| {
-            const pt = try self.pathTokenForAddress(addr);
-            const new_peer_path = self.default_path_token != null and self.default_path_token.? != pt;
-            self.current_path_token = pt;
-            if (self.default_path_token == null) {
-                self.default_path_token = pt;
-                if (self.address_validated) self.paths.getPtr(pt).?.validated = true;
-            }
-            if (self.paths.getPtr(pt)) |p| {
-                p.recv_bytes += datagram.len;
-                if (self.handshake_confirmed and new_peer_path and !p.validated) {
-                    try self.queueAutomaticPathChallenge(pt, now);
-                    auto_path_challenge_queued = true;
-                }
-            }
+            self.current_path_token = std.hash.Wyhash.hash(0, addr);
         }
         var rest = datagram;
         while (rest.len > 0) {
-            const consumed = self.receivePacket(rest, now, datagram.len) catch |e| switch (e) {
+            const consumed = self.receivePacket(rest, &context) catch |e| switch (e) {
                 // A short-header packet has no length field, so an undecryptable one
                 // ends the walk (its boundary is the datagram end). A long-header
                 // packet whose boundary IS known returns its length from receiveLong
@@ -2246,7 +2241,7 @@ pub const Connection = struct {
         // CRYPTO that stalled on the limit (RFC 9000 8.1).
         try self.flushCrypto(.initial, now);
         try self.flushCrypto(.handshake, now);
-        if (auto_path_challenge_queued) {
+        if (context.auto_path_challenge_queued) {
             self.flushPathChallenges(.application, now) catch |e| switch (e) {
                 error.AmplificationLimited => {},
                 else => return e,
@@ -2254,12 +2249,12 @@ pub const Connection = struct {
         }
     }
 
-    fn receivePacket(self: *Connection, buf: []const u8, now: u64, datagram_len: usize) Error!usize {
-        if (packet.isLong(buf[0])) return self.receiveLong(buf, now, datagram_len);
-        return self.receiveShort(buf, now);
+    fn receivePacket(self: *Connection, buf: []const u8, context: *ReceiveContext) Error!usize {
+        if (packet.isLong(buf[0])) return self.receiveLong(buf, context);
+        return self.receiveShort(buf, context);
     }
 
-    fn receiveLong(self: *Connection, buf: []const u8, now: u64, datagram_len: usize) Error!usize {
+    fn receiveLong(self: *Connection, buf: []const u8, context: *ReceiveContext) Error!usize {
         const prefix = packet.parseLongPrefix(buf) catch return error.Dropped;
         if (prefix.version == 0) return self.receiveVersionNegotiation(prefix, buf);
         if (prefix.version != constants.VERSION_1) {
@@ -2267,7 +2262,7 @@ pub const Connection = struct {
             return buf.len;
         }
         const hdr = packet.parseLong(buf) catch return error.Dropped;
-        if (hdr.ltype == .retry) return self.receiveRetry(hdr, buf, now);
+        if (hdr.ltype == .retry) return self.receiveRetry(hdr, buf, context);
         const space: Space = switch (hdr.ltype) {
             .initial => .initial,
             .handshake => .handshake,
@@ -2276,7 +2271,7 @@ pub const Connection = struct {
         };
         const total = hdr.pn_offset + @as(usize, @intCast(hdr.length));
         if (total > buf.len) return error.Dropped;
-        if (self.role == .server and hdr.ltype == .initial and datagram_len < constants.MIN_INITIAL_DATAGRAM) {
+        if (self.role == .server and hdr.ltype == .initial and context.datagram_len < constants.MIN_INITIAL_DATAGRAM) {
             return error.Dropped;
         }
         // A long header's length is known, so a packet we cannot decrypt (no keys
@@ -2284,7 +2279,7 @@ pub const Connection = struct {
         // length so the caller keeps walking any coalesced packets behind it
         // (e.g. a Handshake packet coalesced after an Initial). RFC 9000 12.2.
         const peer_scid_candidate = if (hdr.ltype == .initial) hdr.scid else null;
-        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, peer_scid_candidate, now) catch |e| switch (e) {
+        self.decryptAndDispatch(buf[0..total], hdr.pn_offset, space, true, peer_scid_candidate, context) catch |e| switch (e) {
             error.Dropped => return total,
             else => return e,
         };
@@ -2326,12 +2321,13 @@ pub const Connection = struct {
         return error.ProtocolViolation;
     }
 
-    fn receiveRetry(self: *Connection, hdr: packet.LongHeader, buf: []const u8, now: u64) Error!usize {
+    fn receiveRetry(self: *Connection, hdr: packet.LongHeader, buf: []const u8, context: *ReceiveContext) Error!usize {
         if (self.role != .client) return error.Dropped;
         if (self.retried or self.spaces[@intFromEnum(Space.handshake)].recv_keys != null) return error.Dropped;
         if (!std.mem.eql(u8, hdr.dcid, self.scid)) return error.Dropped;
         if (hdr.scid.len == 0 or hdr.token.len == 0) return error.Dropped;
         if (!(packet.validateRetryIntegrity(self.gpa, buf, self.peer_scid) catch return error.OutOfMemory)) return error.Dropped;
+        try self.recordAuthenticatedPath(context);
 
         const token = self.gpa.dupe(u8, hdr.token) catch return error.OutOfMemory;
         errdefer self.gpa.free(token);
@@ -2355,11 +2351,11 @@ pub const Connection = struct {
         st.send_keys = initial.client;
         if (st.crypto_send.end() > 0) try st.crypto_send.onLost(0, st.crypto_send.end(), false);
         st.crypto_sent.clearRetainingCapacity();
-        try self.flushCrypto(.initial, now);
+        try self.flushCrypto(.initial, context.now);
         return buf.len;
     }
 
-    fn receiveShort(self: *Connection, buf: []const u8, now: u64) Error!usize {
+    fn receiveShort(self: *Connection, buf: []const u8, context: *ReceiveContext) Error!usize {
         const parsed = self.parseShortForLocalCid(buf) catch {
             if (self.detectStatelessReset(buf)) return buf.len;
             return error.Dropped;
@@ -2368,7 +2364,7 @@ pub const Connection = struct {
         self.current_packet_local_cid_seq = parsed.local_cid_seq;
         defer self.current_packet_local_cid_seq = previous_cid_seq;
         // A short-header packet is the rest of the datagram (no length field).
-        self.decryptAndDispatch(buf, parsed.hdr.pn_offset, .application, false, null, now) catch |e| switch (e) {
+        self.decryptAndDispatch(buf, parsed.hdr.pn_offset, .application, false, null, context) catch |e| switch (e) {
             error.Dropped => {
                 if (self.detectStatelessReset(buf)) return buf.len;
                 return error.Dropped;
@@ -2449,7 +2445,7 @@ pub const Connection = struct {
         space: Space,
         long: bool,
         peer_scid_candidate: ?[]const u8,
-        now: u64,
+        context: *ReceiveContext,
     ) Error!void {
         const st = &self.spaces[@intFromEnum(space)];
         const opened = if (space == .application and !long)
@@ -2460,6 +2456,7 @@ pub const Connection = struct {
             try self.openPacket(pkt, pn_offset, space, long, st.recv_keys orelse return error.Dropped, null);
         defer self.gpa.free(opened.work);
         defer self.gpa.free(opened.plaintext);
+        try self.recordAuthenticatedPath(context);
         if (peer_scid_candidate) |candidate| {
             // RFC 9000 7.2 permits adoption only after packet authentication.
             if (!self.peer_scid_set and candidate.len > 0) {
@@ -2481,11 +2478,30 @@ pub const Connection = struct {
         if (st.recv_ranges.shouldIgnore(opened.pn)) return;
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
         st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
-        try self.dispatchFrames(opened.payload, space, long, now);
-        self.resetIdleTimer(now);
+        try self.dispatchFrames(opened.payload, space, long, context.now);
+        self.resetIdleTimer(context.now);
 
         // Acknowledge the space if it carried an ack-eliciting frame this packet.
-        if (st.ack_pending) try self.sendAck(space, now);
+        if (st.ack_pending) try self.sendAck(space, context.now);
+    }
+
+    fn recordAuthenticatedPath(self: *Connection, context: *ReceiveContext) Error!void {
+        if (context.path_recorded) return;
+        const addr = context.peer_address orelse return;
+        const pt = try self.pathTokenForAddress(addr);
+        const new_peer_path = self.default_path_token != null and self.default_path_token.? != pt;
+        self.current_path_token = pt;
+        const p = self.paths.getPtr(pt).?;
+        p.recv_bytes += context.datagram_len;
+        if (self.default_path_token == null) {
+            self.default_path_token = pt;
+            if (self.address_validated) p.validated = true;
+        }
+        if (self.handshake_confirmed and new_peer_path and !p.validated) {
+            try self.queueAutomaticPathChallenge(pt, context.now);
+            context.auto_path_challenge_queued = true;
+        }
+        context.path_recorded = true;
     }
 
     fn openApplicationPacket(self: *Connection, pkt: []const u8, pn_offset: usize) Error!OpenedPacket {
@@ -3575,6 +3591,24 @@ test "1-RTT packets obey the anti-amplification budget" {
     server.recv_bytes = 100;
     try server.sendPing(.application, 2000);
     try testing.expectEqual(@as(usize, 1), server.datagramLengths().len);
+}
+
+test "unauthenticated datagram does not retain path state" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+    const peer_address = "203.0.113.1:4433";
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+
+    const frames = [_]u8{ 0x01, 0x00, 0x00 };
+    const dgram = try testBuildApp(gpa, &dcid, 0, &frames);
+    defer gpa.free(dgram);
+    dgram[dgram.len - 1] ^= 1;
+
+    try conn.receiveDatagramFrom(dgram, 1000, peer_address);
+    const token = std.hash.Wyhash.hash(0, peer_address);
+    try testing.expect(conn.pathAddress(token) == null);
 }
 
 test "PATH_CHALLENGE elicits a matching PATH_RESPONSE" {


### PR DESCRIPTION
## Summary

Retain address-aware QUIC path state only after packet authentication or Retry integrity validation. This prevents unauthenticated address churn from growing connection memory while preserving path accounting for accepted packets.

Closes #255.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unauthenticated QUIC datagrams no longer grow connection path state, fixing a memory leak risk from address churn. Path accounting now starts only after a packet is authenticated or a Retry passes integrity validation; the previously recorded receive bytes, validated flags, and automatic path challenges are unchanged for accepted packets.

- Records path state once per datagram after authentication or Retry validation.
- Threads a `ReceiveContext` through the receive path to carry datagram metadata without repeated parsing.
- Adds a test proving a corrupted (unauthenticated) datagram leaves no path entry.
- Closes #255.

<sup>Written for commit cb3a6e1cadd10453029b09106408151ce23f71e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

