### PR TITLE
Advertise MAX_STREAMS after peer streams close

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1272,12 +1272,16 @@ pub const Connection = struct {
 
     fn checkPeerStreamLimit(self: *Connection, id: u64) Error!void {
         if (!self.isPeerInitiated(id)) return;
-        const st = stream.StreamType.of(id);
+        const is_uni = stream.StreamType.of(id).isUni();
         const idx = id >> 2;
-        if (st.isUni()) {
-            self.peer_uni_streams.onOpened(idx) catch return error.StreamLimitError;
-        } else {
-            self.peer_bidi_streams.onOpened(idx) catch return error.StreamLimitError;
+        const limit = if (is_uni) &self.peer_uni_streams else &self.peer_bidi_streams;
+        limit.onOpened(idx) catch return error.StreamLimitError;
+        if (limit.shouldUpdate()) {
+            if (is_uni) {
+                self.max_streams_uni_pending = true;
+            } else {
+                self.max_streams_bidi_pending = true;
+            }
         }
     }
 
@@ -5792,6 +5796,39 @@ test "closing a peer stream advertises a raised MAX_STREAMS" {
     try conn.flushSend(2000);
     try testing.expect(!conn.max_streams_bidi_pending);
     try testing.expect(conn.datagramLengths().len >= 1);
+}
+
+test "opening later peer streams advertises previously closed capacity" {
+    const gpa = testing.allocator;
+    const dcid = [_]u8{ 0x16, 0x17, 0x18, 0x1a };
+    var conn = try Connection.init(gpa, .server, &dcid);
+    defer conn.deinit();
+    testInstallAppKeys(&conn);
+    conn.peer_bidi_streams = flow.StreamLimit.init(4);
+
+    var frames: std.ArrayListUnmanaged(u8) = .empty;
+    defer frames.deinit(gpa);
+    try frame.encodeStream(&frames, gpa, 0, 0, "x", true);
+    const closed = try testBuildApp(gpa, &dcid, 0, frames.items);
+    defer gpa.free(closed);
+    try conn.receiveDatagram(closed, 1000);
+    conn.consumeStream(0, 1);
+    try testing.expect(conn.dropStream(0));
+
+    conn.clearSend();
+    frames.clearRetainingCapacity();
+    for ([_]u64{ 4, 8, 12 }) |id| try frame.encodeStream(&frames, gpa, id, 0, "", false);
+    const opened = try testBuildApp(gpa, &dcid, 1, frames.items);
+    defer gpa.free(opened);
+    try conn.receiveDatagram(opened, 2000);
+    try conn.flushSend(3000);
+
+    const decoded = try decodeQueuedAppFrame(&conn, 1);
+    defer gpa.free(decoded.work);
+    defer gpa.free(decoded.plaintext);
+    try testing.expectEqual(@as(std.meta.Tag(frame.Frame), .max_streams), std.meta.activeTag(decoded.frame));
+    try testing.expect(decoded.frame.max_streams.bidi);
+    try testing.expectEqual(@as(u64, 5), decoded.frame.max_streams.max);
 }
 
 test "local stream creation is limited by peer initial_max_streams" {

--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -1276,10 +1276,8 @@ pub const Connection = struct {
         const idx = id >> 2;
         if (st.isUni()) {
             self.peer_uni_streams.onOpened(idx) catch return error.StreamLimitError;
-            if (self.peer_uni_streams.shouldUpdate()) self.max_streams_uni_pending = true;
         } else {
             self.peer_bidi_streams.onOpened(idx) catch return error.StreamLimitError;
-            if (self.peer_bidi_streams.shouldUpdate()) self.max_streams_bidi_pending = true;
         }
     }
 
@@ -3224,6 +3222,17 @@ pub const Connection = struct {
         _ = self.recv_windows.remove(id);
         _ = self.max_stream_data_pending.remove(id);
         _ = self.peer_stream_data_blocked.remove(id);
+        if (self.isPeerInitiated(id)) {
+            const limit = if (stream.StreamType.of(id).isUni()) &self.peer_uni_streams else &self.peer_bidi_streams;
+            limit.onClosed();
+            if (limit.shouldUpdate()) {
+                if (stream.StreamType.of(id).isUni()) {
+                    self.max_streams_uni_pending = true;
+                } else {
+                    self.max_streams_bidi_pending = true;
+                }
+            }
+        }
         s.deinit();
         self.gpa.destroy(s);
         return true;
@@ -5760,7 +5769,7 @@ test "STOP_SENDING rejects streams past the advertised count" {
     try testing.expectEqual(@as(usize, 0), conn.peer_reset_streams.count());
 }
 
-test "opening enough peer streams advertises a raised MAX_STREAMS" {
+test "closing a peer stream advertises a raised MAX_STREAMS" {
     const gpa = testing.allocator;
     const dcid = [_]u8{ 0x16, 0x17, 0x18, 0x19 };
     var conn = try Connection.init(gpa, .server, &dcid);
@@ -5770,10 +5779,13 @@ test "opening enough peer streams advertises a raised MAX_STREAMS" {
 
     var frames: std.ArrayListUnmanaged(u8) = .empty;
     defer frames.deinit(gpa);
-    try frame.encodeStream(&frames, gpa, 4, 0, "x", false); // opens index 1 of 2
+    try frame.encodeStream(&frames, gpa, 4, 0, "x", true); // opens index 1 of 2
     const dgram = try testBuildApp(gpa, &dcid, 0, frames.items);
     defer gpa.free(dgram);
     try conn.receiveDatagram(dgram, 1000);
+    try testing.expect(!conn.max_streams_bidi_pending);
+    conn.consumeStream(4, 1);
+    try testing.expect(conn.dropStream(4));
     try testing.expect(conn.max_streams_bidi_pending);
 
     conn.clearSend(); // discard ACK bytes from receiving the STREAM

--- a/src/core/quic/flow.zig
+++ b/src/core/quic/flow.zig
@@ -102,15 +102,19 @@ pub const SendWindow = struct {
 
 /// The concurrency cap on streams a peer may open (RFC 9000 4.6, MAX_STREAMS).
 /// Bidi and uni are tracked separately by the caller with two of these. It mirrors
-/// `Window`: the cap slides above the highest stream opened so a steady stream of
-/// short-lived requests is never starved, re-advertising once headroom runs low.
+/// `Window`: closed streams return credit so a steady stream of short-lived requests
+/// is never starved without allowing more than `window` streams concurrently.
 pub const StreamLimit = struct {
     /// The maximum stream count the peer may open (a count, not an id).
     max: u64,
     /// The highest stream count opened so far; the floor the cap slides above.
     opened: u64 = 0,
-    /// The headroom to keep ahead of `opened`; a new cap is `opened + window`.
+    /// The maximum number of peer streams allowed concurrently.
     window: u64,
+    /// Peer streams that reached a terminal state and can be replaced.
+    closed: u64 = 0,
+    /// Closed-stream credit already included in an advertised limit.
+    granted_closed: u64 = 0,
 
     pub fn init(max: u64) StreamLimit {
         return .{ .max = max, .window = max };
@@ -128,18 +132,24 @@ pub const StreamLimit = struct {
         self.opened = @max(self.opened, index + 1);
     }
 
+    /// A peer-initiated stream reached a terminal state.
+    pub fn onClosed(self: *StreamLimit) void {
+        self.closed += 1;
+    }
+
     /// Should a higher cap be advertised? True once the headroom ahead of the highest
     /// opened stream falls below half the window (RFC 9000 4.6 auto-tuning). The half is
     /// rounded up so a window of 1 still trips after its single slot is used - an
     /// integer `window / 2` would be 0, a threshold unsigned headroom can never fall
     /// below, stranding a one-request-at-a-time server.
     pub fn shouldUpdate(self: *const StreamLimit) bool {
-        return self.max - self.opened < (self.window + 1) / 2;
+        return self.closed > self.granted_closed and self.max - self.opened < (self.window + 1) / 2;
     }
 
-    /// Slide the cap to `opened + window` and record it; the new value to advertise.
+    /// Add newly closed-stream credit to the cumulative limit and return it.
     pub fn grant(self: *StreamLimit) u64 {
-        self.max = self.opened + self.window;
+        self.max += self.closed - self.granted_closed;
+        self.granted_closed = self.closed;
         return self.max;
     }
 
@@ -191,24 +201,28 @@ test "stream limit rejects too many streams" {
     try std.testing.expectError(error.StreamLimitError, l.onOpened(3));
 }
 
-test "stream limit re-advertises once headroom runs low" {
+test "stream limit re-advertises closed capacity once headroom runs low" {
     var l = StreamLimit.init(4);
     try std.testing.expect(!l.shouldUpdate());
     try l.onOpened(0);
     try l.onOpened(1);
     try l.onOpened(2); // 3 of 4 opened: headroom 1 < window/2 (2)
-    try std.testing.expect(l.shouldUpdate());
-    try std.testing.expectEqual(@as(u64, 7), l.grant()); // opened 3 + window 4
     try std.testing.expect(!l.shouldUpdate());
-    try l.onOpened(6); // the newly granted ids are now usable
+    l.onClosed();
+    try std.testing.expect(l.shouldUpdate());
+    try std.testing.expectEqual(@as(u64, 5), l.grant());
+    try std.testing.expect(!l.shouldUpdate());
+    try l.onOpened(4); // the replacement stream is now permitted
 }
 
-test "a window of 1 still slides after its single slot is used" {
+test "a window of 1 grants a replacement after its stream closes" {
     var l = StreamLimit.init(1);
     try std.testing.expect(!l.shouldUpdate()); // nothing opened yet
     try l.onOpened(0); // the one allowed stream
-    try std.testing.expect(l.shouldUpdate()); // would be never-true with `window / 2`
-    try std.testing.expectEqual(@as(u64, 2), l.grant()); // opened 1 + window 1
+    try std.testing.expect(!l.shouldUpdate());
+    l.onClosed();
+    try std.testing.expect(l.shouldUpdate());
+    try std.testing.expectEqual(@as(u64, 2), l.grant());
     try l.onOpened(1); // the next stream is now permitted
 }
 


### PR DESCRIPTION
## Summary

- Return peer stream capacity only after a stream reaches a terminal state.
- Keep the configured bidirectional and unidirectional concurrency windows bounded.
- Cover closure-driven MAX_STREAMS advertisement for regular and single-stream windows.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

