### PR TITLE
Fuzz QUIC and HTTP/3 connection state machines

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,10 +51,13 @@ jobs:
           uv run --no-sync python -m fuzz.run --runs "$FUZZ_RUNS" --seed "$GITHUB_RUN_ID"
           uv run --no-sync python -m fuzz.run --runs "$FUZZ_RUNS" --seed 0
 
+      - name: Fuzz the Zig core under sanitizers
+        run: scripts/fuzz-libfuzzer -artifact_prefix=fuzz/corpus/ -runs=200000 fuzz/corpus
+
       - name: Upload reproducers
         if: failure()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: fuzz-reproducers
-          path: fuzz/corpus/crash-*.bin
+          path: fuzz/corpus/crash-*
           if-no-files-found: ignore

--- a/build.zig
+++ b/build.zig
@@ -24,11 +24,24 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run pure-Zig core unit tests");
     test_step.dependOn(&run_core_tests.step);
 
-    // The parser-core property test ("fuzz: reader never panics ...") runs as
-    // part of `zig build test`; `zig build fuzz` is an alias that runs the same
-    // suite, kept as an explicit entry point for the adversarial-input net.
-    const fuzz_step = b.step("fuzz", "Run the parser-core adversarial-input property test");
+    const fuzz_driver_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("fuzz/target.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    fuzz_driver_tests.root_module.addImport("core", b.createModule(.{
+        .root_source_file = b.path("src/core/root.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    }));
+    const run_fuzz_driver_tests = b.addRunArtifact(fuzz_driver_tests);
+    const fuzz_step = b.step("fuzz", "Run core property tests and fuzz-driver smoke tests");
     fuzz_step.dependOn(&run_core_tests.step);
+    fuzz_step.dependOn(&run_fuzz_driver_tests.step);
 
     // A coverage-instrumented object exporting the `zttp_fuzz_drive` C ABI. The
     // C shim (fuzz/target.c) owns the libFuzzer entry point and registers this

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -51,11 +51,13 @@ scripts/fuzz-docker -max_total_time=60
 ## libFuzzer target and OSS-Fuzz
 
 `fuzz/target.zig` exports `zttp_fuzz_drive`, a coverage-instrumented (`.fuzz`)
-drive of the core. The low 2 bits of the first input byte select the surface:
-the HTTP/1.1 reader, the HTTP/2 connection, or an HPACK / QPACK encode->decode
-roundtrip (a header list drawn from the input is encoded and must decode back
-identical - the write/read differential at the codec layer). `fuzz/target.c` is
-the libFuzzer/AFL++ entry point: it
+drive of the core. The first input byte modulo 6 selects the HTTP/1.1 reader,
+HTTP/2 connection, HPACK roundtrip, QPACK roundtrip, QUIC connection, or HTTP/3
+connection. The stateful QUIC targets authenticate structured packets, reorder
+stream fragments, reset streams, change paths, and mix in unauthenticated bytes.
+Inputs and retained state are capped so ASan and LeakSanitizer can run long
+campaigns without resource exhaustion. `fuzz/target.c` is the libFuzzer/AFL++
+entry point: it
 forwards to `zttp_fuzz_drive` and registers the Zig object's SanitizerCoverage
 counters with the engine - Zig 0.16 emits the counter section but not the
 registration hook clang would, so the shim wires it up. `zig build fuzz-obj`

--- a/fuzz/corpus/h3-state.bin
+++ b/fuzz/corpus/h3-state.bin
@@ -1,0 +1,1 @@
+)headers data reset and path changes

--- a/fuzz/corpus/quic-state.bin
+++ b/fuzz/corpus/quic-state.bin
@@ -1,0 +1,1 @@
+(reordered stream data and a reset across path changes

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -165,6 +165,7 @@ fn driveQuic(input: []const u8) void {
     var conn = QuicConnection.init(std.heap.c_allocator, .server, &FUZZ_DCID) catch return;
     defer conn.deinit();
     core.quic.connection.testInstallAppKeys(&conn);
+    core.quic.connection.testConfirmHandshake(&conn);
 
     const split = if (body.len == 0) 0 else @as(usize, body[0]) % (body.len + 1);
     var frames: std.ArrayListUnmanaged(u8) = .empty;
@@ -194,6 +195,7 @@ fn driveH3(input: []const u8) void {
     var qc = QuicConnection.init(std.heap.c_allocator, .server, &FUZZ_DCID) catch return;
     defer qc.deinit();
     core.quic.connection.testInstallAppKeys(&qc);
+    core.quic.connection.testConfirmHandshake(&qc);
     var h3 = H3Connection.init(std.heap.c_allocator, &qc);
     defer h3.deinit();
 

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -1,11 +1,7 @@
-//! Coverage-instrumented drive function for the sans-IO reader, exported under
-//! a C ABI as `zttp_fuzz_drive`. The libFuzzer/AFL++ entry point and the sancov
-//! section registration live in the C shim (`fuzz/target.c`), which OSS-Fuzz's
-//! own clang compiles and links against this object's `.fuzz` instrumentation.
-//!
-//! The drive loop mirrors the `driveReader` property test in `reader.zig`, but
-//! uses the C allocator so the sanitizer the engine links (ASan/UBSan)
-//! intercepts every allocation.
+//! Coverage-instrumented drivers for the sans-IO protocol core, exported through
+//! the `zttp_fuzz_drive` C ABI. The C shim owns the libFuzzer/AFL++ entry point
+//! and registers this object's sanitizer-coverage counters. Every driver uses
+//! the C allocator so ASan and LeakSanitizer intercept its allocations.
 
 const std = @import("std");
 const core = @import("core");
@@ -20,6 +16,15 @@ const hpack_encoder = core.h2.hpack_encoder;
 const HpackDecoder = core.h2.hpack_decoder.Decoder;
 const qpack_encoder = core.h3.qpack_encoder;
 const QpackDecoder = core.h3.qpack_decoder.Decoder;
+const QuicConnection = core.quic.connection.Connection;
+const quic_frame = core.quic.frame;
+const H3Connection = core.h3.connection.Connection;
+const h3_frame = core.h3.frame;
+
+const MAX_FUZZ_INPUT: usize = 64 * 1024;
+const MAX_STATE_INPUT: usize = 4 * 1024;
+const FUZZ_DCID = [_]u8{ 0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08 };
+const FUZZ_ADDRESSES = [_][]const u8{ "path-a", "path-b", "path-c", "path-d" };
 
 fn drive(input: []const u8) void {
     inline for (.{ Role.server, Role.client }) |role| {
@@ -35,7 +40,7 @@ fn drive(input: []const u8) void {
                 switch (ev) {
                     .need_data, .connection_closed => break,
                     .end_of_message => {
-                        r.reset();
+                        r.reset() catch continue :outer;
                         break;
                     },
                     else => {},
@@ -141,21 +146,122 @@ fn driveQpackRoundtrip(input: []const u8) void {
     std.debug.assert(headersEqual(headers, out));
 }
 
+fn deliverAppPacket(conn: *QuicConnection, pn: u64, frames: []const u8, address: []const u8) bool {
+    const datagram = core.quic.connection.testBuildApp(std.heap.c_allocator, &FUZZ_DCID, pn, frames) catch return false;
+    defer std.heap.c_allocator.free(datagram);
+    conn.receiveDatagramFrom(datagram, pn + 1, address) catch return false;
+    conn.clearSend();
+    return true;
+}
+
+fn driveQuic(input: []const u8) void {
+    const body = input[0..@min(input.len, MAX_STATE_INPUT)];
+
+    var unauthenticated = QuicConnection.init(std.heap.c_allocator, .server, &FUZZ_DCID) catch return;
+    defer unauthenticated.deinit();
+    core.quic.connection.testInstallAppKeys(&unauthenticated);
+    unauthenticated.receiveDatagramFrom(body, 0, FUZZ_ADDRESSES[0]) catch {};
+
+    var conn = QuicConnection.init(std.heap.c_allocator, .server, &FUZZ_DCID) catch return;
+    defer conn.deinit();
+    core.quic.connection.testInstallAppKeys(&conn);
+
+    const split = if (body.len == 0) 0 else @as(usize, body[0]) % (body.len + 1);
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(std.heap.c_allocator);
+
+    quic_frame.encodeStream(&frames, std.heap.c_allocator, 0, split, body[split..], true) catch return;
+    if (!deliverAppPacket(&conn, 0, frames.items, FUZZ_ADDRESSES[0])) return;
+    frames.clearRetainingCapacity();
+    quic_frame.encodeStream(&frames, std.heap.c_allocator, 0, 0, body[0..split], false) catch return;
+    if (!deliverAppPacket(&conn, 1, frames.items, FUZZ_ADDRESSES[1])) return;
+
+    frames.clearRetainingCapacity();
+    const reset_code = if (body.len == 0) 0 else body[0];
+    const reset_size = if (body.len < 2) body.len else @as(u64, body[1]) * 16;
+    quic_frame.encodeResetStream(&frames, std.heap.c_allocator, 4, reset_code, reset_size) catch return;
+    if (!deliverAppPacket(&conn, 2, frames.items, FUZZ_ADDRESSES[2])) return;
+
+    const ping = [_]u8{0x01} ++ [_]u8{0x00} ** 19;
+    const tampered = core.quic.connection.testBuildApp(std.heap.c_allocator, &FUZZ_DCID, 3, &ping) catch return;
+    defer std.heap.c_allocator.free(tampered);
+    tampered[tampered.len - 1] ^= if (body.len == 0) 1 else body[0] | 1;
+    conn.receiveDatagramFrom(tampered, 4, FUZZ_ADDRESSES[3]) catch {};
+}
+
+fn driveH3(input: []const u8) void {
+    const body = input[0..@min(input.len, MAX_STATE_INPUT)];
+    var qc = QuicConnection.init(std.heap.c_allocator, .server, &FUZZ_DCID) catch return;
+    defer qc.deinit();
+    core.quic.connection.testInstallAppKeys(&qc);
+    var h3 = H3Connection.init(std.heap.c_allocator, &qc);
+    defer h3.deinit();
+
+    var h3_bytes: std.ArrayListUnmanaged(u8) = .empty;
+    defer h3_bytes.deinit(std.heap.c_allocator);
+    h3_bytes.append(std.heap.c_allocator, 0) catch return;
+    h3_frame.append(&h3_bytes, std.heap.c_allocator, .settings, &.{}) catch return;
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(std.heap.c_allocator);
+    quic_frame.encodeStream(&frames, std.heap.c_allocator, 2, 0, h3_bytes.items, false) catch return;
+    if (!deliverAppPacket(&qc, 0, frames.items, FUZZ_ADDRESSES[0])) return;
+    h3.pump(2) catch return;
+
+    h3_bytes.clearRetainingCapacity();
+    const qpack_block = [_]u8{ 0x00, 0x00, 0xC0 | 17, 0xC0 | 23, 0xC0 | 1 };
+    h3_frame.append(&h3_bytes, std.heap.c_allocator, .headers, &qpack_block) catch return;
+    h3_bytes.appendSlice(std.heap.c_allocator, body) catch return;
+    const split = (if (body.len == 0) 0 else @as(usize, body[0])) %
+        (h3_bytes.items.len + 1);
+
+    frames.clearRetainingCapacity();
+    quic_frame.encodeStream(
+        &frames,
+        std.heap.c_allocator,
+        0,
+        split,
+        h3_bytes.items[split..],
+        false,
+    ) catch return;
+    if (!deliverAppPacket(&qc, 1, frames.items, FUZZ_ADDRESSES[1])) return;
+    h3.pump(0) catch return;
+    frames.clearRetainingCapacity();
+    quic_frame.encodeStream(&frames, std.heap.c_allocator, 0, 0, h3_bytes.items[0..split], false) catch return;
+    if (!deliverAppPacket(&qc, 2, frames.items, FUZZ_ADDRESSES[2])) return;
+    h3.pump(0) catch return;
+
+    frames.clearRetainingCapacity();
+    const reset_code = if (body.len < 2) 0 else body[1];
+    quic_frame.encodeResetStream(&frames, std.heap.c_allocator, 0, reset_code, h3_bytes.items.len) catch return;
+    if (deliverAppPacket(&qc, 3, frames.items, FUZZ_ADDRESSES[3])) h3.pump(0) catch {};
+
+    for (0..64) |_| switch (h3.nextEvent()) {
+        .need_data => break,
+        else => {},
+    };
+}
+
 export fn zttp_fuzz_drive(data: [*]const u8, size: usize) callconv(.c) void {
     const input = data[0..size];
-    // The low 2 bits of the first byte select the target so one corpus exercises
-    // every surface (H1 read, H2 read, HPACK and QPACK encode->decode); the rest
-    // is the mutated body. No build wiring changes: the `.fuzz` instrumentation
-    // already covers the whole `core` import.
     if (input.len == 0) {
         drive(input);
         return;
     }
-    const body = input[1..];
-    switch (@as(u2, @truncate(input[0]))) {
+    const body = input[1..@min(input.len, MAX_FUZZ_INPUT + 1)];
+    switch (input[0] % 6) {
         0 => drive(body),
         1 => driveH2(body),
         2 => driveHpackRoundtrip(body),
         3 => driveQpackRoundtrip(body),
+        4 => driveQuic(body),
+        5 => driveH3(body),
+        else => unreachable,
     }
+}
+
+test "stateful fuzz drivers accept bounded seeds" {
+    const quic_seed = "(reordered stream data and a reset";
+    zttp_fuzz_drive(quic_seed.ptr, quic_seed.len);
+    const h3_seed = ")headers, data, reset, and path changes";
+    zttp_fuzz_drive(h3_seed.ptr, h3_seed.len);
 }

--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -210,7 +210,7 @@ fn driveH3(input: []const u8) void {
     h3_bytes.clearRetainingCapacity();
     const qpack_block = [_]u8{ 0x00, 0x00, 0xC0 | 17, 0xC0 | 23, 0xC0 | 1 };
     h3_frame.append(&h3_bytes, std.heap.c_allocator, .headers, &qpack_block) catch return;
-    h3_bytes.appendSlice(std.heap.c_allocator, body) catch return;
+    h3_frame.append(&h3_bytes, std.heap.c_allocator, .data, body) catch return;
     const split = (if (body.len == 0) 0 else @as(usize, body[0])) %
         (h3_bytes.items.len + 1);
 

--- a/scripts/check
+++ b/scripts/check
@@ -17,4 +17,4 @@ uv run --no-sync python -m mypy.stubtest zttp._zttp --allowlist tests/stubtest_a
 uv run --no-sync ruff check $SOURCE_FILES
 
 # Zig.
-zig fmt --check src build.zig
+zig fmt --check src fuzz/target.zig build.zig

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -3180,6 +3180,11 @@ pub fn testInstallAppKeys(conn: *Connection) void {
     conn.peer_uni_streams = flow.StreamLimit.init(conn.local_tp.initial_max_streams_uni);
 }
 
+/// Mark a test connection's handshake as confirmed without running TLS.
+pub fn testConfirmHandshake(conn: *Connection) void {
+    conn.handshake_confirmed = true;
+}
+
 pub fn testSetAppNextPn(conn: *Connection, next_pn: u64) void {
     conn.spaces[@intFromEnum(Space.application)].next_pn = next_pn;
 }


### PR DESCRIPTION
## Summary

Add bounded coverage-guided QUIC and HTTP/3 drivers for authenticated and unauthenticated packets, reordered stream data, resets, and path changes. Add state-machine corpus seeds, smoke coverage, and a Linux ASan/UBSan/LeakSanitizer campaign to the fuzz workflow.

Closes #261.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

