### PR TITLE
Bound pending HTTP/3 events

### DIFF
--- a/fuzz/target.zig
+++ b/fuzz/target.zig
@@ -207,7 +207,7 @@ fn driveH3(input: []const u8) void {
     defer frames.deinit(std.heap.c_allocator);
     quic_frame.encodeStream(&frames, std.heap.c_allocator, 2, 0, h3_bytes.items, false) catch return;
     if (!deliverAppPacket(&qc, 0, frames.items, FUZZ_ADDRESSES[0])) return;
-    h3.pump(2) catch return;
+    h3.pumpStreams(&.{2}) catch return;
 
     h3_bytes.clearRetainingCapacity();
     const qpack_block = [_]u8{ 0x00, 0x00, 0xC0 | 17, 0xC0 | 23, 0xC0 | 1 };
@@ -226,16 +226,16 @@ fn driveH3(input: []const u8) void {
         false,
     ) catch return;
     if (!deliverAppPacket(&qc, 1, frames.items, FUZZ_ADDRESSES[1])) return;
-    h3.pump(0) catch return;
+    h3.pumpStreams(&.{0}) catch return;
     frames.clearRetainingCapacity();
     quic_frame.encodeStream(&frames, std.heap.c_allocator, 0, 0, h3_bytes.items[0..split], false) catch return;
     if (!deliverAppPacket(&qc, 2, frames.items, FUZZ_ADDRESSES[2])) return;
-    h3.pump(0) catch return;
+    h3.pumpStreams(&.{0}) catch return;
 
     frames.clearRetainingCapacity();
     const reset_code = if (body.len < 2) 0 else body[1];
     quic_frame.encodeResetStream(&frames, std.heap.c_allocator, 0, reset_code, h3_bytes.items.len) catch return;
-    if (deliverAppPacket(&qc, 3, frames.items, FUZZ_ADDRESSES[3])) h3.pump(0) catch {};
+    if (deliverAppPacket(&qc, 3, frames.items, FUZZ_ADDRESSES[3])) h3.pumpStreams(&.{0}) catch {};
 
     for (0..64) |_| switch (h3.nextEvent()) {
         .need_data => break,

--- a/src/core/h3/connection.zig
+++ b/src/core/h3/connection.zig
@@ -37,7 +37,15 @@ pub const Error = error{
     /// Internal signal: a QPACK field section is waiting for more encoder-stream
     /// inserts and has been stored on the stream for later retry.
     Blocked,
+    /// The integrator must drain queued events before pumping more transport data.
+    EventQueueFull,
     OutOfMemory,
+};
+
+/// Resource limits for one HTTP/3 connection.
+pub const Limits = struct {
+    /// Require the integrator to drain before the next pump batch once this many events are waiting.
+    max_pending_events: usize = 1024,
 };
 
 const MsgState = enum { idle, headers_done, trailers_done, done, rejected };
@@ -117,6 +125,7 @@ const QPACK_BLOCKED_STREAMS = qpack_enc.max_blocked_streams;
 pub const Connection = struct {
     gpa: std.mem.Allocator,
     qc: *quic_conn.Connection,
+    limits: Limits,
     streams: std.AutoHashMapUnmanaged(u64, RequestStream) = .empty,
     send_state: std.AutoHashMapUnmanaged(u64, SendState) = .empty,
     send_content_length: std.AutoHashMapUnmanaged(u64, u64) = .empty,
@@ -170,11 +179,17 @@ pub const Connection = struct {
     pending_reject: ?h3_error.ErrorCode = null,
 
     pub fn init(gpa: std.mem.Allocator, qc: *quic_conn.Connection) Connection {
+        return initWithLimits(gpa, qc, .{});
+    }
+
+    /// Initialize a connection with explicit resource limits.
+    pub fn initWithLimits(gpa: std.mem.Allocator, qc: *quic_conn.Connection, limits: Limits) Connection {
         var dec = qpack.Decoder.init(gpa, MAX_FIELD_SECTION_SIZE);
         dec.setMaxDynamicCapacity(QPACK_MAX_TABLE_CAPACITY);
         return .{
             .gpa = gpa,
             .qc = qc,
+            .limits = limits,
             .qpack_dec = dec,
             .qpack_enc_state = qpack_enc.Encoder.init(gpa),
             .arena = std.heap.ArenaAllocator.init(gpa),
@@ -310,11 +325,13 @@ pub const Connection = struct {
 
     /// Advance only the streams changed by the datagram the transport just handled.
     pub fn pumpStreams(self: *Connection, ids: []const u64) Error!void {
+        if (self.eventQueueFull()) return error.EventQueueFull;
         try self.pumpStreamSnapshot(ids);
     }
 
     /// Advance every stream the transport currently knows about.
     pub fn pumpAll(self: *Connection) Error!void {
+        if (self.eventQueueFull()) return error.EventQueueFull;
         var stack_ids: [64]u64 = undefined;
         const count = self.qc.streamCount();
         if (count <= stack_ids.len) {
@@ -361,7 +378,7 @@ pub const Connection = struct {
         return quic_stream.StreamType.of(id) == .client_bidi;
     }
 
-    pub fn pump(self: *Connection, id: u64) Error!void {
+    fn pump(self: *Connection, id: u64) Error!void {
         switch (self.qc.role) {
             .server => switch (quic_stream.StreamType.of(id)) {
                 .client_bidi => try self.pumpRequest(id),
@@ -1314,6 +1331,11 @@ pub const Connection = struct {
         const ev = self.queue.items[self.qpos];
         self.qpos += 1;
         return ev;
+    }
+
+    /// Whether the integrator must drain events before pumping another batch.
+    pub fn eventQueueFull(self: *const Connection) bool {
+        return self.queue.items.len - self.qpos >= self.limits.max_pending_events;
     }
 
     // ---- response send path (RFC 9114 4.1) -------------------------------------
@@ -3424,8 +3446,9 @@ test "a request split across two datagrams parses correctly (parsed-offset regre
     var qc = try quic_conn.Connection.init(gpa, .server, &dcid);
     defer qc.deinit();
     quic_conn.testInstallAppKeys(&qc); // H3 request data rides the Application space
-    var h3 = Connection.init(gpa, &qc);
+    var h3 = Connection.initWithLimits(gpa, &qc, .{ .max_pending_events = 1 });
     defer h3.deinit();
+    h3.peer_settings = .{};
 
     const qpack_block = [_]u8{ 0x00, 0x00, 0xC0 | 20, 0xC0 | 23, 0xC0 | 1 }; // POST https /
     var headers_bytes: std.ArrayListUnmanaged(u8) = .empty;
@@ -3439,15 +3462,17 @@ test "a request split across two datagrams parses correctly (parsed-offset regre
     const dg1 = try buildRequestAt(gpa, &dcid, 0, 0, headers_bytes.items);
     defer gpa.free(dg1);
     try qc.receiveDatagram(dg1, 1000);
-    try h3.pump(0);
-    try testing.expect(h3.nextEvent() == .request);
-    try testing.expect(h3.nextEvent() == .need_data);
+    try h3.pumpStreams(&.{0});
+    try testing.expect(h3.eventQueueFull());
 
     // Datagram 2: the DATA frame at the offset right after the HEADERS frame.
     const dg2 = try buildRequestAt(gpa, &dcid, headers_bytes.items.len, 1, data_bytes.items);
     defer gpa.free(dg2);
     try qc.receiveDatagram(dg2, 2000);
-    try h3.pump(0);
+    try testing.expectError(error.EventQueueFull, h3.pumpStreams(&.{0}));
+    try testing.expect(h3.nextEvent() == .request);
+    try testing.expect(h3.nextEvent() == .need_data);
+    try h3.pumpStreams(&.{0});
     const data_ev = h3.nextEvent();
     try testing.expect(data_ev == .data);
     try testing.expectEqualStrings("second-datagram-body", data_ev.data.data);

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -805,6 +805,14 @@ const H3Engine = struct {
     }
 
     fn receiveDatagram(self: *H3Engine, dgram: []const u8, now: u64, peer_address: ?[]const u8) py.Object {
+        if (self.h3) |h| {
+            if (h.eventQueueFull()) {
+                return py.raise(
+                    exceptions.LocalProtocolError,
+                    "drain pending HTTP/3 events before receiving more data",
+                );
+            }
+        }
         self.now = now;
         if (self.qc == null) {
             // Build the transport from the connection id in the client's first

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2878,8 +2878,7 @@ fn h2RaiseWrite(e: core.h2.writer.WriteError) py.Object {
 fn h3RaiseLocal(e: core.h3.connection.Error) py.Object {
     return switch (e) {
         error.OutOfMemory => c.PyErr_NoMemory(),
-        error.H3Error, error.EventQueueFull, error.Blocked =>
-            py.raise(exceptions.LocalProtocolError, "invalid HTTP/3 send"),
+        error.H3Error, error.EventQueueFull, error.Blocked => py.raise(exceptions.LocalProtocolError, "invalid HTTP/3 send"),
     };
 }
 

--- a/src/python/exceptions.zig
+++ b/src/python/exceptions.zig
@@ -83,6 +83,10 @@ pub fn raiseH3(e: H3Error) py.Object {
     return switch (e) {
         error.OutOfMemory => c.PyErr_NoMemory(),
         error.H3Error => py.raise(RemoteProtocolError, "HTTP/3 protocol error"),
+        error.EventQueueFull => py.raise(
+            LocalProtocolError,
+            "drain pending HTTP/3 events before receiving more data",
+        ),
         // A stream-level error is handled inside the pump (it resets one stream), so it
         // never escapes to here; mapped only to keep the switch exhaustive.
         error.StreamError, error.Blocked => py.raise(RemoteProtocolError, "HTTP/3 stream error"),

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -424,7 +424,11 @@ class H3Connection(Connection):
         """
 
     def receive_datagram(self, datagram: Buffer, now: int = ..., peer_address: bytes | None = ..., /) -> None:
-        """Feed one received UDP datagram. `peer_address` is an opaque key for path validation."""
+        """Feed one received UDP datagram. `peer_address` is an opaque key for path validation.
+
+        Drain events regularly. Once 1024 events are pending, this raises
+        `LocalProtocolError` until `next_event()` reduces the backlog.
+        """
 
     def data_to_send_with_addresses(self) -> list[OutboundDatagram]:
         """Return queued datagrams with their opaque destination address keys."""


### PR DESCRIPTION
## Summary

- Add a configurable HTTP/3 pending-event high-water mark.
- Require callers to drain events before pumping more transport data at the limit.
- Keep the low-level single-stream pump private and exercise backpressure through the public batch API.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

