### PR TITLE
Batch QUIC stream buffer compaction

### DIFF
--- a/benchmarks/quic_stream.zig
+++ b/benchmarks/quic_stream.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+const stream = @import("quic_stream");
+
+const TRANSFER_SIZE: usize = 4 * 1024 * 1024;
+const PACKET_PAYLOAD: usize = 1200;
+
+pub fn main(init: std.process.Init) !void {
+    const gpa = init.gpa;
+    const data = try gpa.alloc(u8, TRANSFER_SIZE);
+    defer gpa.free(data);
+    @memset(data, 'x');
+
+    var send = stream.SendStream.init(gpa);
+    defer send.deinit();
+    try send.write(data, true);
+    while (send.peek(PACKET_PAYLOAD)) |chunk| send.commit(chunk.offset, chunk.data.len, chunk.fin);
+
+    const ack_start = std.Io.Clock.awake.now(init.io);
+    var offset: u64 = 0;
+    while (offset < TRANSFER_SIZE) {
+        const len = @min(@as(u64, PACKET_PAYLOAD), TRANSFER_SIZE - offset);
+        try send.onAck(offset, len, offset + len == TRANSFER_SIZE);
+        offset += len;
+    }
+    const ack_ns = ack_start.untilNow(init.io, .awake).toNanoseconds();
+
+    var recv = stream.RecvStream.init(gpa);
+    defer recv.deinit();
+    _ = try recv.push(0, data, true);
+    const consume_start = std.Io.Clock.awake.now(init.io);
+    while (recv.readable().len > 0) recv.consume(@min(PACKET_PAYLOAD, recv.readable().len));
+    const consume_ns = consume_start.untilNow(init.io, .awake).toNanoseconds();
+
+    std.debug.print(
+        "{d} MiB in {d}-byte chunks: sequential ACKs {d:.2} ms, receives {d:.2} ms\n",
+        .{
+            TRANSFER_SIZE / (1024 * 1024),
+            PACKET_PAYLOAD,
+            @as(f64, @floatFromInt(ack_ns)) / std.time.ns_per_ms,
+            @as(f64, @floatFromInt(consume_ns)) / std.time.ns_per_ms,
+        },
+    );
+}

