### PR TITLE
Pump only QUIC streams changed by each datagram

### DIFF
--- a/benchmarks/http3.py
+++ b/benchmarks/http3.py
@@ -185,6 +185,71 @@ def make_zttp(w: Workload) -> Runner:
     return run
 
 
+def make_zttp_multiplexed(active_streams: int) -> Runner:
+    _cert_path, _key_path, certificate, private_key = _make_cert()
+    transport_params = zttp.QuicTransportParameters(initial_max_streams_bidi=256)
+    client = zttp.Connection(
+        zttp.CLIENT,
+        protocol=zttp.HTTP3,
+        server_name=AUTHORITY,
+        server_certificate=certificate,
+        transport_params=transport_params,
+    )
+    server = zttp.Connection(
+        zttp.SERVER,
+        protocol=zttp.HTTP3,
+        credentials=zttp.TlsCredentials(certificate=certificate, private_key_scalar=private_key),
+        transport_params=transport_params,
+    )
+    now = [1000]
+
+    def transfer(src: zttp.H3Connection, dst: zttp.H3Connection) -> None:
+        for datagram in src.data_to_send():
+            dst.receive_datagram(datagram, now[0])
+
+    for _ in range(6):
+        transfer(client, server)
+        transfer(server, client)
+        now[0] += 1000
+
+    requests = 0
+    for _ in range(active_streams - 1):
+        client.send_request(
+            b"POST",
+            b"/",
+            b"3",
+            [(b"host", AUTHORITY)],
+        )
+        transfer(client, server)
+        while (event := server.next_event()) is not zttp.NEED_DATA:
+            if isinstance(event, zttp.Request):
+                requests += 1
+        transfer(server, client)
+    if requests != active_streams - 1:
+        raise RuntimeError(f"zttp opened {requests}/{active_streams - 1} held request streams")
+
+    def run(n: int) -> None:
+        received = 0
+        for _ in range(n):
+            now[0] += 100
+            stream = client.send_request(
+                b"GET",
+                b"/",
+                b"3",
+                [(b"host", AUTHORITY)],
+            )
+            stream.end_message()
+            transfer(client, server)
+            while (event := server.next_event()) is not zttp.NEED_DATA:
+                if isinstance(event, zttp.Request):
+                    received += 1
+            transfer(server, client)
+        if received != n:
+            raise RuntimeError(f"zttp delivered {received}/{n} multiplexed requests")
+
+    return run
+
+
 # -- aioquic ------------------------------------------------------------------
 
 
@@ -331,16 +396,34 @@ def bench(w: Workload, batch: int, repeats: int) -> dict[str, float]:
     return rates
 
 
