### PR TITLE
Make QUIC receive stream updates failure-atomic

### DIFF
--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -45,6 +45,15 @@ pub const AckRanges = struct {
         return pn < self.ignore_below;
     }
 
+    /// Reserve any storage `add` will need for `pn` without recording it.
+    pub fn ensureCanAdd(self: *AckRanges, gpa: std.mem.Allocator, pn: u64) !void {
+        for (self.ranges.items) |range| {
+            if (pn >= range.lo and pn <= range.hi) return;
+            if (pn == range.hi + 1 or pn + 1 == range.lo) return;
+        }
+        if (self.ranges.items.len < MAX_RANGES) try self.ranges.ensureUnusedCapacity(gpa, 1);
+    }
+
     /// Record that packet number `pn` was received. Extends or merges an existing
     /// range, or inserts a new one in descending order. If the list is at capacity
     /// the oldest (smallest) range is dropped - the peer will simply re-send those

--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -45,6 +45,11 @@ pub const AckRanges = struct {
         return pn < self.ignore_below;
     }
 
+    /// Reserve any storage that recording one more packet number could need.
+    pub fn ensureCanAdd(self: *AckRanges, gpa: std.mem.Allocator) !void {
+        if (self.ranges.items.len < MAX_RANGES) try self.ranges.ensureUnusedCapacity(gpa, 1);
+    }
+
     /// Record that packet number `pn` was received. Extends or merges an existing
     /// range, or inserts a new one in descending order. If the list is at capacity
     /// the oldest (smallest) range is dropped - the peer will simply re-send those

--- a/src/core/quic/ack_ranges.zig
+++ b/src/core/quic/ack_ranges.zig
@@ -45,11 +45,6 @@ pub const AckRanges = struct {
         return pn < self.ignore_below;
     }
 