--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,23 @@ pub fn build(b: *std.Build) void {
     const fuzz_obj_step = b.step("fuzz-obj", "Emit the libFuzzer object (zig-out/bin/zttp_fuzz_reader.o)");
     fuzz_obj_step.dependOn(&install_fuzz.step);
 
+    const stream_benchmark = b.addExecutable(.{
+        .name = "quic_stream_benchmark",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("benchmarks/quic_stream.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    stream_benchmark.root_module.addImport("quic_stream", b.createModule(.{
+        .root_source_file = b.path("src/core/quic/stream.zig"),
+        .target = target,
+        .optimize = optimize,
+    }));
+    const run_stream_benchmark = b.addRunArtifact(stream_benchmark);
+    const stream_benchmark_step = b.step("bench-stream", "Benchmark QUIC stream buffer compaction");
+    stream_benchmark_step.dependOn(&run_stream_benchmark.step);
+
     // Python build configuration is discovered by the hatch-ziglang hook and
     // passed in as -D options or environment variables. Resolved lazily so the
     // test step above never requires a Python toolchain.

--- a/scripts/check
+++ b/scripts/check
@@ -17,4 +17,4 @@ uv run --no-sync python -m mypy.stubtest zttp._zttp --allowlist tests/stubtest_a
 uv run --no-sync ruff check $SOURCE_FILES
 
 # Zig.
-zig fmt --check src build.zig
+zig fmt --check src benchmarks/quic_stream.zig build.zig

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -131,7 +131,9 @@ pub const RecvStream = struct {
         self.highest_received = new_high;
         if (fin) {
             self.final_size = end;
-            if (self.state == .recv) self.state = .size_known;
+            if (self.state == .recv) {
+                self.state = if (self.isFinished() and self.readable().len == 0) .data_read else .size_known;
+            }
         }
         return delta;
     }
@@ -563,6 +565,18 @@ test "consume slides the read offset" {
     try std.testing.expectEqual(@as(u64, 3), s.read_offset);
     s.consume(3);
     try std.testing.expectEqual(RecvState.data_read, s.state);
+}
+
+test "fin-only frame completes an already consumed receive stream" {
+    const gpa = std.testing.allocator;
+    var s = RecvStream.init(gpa);
+    defer s.deinit();
+    _ = try s.push(0, "abc", false);
+    s.consume(3);
+    try std.testing.expect(!s.isTerminal());
+    _ = try s.push(3, "", true);
+    try std.testing.expectEqual(RecvState.data_read, s.state);
+    try std.testing.expect(s.isTerminal());
 }
 
 test "receive stream batches prefix compaction" {

--- a/src/core/quic/stream.zig
+++ b/src/core/quic/stream.zig
@@ -12,6 +12,7 @@ const std = @import("std");
 /// Flow control already caps bytes; this caps allocator/list pressure from a peer
 /// sending one-byte fragments in reverse order.
 pub const MAX_RECV_FRAGMENTS: usize = 1024;
+const COMPACT_THRESHOLD: usize = 64 * 1024;
 
 /// The four stream-id classes (RFC 9000 2.1), the low two bits of the id.
 pub const StreamType = enum(u2) {
@@ -82,6 +83,7 @@ pub const RecvStream = struct {
     pending: std.ArrayListUnmanaged(Fragment) = .empty,
     /// The in-order, not-yet-read bytes [read_offset, contiguous).
     ready: std.ArrayListUnmanaged(u8) = .empty,
+    ready_head: usize = 0,
 
     pub fn init(gpa: std.mem.Allocator) RecvStream {
         return .{ .gpa = gpa };
@@ -167,19 +169,25 @@ pub const RecvStream = struct {
     /// The in-order bytes available to read right now (a borrow valid until the
     /// next `consume`).
     pub fn readable(self: *const RecvStream) []const u8 {
-        return self.ready.items;
+        return self.ready.items[self.ready_head..];
     }
 
     /// Mark `n` readable bytes consumed, sliding the read offset. The transport
     /// uses this to know how much connection/stream flow-control credit to re-grant.
     pub fn consume(self: *RecvStream, n: usize) void {
-        const take = @min(n, self.ready.items.len);
+        const take = @min(n, self.ready.items.len - self.ready_head);
         self.read_offset += take;
-        // Shift the remaining ready bytes down.
-        const rest = self.ready.items.len - take;
-        std.mem.copyForwards(u8, self.ready.items[0..rest], self.ready.items[take..]);
-        self.ready.shrinkRetainingCapacity(rest);
-        if (self.isFinished() and self.ready.items.len == 0) self.state = .data_read;
+        self.ready_head += take;
+        const remaining = self.ready.items.len - self.ready_head;
+        if (remaining == 0) {
+            self.ready.clearRetainingCapacity();
+            self.ready_head = 0;
+        } else if (self.ready_head >= COMPACT_THRESHOLD and self.ready_head >= remaining) {
+            std.mem.copyForwards(u8, self.ready.items[0..remaining], self.ready.items[self.ready_head..]);
+            self.ready.shrinkRetainingCapacity(remaining);
+            self.ready_head = 0;
+        }
+        if (self.isFinished() and remaining == 0) self.state = .data_read;
     }
 
     /// Return up to `n` bytes of parsed data to flow control.
@@ -222,15 +230,15 @@ pub const RecvStream = struct {
 
 /// The send side of one stream: a retain buffer of all unacked bytes the
 /// connection drains into STREAM frames, plus the bookkeeping to retransmit a
-/// range whose packet was lost. One contiguous `buf` holds [base_offset, end);
-/// the `sent` cursor splits already-framed bytes (left) from never-framed bytes
-/// (right). Lost ranges are re-framed before new bytes (RFC 9002 13.3); acked
-/// bytes are freed off the front. Mirrors RecvStream, but for the write direction.
+/// range whose packet was lost. `buf_head` separates a lazily discarded prefix
+/// from [base_offset, end); the `sent` cursor splits already-framed bytes from new
+/// bytes. Lost ranges are re-framed before new bytes (RFC 9002 13.3).
 pub const SendStream = struct {
     gpa: std.mem.Allocator,
-    /// Every written, not-yet-acked byte: [base_offset, base_offset + buf.len).
+    /// Written bytes, including a lazily discarded prefix before `buf_head`.
     buf: std.ArrayListUnmanaged(u8) = .empty,
-    /// Offset of buf.items[0]; everything below is acked and freed.
+    buf_head: usize = 0,
+    /// Offset of buf.items[buf_head]; everything below is acknowledged.
     base_offset: u64 = 0,
     /// Bytes in [base_offset, sent) have ridden a frame; [sent, end) are new. The
     /// cursor only moves forward (commit); a loss records a `lost` range instead.
@@ -267,7 +275,7 @@ pub const SendStream = struct {
     }
 
     pub fn end(self: *const SendStream) u64 {
-        return self.base_offset + self.buf.items.len;
+        return self.base_offset + self.buf.items.len - self.buf_head;
     }
 
     /// Every written byte (and the FIN, if one was written) has been acknowledged,
@@ -276,7 +284,7 @@ pub const SendStream = struct {
     /// stream is done once its RESET_STREAM is acked (the unsent data is abandoned).
     pub fn fullyAcked(self: *const SendStream) bool {
         if (self.reset_code != null) return self.reset_acked;
-        return self.buf.items.len == 0 and (!self.fin or self.fin_acked);
+        return self.buf.items.len == self.buf_head and (!self.fin or self.fin_acked);
     }
 
     /// Abort the sending part with `error_code` (RFC 9000 19.4). The first reset wins;
@@ -352,7 +360,7 @@ pub const SendStream = struct {
         if (self.lost.items.len > 0) {
             const r = self.lost.items[0];
             const n: usize = @intCast(@min(@as(u64, max), r.len));
-            const lo: usize = @intCast(r.offset - self.base_offset);
+            const lo = self.buf_head + @as(usize, @intCast(r.offset - self.base_offset));
             const carries_fin = self.fin_lost and n == r.len and r.offset + r.len == self.end();
             return .{ .offset = r.offset, .data = self.buf.items[lo .. lo + n], .fin = carries_fin };
         }
@@ -365,7 +373,7 @@ pub const SendStream = struct {
         const n: usize = @intCast(@min(@as(u64, max), avail));
         const carries_fin = self.finOwedAtEnd() and @as(u64, n) == avail;
         if (n == 0 and !carries_fin) return null;
-        const lo: usize = @intCast(self.sent - self.base_offset);
+        const lo = self.buf_head + @as(usize, @intCast(self.sent - self.base_offset));
         return .{ .offset = self.sent, .data = self.buf.items[lo .. lo + n], .fin = carries_fin };
     }
 
@@ -433,12 +441,18 @@ pub const SendStream = struct {
                 i = 0; // a merge can unlock an earlier-skipped gap; rescan
             } else i += 1;
         }
-        const drop: usize = @intCast(new_base - self.base_offset);
-        const keep = self.buf.items.len - drop;
-        std.mem.copyForwards(u8, self.buf.items[0..keep], self.buf.items[drop..]);
-        self.buf.shrinkRetainingCapacity(keep);
+        self.buf_head += @intCast(new_base - self.base_offset);
         self.base_offset = new_base;
         if (self.sent < self.base_offset) self.sent = self.base_offset;
+        const remaining = self.buf.items.len - self.buf_head;
+        if (remaining == 0) {
+            self.buf.clearRetainingCapacity();
+            self.buf_head = 0;
+        } else if (self.buf_head >= COMPACT_THRESHOLD and self.buf_head >= remaining) {
+            std.mem.copyForwards(u8, self.buf.items[0..remaining], self.buf.items[self.buf_head..]);
+            self.buf.shrinkRetainingCapacity(remaining);
+            self.buf_head = 0;
+        }
     }
 
     fn insertLost(self: *SendStream, offset: u64, len: u64) Error!void {
@@ -543,6 +557,27 @@ test "consume slides the read offset" {
     try std.testing.expectEqual(RecvState.data_read, s.state);
 }
 
+test "receive stream batches prefix compaction" {
+    const gpa = std.testing.allocator;
+    const size = COMPACT_THRESHOLD * 4;
+    const data = try gpa.alloc(u8, size);
+    defer gpa.free(data);
+    @memset(data, 'x');
+    var s = RecvStream.init(gpa);
+    defer s.deinit();
+    _ = try s.push(0, data, true);
+
+    const physical_len = s.ready.items.len;
+    s.consume(1200);
+    try std.testing.expectEqual(physical_len, s.ready.items.len);
+    try std.testing.expectEqual(@as(usize, 1200), s.ready_head);
+    try std.testing.expectEqual(size - 1200, s.readable().len);
+
+    while (s.readable().len > 0) s.consume(@min(1200, s.readable().len));
+    try std.testing.expectEqual(RecvState.data_read, s.state);
+    try std.testing.expectEqual(@as(usize, 0), s.ready.items.len);
+}
+
 test "data past a known final size is a final-size error" {
     const gpa = std.testing.allocator;
     var s = RecvStream.init(gpa);
@@ -638,13 +673,39 @@ test "SendStream retains sent bytes until acked, then frees the prefix" {
     const c = s.peek(100).?;
     s.commit(c.offset, c.data.len, false);
     try std.testing.expect(!s.pending()); // all sent
-    try std.testing.expectEqual(@as(usize, 10), s.buf.items.len); // but retained
+    try std.testing.expectEqual(@as(u64, 10), s.end() - s.base_offset); // but retained
 
     try s.onAck(0, 4, false); // first 4 bytes acked
     try std.testing.expectEqual(@as(u64, 4), s.base_offset);
-    try std.testing.expectEqual(@as(usize, 6), s.buf.items.len); // prefix freed
+    try std.testing.expectEqual(@as(u64, 6), s.end() - s.base_offset); // prefix freed
     try s.onAck(4, 6, false);
-    try std.testing.expectEqual(@as(usize, 0), s.buf.items.len); // fully freed
+    try std.testing.expectEqual(@as(u64, 0), s.end() - s.base_offset); // fully freed
+}
+
+test "SendStream batches prefix compaction across sequential acknowledgements" {
+    const gpa = std.testing.allocator;
+    const size = COMPACT_THRESHOLD * 4;
+    const data = try gpa.alloc(u8, size);
+    defer gpa.free(data);
+    @memset(data, 'x');
+    var s = SendStream.init(gpa);
+    defer s.deinit();
+    try s.write(data, true);
+
+    while (s.peek(1200)) |chunk| s.commit(chunk.offset, chunk.data.len, chunk.fin);
+    const physical_len = s.buf.items.len;
+    try s.onAck(0, 1200, false);
+    try std.testing.expectEqual(physical_len, s.buf.items.len);
+    try std.testing.expectEqual(@as(usize, 1200), s.buf_head);
+
+    var offset: u64 = 1200;
+    while (offset < size) {
+        const len = @min(@as(u64, 1200), size - offset);
+        try s.onAck(offset, len, offset + len == size);
+        offset += len;
+    }
+    try std.testing.expect(s.fullyAcked());
+    try std.testing.expectEqual(@as(usize, 0), s.buf.items.len);
 }
 
 test "SendStream re-frames a lost range before new bytes" {
@@ -677,10 +738,10 @@ test "SendStream frees out-of-order acks once the gap fills" {
 
     try s.onAck(5, 5, false); // ack the LATER half first (out of order)
     try std.testing.expectEqual(@as(u64, 0), s.base_offset); // cannot free yet
-    try std.testing.expectEqual(@as(usize, 10), s.buf.items.len);
+    try std.testing.expectEqual(@as(u64, 10), s.end() - s.base_offset);
     try s.onAck(0, 5, false); // the filling ack lets base slide through the held gap
     try std.testing.expectEqual(@as(u64, 10), s.base_offset);
-    try std.testing.expectEqual(@as(usize, 0), s.buf.items.len);
+    try std.testing.expectEqual(@as(u64, 0), s.end() - s.base_offset);
 }
 
 test "SendStream re-sends a lost FIN exactly once" {


### PR DESCRIPTION
## Summary

Track logical head offsets for QUIC receive and send buffers instead of copying the remaining bytes after every consume or ACK. Compact only after 64 KiB is reclaimable and at least half the backing buffer is stale, with a 4 MiB packet-sized benchmark.

Closes #260.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