+def bench_active_stream_scaling(batch: int, repeats: int) -> None:
+    print(f"\n== one changed stream by active stream count ({repeats} batches of {batch:,} requests) ==")
+    for active_streams in (1, 16, 64):
+        run = make_zttp_multiplexed(active_streams)
+        run(max(1, batch // 10))
+        samples = [batch / timed(run, batch) for _ in range(repeats)]
+        p25, median, p75 = _quartiles(samples)
+        print(f"  {active_streams:>3} active: {median:12,.0f} requests/s  (p25-p75 {p25:,.0f}-{p75:,.0f})")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--batch", type=int, default=2_000, help="round-trips per timed batch")
     parser.add_argument("--repeats", type=int, default=15, help="timed batches per stack")
     parser.add_argument("--only", type=str, default=None, help="substring filter on workload names")
+    parser.add_argument(
+        "--active-stream-scaling",
+        action="store_true",
+        help="measure one changed stream with 1, 16, and 64 active streams",
+    )
     args = parser.parse_args()
 
     print(
         f"CPython {sys.version.split()[0]}, zttp {version('zttp')}, aioquic {version('aioquic')} (Python QUIC, C QPACK)"
     )
+    if args.active_stream_scaling:
+        bench_active_stream_scaling(args.batch, args.repeats)
+        return
     selected = [w for w in WORKLOADS if args.only is None or args.only.lower() in w.name.lower()]
     results = {w.name: bench(w, args.batch, args.repeats) for w in selected}
 

--- a/benchmarks/http3.py
+++ b/benchmarks/http3.py
@@ -230,6 +230,7 @@ def make_zttp_multiplexed(active_streams: int) -> Runner:
 
     def run(n: int) -> None:
         received = 0
+        completed = 0
         for _ in range(n):
             now[0] += 100
             stream = client.send_request(
@@ -243,9 +244,15 @@ def make_zttp_multiplexed(active_streams: int) -> Runner:
             while (event := server.next_event()) is not zttp.NEED_DATA:
                 if isinstance(event, zttp.Request):
                     received += 1
+                    response = server.stream(event.stream_id)
+                    response.send_response(200, [])
+                    response.end_message()
             transfer(server, client)
-        if received != n:
-            raise RuntimeError(f"zttp delivered {received}/{n} multiplexed requests")
+            while (event := client.next_event()) is not zttp.NEED_DATA:
+                if isinstance(event, zttp.Response) and event.status_code == 200:
+                    completed += 1
+        if received != n or completed != n:
+            raise RuntimeError(f"zttp completed {completed}/{received}/{n} multiplexed round-trips")
 
     return run
 

--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -15,6 +15,7 @@ const ascii = @import("../ascii.zig");
 const events = @import("../events.zig");
 const fields = @import("../fields.zig");
 const quic_conn = @import("../quic/connection.zig");
+const quic_frame = @import("../quic/frame.zig");
 const quic_stream = @import("../quic/stream.zig");
 const varint = @import("../quic/varint.zig");
 const h3_frame = @import("frame.zig");
@@ -307,14 +308,12 @@ pub const Connection = struct {
         return if (self.qc.role == .client) 10 else 11;
     }
 
-    /// Advance the parse of request stream `id` from whatever ordered bytes the
-    /// QUIC transport now has. Newly completed events are appended to the queue.
-    /// The caller (the adapter) calls this when it knows a stream got data; a
-    /// production driver would call it for every stream that advanced.
-    /// Advance the parse of every stream the transport currently knows about.
-    /// The adapter calls this after each datagram so it need not track which
-    /// streams advanced. Take a snapshot first so streams can be reclaimed while
-    /// pumping without invalidating the transport map iterator.
+    /// Advance only the streams changed by the datagram the transport just handled.
+    pub fn pumpStreams(self: *Connection, ids: []const u64) Error!void {
+        try self.pumpStreamSnapshot(ids);
+    }
+
+    /// Advance every stream the transport currently knows about.
     pub fn pumpAll(self: *Connection) Error!void {
         var stack_ids: [64]u64 = undefined;
         const count = self.qc.streamCount();
@@ -2513,6 +2512,41 @@ fn buildRequestOnFin(gpa: std.mem.Allocator, dcid: []const u8, stream_id: u64, p
     try varint.append(&sframe, gpa, h3_bytes.len);
     try sframe.appendSlice(gpa, h3_bytes);
     return @import("../quic/connection.zig").testBuildApp(gpa, dcid, pn, sframe.items);
+}
+
+test "pumpStreams advances a request changed by each datagram" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0xa6, 0xa7, 0xa8, 0xb9 };
+    var qc = try quic_conn.Connection.init(gpa, .server, &dcid);
+    defer qc.deinit();
+    quic_conn.testInstallAppKeys(&qc);
+    var h3 = Connection.init(gpa, &qc);
+    defer h3.deinit();
+    h3.peer_settings = .{};
+
+    var headers: std.ArrayListUnmanaged(u8) = .empty;
+    defer headers.deinit(gpa);
+    const qpack_block = [_]u8{ 0x00, 0x00, 0xC0 | 20, 0xC0 | 23, 0xC0 | 1 }; // POST https /
+    try h3_frame.append(&headers, gpa, .headers, &qpack_block);
+    var stream_frame: std.ArrayListUnmanaged(u8) = .empty;
+    defer stream_frame.deinit(gpa);
+    try quic_frame.encodeStream(&stream_frame, gpa, 0, 0, headers.items, false);
+    const first = try quic_conn.testBuildApp(gpa, &dcid, 0, stream_frame.items);
+    defer gpa.free(first);
+    try qc.receiveDatagram(first, 1000);
+    try h3.pumpStreams(qc.changedStreamIds());
+    try testing.expect(h3.nextEvent() == .request);
+
+    var data: std.ArrayListUnmanaged(u8) = .empty;
+    defer data.deinit(gpa);
+    try h3_frame.append(&data, gpa, .data, "x");
+    stream_frame.clearRetainingCapacity();
+    try quic_frame.encodeStream(&stream_frame, gpa, 0, headers.items.len, data.items, false);
+    const second = try quic_conn.testBuildApp(gpa, &dcid, 1, stream_frame.items);
+    defer gpa.free(second);
+    try qc.receiveDatagram(second, 2000);
+    try h3.pumpStreams(qc.changedStreamIds());
+    try testing.expect(h3.nextEvent() == .data);
 }
 
 test "pumpAll advances more than the small stack stream snapshot" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -264,6 +264,8 @@ pub const Connection = struct {
     conn_received_total: u64 = 0,
     conn_consumed_total: u64 = 0,
     streams: std.AutoHashMapUnmanaged(u64, *stream.RecvStream) = .empty,
+    /// Receive-stream ids changed by the current datagram, in first-seen order.
+    changed_streams: std.ArrayListUnmanaged(u64) = .empty,
     /// Per-stream receive flow-control windows, keyed by stream id.
     recv_windows: std.AutoHashMapUnmanaged(u64, flow.Window) = .empty,
     send_streams: std.AutoHashMapUnmanaged(u64, *stream.SendStream) = .empty,
@@ -652,6 +654,7 @@ pub const Connection = struct {
             self.gpa.destroy(s.*);
         }
         self.streams.deinit(self.gpa);
+        self.changed_streams.deinit(self.gpa);
         self.recv_windows.deinit(self.gpa);
         var sit = self.send_streams.valueIterator();
         while (sit.next()) |s| {
@@ -2198,6 +2201,7 @@ pub const Connection = struct {
     }
 
     fn receiveDatagramOn(self: *Connection, datagram: []const u8, now: u64, peer_address: ?[]const u8) Error!void {
+        self.changed_streams.clearRetainingCapacity();
         if (self.closed) return error.ProtocolViolation;
         if (peer_address) |addr| {
             // A spoofable path change is silently dropped, never connection-fatal.
@@ -2858,6 +2862,7 @@ pub const Connection = struct {
         if (new_high > recv_limit) return error.FlowControlError;
         const new_total = std.math.add(u64, self.conn_received_total, expected_delta) catch return error.FlowControlError;
         if (new_total > self.conn_recv_window.limit) return error.FlowControlError;
+        try self.markStreamChanged(id);
         const s = existing orelse try self.recvStream(id);
         const rw = try self.recvWindow(id);
         const delta = s.push(offset, data, fin) catch |e| switch (e) {
@@ -2885,6 +2890,7 @@ pub const Connection = struct {
         if (new_high > rw.limit) return error.FlowControlError;
         const new_total = std.math.add(u64, self.conn_received_total, delta) catch return error.FlowControlError;
         if (new_total > self.conn_recv_window.limit) return error.FlowControlError;
+        try self.markStreamChanged(id);
         const charged = s.onReset(error_code, final_size) catch return error.FinalSizeError;
         std.debug.assert(charged == delta);
         rw.onReceived(s.highest_received) catch return error.FlowControlError;
@@ -2914,6 +2920,11 @@ pub const Connection = struct {
     /// stream's offset accounting is gone, so re-creating it would re-deliver data).
     fn isRetired(self: *const Connection, id: u64) bool {
         return self.retired_recv.contains(id);
+    }
+
+    fn markStreamChanged(self: *Connection, id: u64) Error!void {
+        if (std.mem.indexOfScalar(u64, self.changed_streams.items, id) != null) return;
+        self.changed_streams.append(self.gpa, id) catch return error.OutOfMemory;
     }
 
     fn recvStream(self: *Connection, id: u64) Error!*stream.RecvStream {
@@ -3020,6 +3031,12 @@ pub const Connection = struct {
     /// never-seen id returns false, so the H3 layer does not recreate state for it.
     pub fn hasStream(self: *Connection, id: u64) bool {
         return self.streams.contains(id);
+    }
+
+    /// The receive-stream ids changed by the last datagram. The slice remains valid
+    /// until the next receive call.
+    pub fn changedStreamIds(self: *const Connection) []const u64 {
+        return self.changed_streams.items;
     }
 
     /// Snapshot the ids of every stream the transport currently knows about, into
@@ -3278,6 +3295,31 @@ test "server decrypts a 1-RTT packet and reassembles a stream" {
     try conn.receiveDatagram(dgram, 1000);
     try testing.expectEqualStrings("hi", conn.streamData(0));
     try testing.expect(conn.streamFinished(0));
+}
+
+test "receive datagrams expose only changed stream ids" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x18 };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(gpa);
+    try frame.encodeStream(&frames, gpa, 0, 0, "a", false);
+    try frame.encodeStream(&frames, gpa, 4, 0, "b", true);
+    try frame.encodeStream(&frames, gpa, 0, 1, "c", true);
+    try frame.encodeResetStream(&frames, gpa, 8, 0x010c, 0);
+    const streams = try testBuildApp(gpa, &dcid, 0, frames.items);
+    defer gpa.free(streams);
+    try conn.receiveDatagram(streams, 1000);
+    try testing.expectEqualSlices(u64, &.{ 0, 4, 8 }, conn.changedStreamIds());
+
+    const ping = [_]u8{0x01} ++ [_]u8{0x00} ** 19;
+    const no_streams = try testBuildApp(gpa, &dcid, 1, &ping);
+    defer gpa.free(no_streams);
+    try conn.receiveDatagram(no_streams, 2000);
+    try testing.expectEqual(@as(usize, 0), conn.changedStreamIds().len);
 }
 
 test "peer cannot use an unopened locally initiated stream" {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -848,7 +848,7 @@ const H3Engine = struct {
         } else {
             self.qc.?.receiveDatagram(dgram, now) catch |e| return exceptions.raiseQuic(e);
         }
-        self.h3.?.pumpAll() catch |e| return exceptions.raiseH3(e);
+        self.h3.?.pumpStreams(self.qc.?.changedStreamIds()) catch |e| return exceptions.raiseH3(e);
         return py.none();
     }
 


### PR DESCRIPTION
## Summary

Expose the deduplicated receive-stream IDs changed by each QUIC datagram and make the Python HTTP/3 adapter pump only that snapshot. Preserve control-stream ordering and add active-stream scaling coverage and benchmarking.

Closes #259.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