-    /// Reserve any storage that recording one more packet number could need.
-    pub fn ensureCanAdd(self: *AckRanges, gpa: std.mem.Allocator) !void {
-        if (self.ranges.items.len < MAX_RANGES) try self.ranges.ensureUnusedCapacity(gpa, 1);
-    }
-
     /// Record that packet number `pn` was received. Extends or merges an existing
     /// range, or inserts a new one in descending order. If the list is at capacity
     /// the oldest (smallest) range is dropped - the peer will simply re-send those

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -768,6 +768,8 @@ pub const Connection = struct {
     /// fit one datagram. A long header (Initial/Handshake) carries our scid + a
     /// length field; a short header (Application) runs to the datagram end.
     fn buildPacket(self: *Connection, space: Space, frames: []const u8, ack_eliciting: bool, now: u64) Error!u64 {
+        if (self.receive_failure) |err| return err;
+        if (self.closed) return error.ProtocolViolation;
         const st = &self.spaces[@intFromEnum(space)];
         const use_zero_rtt = space == .application and st.send_keys == null and st.zero_rtt_send_keys != null;
         assertFramesAllowedIn(space, use_zero_rtt, frames); // no illegal frames for the packet type
@@ -2568,7 +2570,8 @@ pub const Connection = struct {
                 // Frame handlers may have committed state, so this packet must never be replayed or acknowledged.
                 self.receive_failure = err;
                 self.closed = true;
-                st.ack_pending = false;
+                for (&self.spaces) |*state| state.ack_pending = false;
+                self.clearSend();
             }
             return err;
         };
@@ -3366,6 +3369,7 @@ fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
     const previous_total = conn.conn_received_total;
     var head_frame: std.ArrayListUnmanaged(u8) = .empty;
     defer head_frame.deinit(gpa);
+    try frame.encodePathChallenge(&head_frame, gpa, .{ 1, 2, 3, 4, 5, 6, 7, 8 });
     try frame.encodeStream(&head_frame, gpa, 0, 0, "hello ", false);
     const head = try testBuildApp(gpa, &dcid, 1, head_frame.items);
     defer gpa.free(head);
@@ -3385,6 +3389,12 @@ fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
             try testing.expectEqual(@as(usize, 0), s.pending.items.len);
             try testing.expect(s.isFinished());
             try testing.expect(conn.spaces[@intFromEnum(Space.application)].recv_ranges.contains(1));
+        }
+        if (conn.receive_failure != null) {
+            try testing.expectEqual(@as(usize, 0), conn.datagramLengths().len);
+            for (&conn.spaces) |*state| try testing.expect(!state.ack_pending);
+            conn.handshake_confirmed = true;
+            try testing.expectError(error.OutOfMemory, conn.sendNewToken("token", 3000));
         }
         return err;
     };

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -108,6 +108,8 @@ const SpaceState = struct {
     recv_key_phase: bool = false,
     send_key_phase: bool = false,
     next_pn: u64 = 0,
+    /// The largest authenticated packet number, used only to decode truncated packet numbers.
+    largest_authenticated_pn: ?u64 = null,
     largest_recv_pn: ?u64 = null,
     rec: recovery.Space = .{},
     crypto: crypto_stream.CryptoStream,
@@ -381,6 +383,8 @@ pub const Connection = struct {
     /// non-zero max_idle_timeout.
     idle_deadline: ?u64 = null,
     idle_timed_out: bool = false,
+    /// A mid-dispatch allocation failure leaves the receive state terminal.
+    receive_failure: ?Error = null,
     closed: bool = false,
     /// The details of a CONNECTION_CLOSE received from the peer (RFC 9000 19.19),
     /// captured so the integrator can report why the peer closed - not just that it
@@ -1314,6 +1318,7 @@ pub const Connection = struct {
     /// detection routes lost pns back into SendStream.onLost, and the PTO timer
     /// probes tail packets that have no later ACK to trigger threshold loss.
     pub fn flushSend(self: *Connection, now: u64) Error!void {
+        if (self.receive_failure) |err| return err;
         if (self.closed) return;
         const space = Space.application;
         const st = &self.spaces[@intFromEnum(space)];
@@ -1689,6 +1694,7 @@ pub const Connection = struct {
     }
 
     pub fn nextTimeout(self: *Connection) ?u64 {
+        if (self.receive_failure != null) return null;
         if (self.closed) return null;
         var earliest: ?u64 = null;
         if (self.idle_deadline) |t| earliest = minOpt(earliest, t);
@@ -1705,6 +1711,7 @@ pub const Connection = struct {
     /// oldest unacked STREAM range so the next flushSend resends it (or a PING). No
     /// I/O happens here - the next flushSend emits whatever was queued.
     pub fn onTimeout(self: *Connection, now: u64) Error!void {
+        if (self.receive_failure) |err| return err;
         if (self.closed) return error.ProtocolViolation;
         if (self.idle_deadline) |deadline| {
             if (now >= deadline) {
@@ -2165,8 +2172,8 @@ pub const Connection = struct {
 
     /// Process one received UDP datagram: walk the coalesced packets, decrypt and
     /// dispatch each. `now` is a monotonic microsecond timestamp. A packet that
-    /// fails authentication is skipped (not fatal); a protocol violation poisons
-    /// the connection.
+    /// fails authentication is skipped (not fatal); a protocol violation or a
+    /// mid-dispatch allocation failure poisons the connection.
     pub fn receiveDatagram(self: *Connection, datagram: []const u8, now: u64) Error!void {
         self.receiveDatagramOn(datagram, now, null) catch |err| return self.closeForReceiveError(err);
     }
@@ -2198,6 +2205,7 @@ pub const Connection = struct {
     }
 
     fn receiveDatagramOn(self: *Connection, datagram: []const u8, now: u64, peer_address: ?[]const u8) Error!void {
+        if (self.receive_failure) |err| return err;
         if (self.closed) return error.ProtocolViolation;
         if (peer_address) |addr| {
             // A spoofable path change is silently dropped, never connection-fatal.
@@ -2460,6 +2468,10 @@ pub const Connection = struct {
             try self.openPacket(pkt, pn_offset, space, long, st.recv_keys orelse return error.Dropped, null);
         defer self.gpa.free(opened.work);
         defer self.gpa.free(opened.plaintext);
+        st.largest_authenticated_pn = if (st.largest_authenticated_pn) |largest|
+            @max(largest, opened.pn)
+        else
+            opened.pn;
         if (peer_scid_candidate) |candidate| {
             // RFC 9000 7.2 permits adoption only after packet authentication.
             if (!self.peer_scid_set and candidate.len > 0) {
@@ -2479,9 +2491,18 @@ pub const Connection = struct {
         if (space == .handshake) self.validateCurrentPath();
 
         if (st.recv_ranges.shouldIgnore(opened.pn)) return;
-        st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
-        st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
-        try self.dispatchFrames(opened.payload, space, long, now);
+        st.recv_ranges.ensureCanAdd(self.gpa, opened.pn) catch return error.OutOfMemory;
+        self.dispatchFrames(opened.payload, space, long, now) catch |err| {
+            if (err == error.OutOfMemory) {
+                // Frame handlers may have committed state, so this packet must never be replayed or acknowledged.
+                self.receive_failure = err;
+                self.closed = true;
+                st.ack_pending = false;
+            }
+            return err;
+        };
+        st.recv_ranges.add(self.gpa, opened.pn) catch unreachable; // ensureCanAdd reserved the only possible allocation.
+        st.largest_recv_pn = if (st.largest_recv_pn) |largest| @max(largest, opened.pn) else opened.pn;
         self.resetIdleTimer(now);
 
         // Acknowledge the space if it carried an ack-eliciting frame this packet.
@@ -2543,7 +2564,7 @@ pub const Connection = struct {
         var truncated: u64 = 0;
         for (work[pn_offset .. pn_offset + pn_len]) |b| truncated = (truncated << 8) | b;
         const st = &self.spaces[@intFromEnum(space)];
-        const pn = packet.decodePacketNumber(st.largest_recv_pn orelse 0, truncated, pn_len);
+        const pn = packet.decodePacketNumber(st.largest_authenticated_pn orelse 0, truncated, pn_len);
 
         const header = work[0 .. pn_offset + pn_len];
         const ciphertext = work[pn_offset + pn_len ..];
@@ -3213,6 +3234,10 @@ fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
     conn.clearSend();
 
     const s = conn.streams.get(0).?;
+    try testing.expectEqual(@as(usize, 1), s.pending.items.len);
+    const previous_pending_offset = s.pending.items[0].offset;
+    const previous_pending_data = try gpa.dupe(u8, s.pending.items[0].data);
+    defer gpa.free(previous_pending_data);
     const previous_window = conn.recv_windows.get(0).?;
     const previous_total = conn.conn_received_total;
     var head_frame: std.ArrayListUnmanaged(u8) = .empty;
@@ -3221,12 +3246,21 @@ fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
     const head = try testBuildApp(gpa, &dcid, 1, head_frame.items);
     defer gpa.free(head);
     conn.receiveDatagram(head, 2000) catch |err| {
+        try testing.expectEqual(@as(u64, 11), s.highest_received);
+        try testing.expectEqual(@as(?u64, 11), s.final_size);
+        try testing.expectEqual(stream.RecvState.size_known, s.state);
+        try testing.expectEqual(previous_window, conn.recv_windows.get(0).?);
+        try testing.expectEqual(previous_total, conn.conn_received_total);
         if (s.readable().len == 0) {
-            try testing.expectEqual(@as(u64, 11), s.highest_received);
-            try testing.expectEqual(@as(?u64, 11), s.final_size);
-            try testing.expectEqual(stream.RecvState.size_known, s.state);
-            try testing.expectEqual(previous_window, conn.recv_windows.get(0).?);
-            try testing.expectEqual(previous_total, conn.conn_received_total);
+            try testing.expectEqual(@as(usize, 1), s.pending.items.len);
+            try testing.expectEqual(previous_pending_offset, s.pending.items[0].offset);
+            try testing.expectEqualStrings(previous_pending_data, s.pending.items[0].data);
+            try testing.expect(!conn.spaces[@intFromEnum(Space.application)].recv_ranges.contains(1));
+        } else {
+            try testing.expectEqualStrings("hello world", s.readable());
+            try testing.expectEqual(@as(usize, 0), s.pending.items.len);
+            try testing.expect(s.isFinished());
+            try testing.expect(conn.spaces[@intFromEnum(Space.application)].recv_ranges.contains(1));
         }
         return err;
     };

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2479,9 +2479,10 @@ pub const Connection = struct {
         if (space == .handshake) self.validateCurrentPath();
 
         if (st.recv_ranges.shouldIgnore(opened.pn)) return;
-        st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
-        st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
+        try st.recv_ranges.ensureCanAdd(self.gpa);
         try self.dispatchFrames(opened.payload, space, long, now);
+        st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
+        st.recv_ranges.add(self.gpa, opened.pn) catch unreachable; // capacity was reserved before dispatch
         self.resetIdleTimer(now);
 
         // Acknowledge the space if it carried an ack-eliciting frame this packet.
@@ -3196,6 +3197,44 @@ fn testRequiredServerTransportParameters(conn: *const Connection) !transport_par
 // space, so stream-reassembly tests use the space STREAM is actually legal in.
 pub fn testBuildApp(gpa: std.mem.Allocator, dcid: []const u8, pn: u64, frames: []const u8) ![]u8 {
     return testBuildAppWithSecret(gpa, dcid, pn, frames, TEST_APP_SECRET, false);
+}
+
+fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
+    const dcid = [_]u8{ 0x0e, 0x0f, 0x10, 0x16 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+
+    var tail_frame: std.ArrayListUnmanaged(u8) = .empty;
+    defer tail_frame.deinit(gpa);
+    try frame.encodeStream(&tail_frame, gpa, 0, 6, "world", true);
+    const tail = try testBuildApp(gpa, &dcid, 0, tail_frame.items);
+    defer gpa.free(tail);
+    try conn.receiveDatagram(tail, 1000);
+    conn.clearSend();
+
+    const s = conn.streams.get(0).?;
+    const previous_window = conn.recv_windows.get(0).?;
+    const previous_total = conn.conn_received_total;
+    var head_frame: std.ArrayListUnmanaged(u8) = .empty;
+    defer head_frame.deinit(gpa);
+    try frame.encodeStream(&head_frame, gpa, 0, 0, "hello ", false);
+    const head = try testBuildApp(gpa, &dcid, 1, head_frame.items);
+    defer gpa.free(head);
+    conn.receiveDatagram(head, 2000) catch |err| {
+        if (s.readable().len == 0) {
+            try testing.expectEqual(@as(u64, 11), s.highest_received);
+            try testing.expectEqual(@as(?u64, 11), s.final_size);
+            try testing.expectEqual(stream.RecvState.size_known, s.state);
+            try testing.expectEqual(previous_window, conn.recv_windows.get(0).?);
+            try testing.expectEqual(previous_total, conn.conn_received_total);
+            try conn.receiveDatagram(head, 2000);
+            try testing.expectEqualStrings("hello world", s.readable());
+        }
+        return err;
+    };
+    try testing.expectEqualStrings("hello world", s.readable());
+    try testing.expect(s.isFinished());
 }
 
 fn testBuildAppWithSecret(gpa: std.mem.Allocator, dcid: []const u8, pn: u64, frames: []const u8, secret: [32]u8, key_phase: bool) ![]u8 {
@@ -4920,6 +4959,10 @@ test "per-stream receive flow control rejects data past the stream limit" {
     try testing.expectEqualStrings("", conn.streamData(0));
     try testing.expect(!conn.hasStream(0));
     try testing.expect(!conn.recv_windows.contains(0));
+}
+
+test "receive stream updates are atomic on allocation failure" {
+    try testing.checkAllAllocationFailures(testing.allocator, receiveStreamUnderAllocationFailure, .{});
 }
 
 test "receive stream fragment count is bounded" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -2479,10 +2479,9 @@ pub const Connection = struct {
         if (space == .handshake) self.validateCurrentPath();
 
         if (st.recv_ranges.shouldIgnore(opened.pn)) return;
-        try st.recv_ranges.ensureCanAdd(self.gpa);
-        try self.dispatchFrames(opened.payload, space, long, now);
         st.largest_recv_pn = if (st.largest_recv_pn) |l| @max(l, opened.pn) else opened.pn;
-        st.recv_ranges.add(self.gpa, opened.pn) catch unreachable; // capacity was reserved before dispatch
+        st.recv_ranges.add(self.gpa, opened.pn) catch return error.OutOfMemory; // for accurate ACKs
+        try self.dispatchFrames(opened.payload, space, long, now);
         self.resetIdleTimer(now);
 
         // Acknowledge the space if it carried an ack-eliciting frame this packet.
@@ -3228,8 +3227,6 @@ fn receiveStreamUnderAllocationFailure(gpa: std.mem.Allocator) !void {
             try testing.expectEqual(stream.RecvState.size_known, s.state);
             try testing.expectEqual(previous_window, conn.recv_windows.get(0).?);
             try testing.expectEqual(previous_total, conn.conn_received_total);
-            try conn.receiveDatagram(head, 2000);
-            try testing.expectEqualStrings("hello world", s.readable());
         }
         return err;
     };

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -499,28 +499,6 @@ pub const SendStream = struct {
     }
 };
 
-fn pushUnderAllocationFailure(gpa: std.mem.Allocator) !void {
-    var s = RecvStream.init(gpa);
-    defer s.deinit();
-
-    _ = s.push(6, "world", true) catch |err| {
-        try std.testing.expectEqual(@as(u64, 0), s.highest_received);
-        try std.testing.expectEqual(@as(?u64, null), s.final_size);
-        try std.testing.expectEqual(RecvState.recv, s.state);
-        try std.testing.expectEqualStrings("", s.readable());
-        return err;
-    };
-    _ = s.push(0, "hello ", false) catch |err| {
-        try std.testing.expectEqual(@as(u64, 11), s.highest_received);
-        try std.testing.expectEqual(@as(?u64, 11), s.final_size);
-        try std.testing.expectEqual(RecvState.size_known, s.state);
-        try std.testing.expectEqualStrings("", s.readable());
-        return err;
-    };
-    try std.testing.expectEqualStrings("hello world", s.readable());
-    try std.testing.expect(s.isFinished());
-}
-
 test "stream-id typing reads the low two bits" {
     try std.testing.expectEqual(StreamType.client_bidi, StreamType.of(0));
     try std.testing.expectEqual(StreamType.server_bidi, StreamType.of(1));
@@ -549,10 +527,6 @@ test "out-of-order fragments are buffered then drained" {
     _ = try s.push(0, "hello ", false); // unlocks the buffered tail
     try std.testing.expectEqualStrings("hello world", s.readable());
     try std.testing.expect(s.isFinished());
-}
-
-test "receive stream updates are atomic on allocation failure" {
-    try std.testing.checkAllAllocationFailures(std.testing.allocator, pushUnderAllocationFailure, .{});
 }
 
 test "overlapping and duplicate data is handled" {

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -105,23 +105,31 @@ pub const RecvStream = struct {
         }
         const new_high = @max(self.highest_received, end);
         const delta = new_high - self.highest_received;
-        self.highest_received = new_high;
-        if (fin) {
-            if (self.final_size) |fs| {
-                if (fs != end) return error.FinalSizeError;
-            } else self.final_size = end;
-            if (self.state == .recv) self.state = .size_known;
+
+        if (end > self.contiguous) {
+            if (offset <= self.contiguous) {
+                var frontier = end;
+                for (self.pending.items) |f| {
+                    if (f.offset > frontier) break;
+                    frontier = @max(frontier, f.offset + f.data.len);
+                }
+                const growth = std.math.cast(usize, frontier - self.contiguous) orelse
+                    return error.StreamBufferExceeded;
+                try self.ready.ensureUnusedCapacity(self.gpa, growth);
+
+                const skip: usize = @intCast(self.contiguous - offset);
+                self.ready.appendSliceAssumeCapacity(data[skip..]);
+                self.contiguous = end;
+                self.drainPendingAssumeCapacity();
+            } else {
+                try self.buffer(offset, data);
+            }
         }
 
-        if (end <= self.contiguous) return delta; // wholly duplicate
-
-        if (offset <= self.contiguous) {
-            const skip = self.contiguous - offset;
-            try self.ready.appendSlice(self.gpa, data[skip..]);
-            self.contiguous = end;
-            try self.drainPending();
-        } else {
-            try self.buffer(offset, data);
+        self.highest_received = new_high;
+        if (fin) {
+            self.final_size = end;
+            if (self.state == .recv) self.state = .size_known;
         }
         return delta;
     }
@@ -136,14 +144,14 @@ pub const RecvStream = struct {
         try self.pending.insert(self.gpa, idx, .{ .offset = offset, .data = copy });
     }
 
-    fn drainPending(self: *RecvStream) Error!void {
+    fn drainPendingAssumeCapacity(self: *RecvStream) void {
         var progressed = true;
         while (progressed) {
             progressed = false;
             var i: usize = 0;
             while (i < self.pending.items.len) {
                 const f = self.pending.items[i];
-                const fend = std.math.add(u64, f.offset, f.data.len) catch return error.FinalSizeError;
+                const fend = f.offset + f.data.len;
                 if (fend <= self.contiguous) {
                     self.gpa.free(f.data);
                     _ = self.pending.orderedRemove(i);
@@ -151,8 +159,8 @@ pub const RecvStream = struct {
                     continue;
                 }
                 if (f.offset <= self.contiguous) {
-                    const skip = self.contiguous - f.offset;
-                    try self.ready.appendSlice(self.gpa, f.data[skip..]);
+                    const skip: usize = @intCast(self.contiguous - f.offset);
+                    self.ready.appendSliceAssumeCapacity(f.data[skip..]);
                     self.contiguous = fend;
                     self.gpa.free(f.data);
                     _ = self.pending.orderedRemove(i);
@@ -491,6 +499,28 @@ pub const SendStream = struct {
     }
 };
 
+fn pushUnderAllocationFailure(gpa: std.mem.Allocator) !void {
+    var s = RecvStream.init(gpa);
+    defer s.deinit();
+
+    _ = s.push(6, "world", true) catch |err| {
+        try std.testing.expectEqual(@as(u64, 0), s.highest_received);
+        try std.testing.expectEqual(@as(?u64, null), s.final_size);
+        try std.testing.expectEqual(RecvState.recv, s.state);
+        try std.testing.expectEqualStrings("", s.readable());
+        return err;
+    };
+    _ = s.push(0, "hello ", false) catch |err| {
+        try std.testing.expectEqual(@as(u64, 11), s.highest_received);
+        try std.testing.expectEqual(@as(?u64, 11), s.final_size);
+        try std.testing.expectEqual(RecvState.size_known, s.state);
+        try std.testing.expectEqualStrings("", s.readable());
+        return err;
+    };
+    try std.testing.expectEqualStrings("hello world", s.readable());
+    try std.testing.expect(s.isFinished());
+}
+
 test "stream-id typing reads the low two bits" {
     try std.testing.expectEqual(StreamType.client_bidi, StreamType.of(0));
     try std.testing.expectEqual(StreamType.server_bidi, StreamType.of(1));
@@ -519,6 +549,10 @@ test "out-of-order fragments are buffered then drained" {
     _ = try s.push(0, "hello ", false); // unlocks the buffered tail
     try std.testing.expectEqualStrings("hello world", s.readable());
     try std.testing.expect(s.isFinished());
+}
+
+test "receive stream updates are atomic on allocation failure" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, pushUnderAllocationFailure, .{});
 }
 
 test "overlapping and duplicate data is handled" {


### PR DESCRIPTION
## Summary

Commit receive-stream metadata only after fragment buffering succeeds. Reserve the full contiguous growth before draining pending fragments and add exhaustive allocation-failure coverage.

Closes #257.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a failure-atomicity bug in `RecvStream.push` where an allocation failure could leave receive stream metadata (highest received, final size, state) updated even though the data wasn't buffered. Now the stream reserves capacity for the full contiguous growth before draining pending fragments, and metadata commits only after buffering succeeds. Adds exhaustive allocation-failure coverage.

<sup>Written for commit 711fcb674769d53732345b87bd869f2868b52260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Kludex/zttp/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

