### PR TITLE
Bind endpoint tokens to authenticated paths

### DIFF
--- a/src/core/quic/connection.zig
+++ b/src/core/quic/connection.zig
@@ -958,6 +958,12 @@ pub const Connection = struct {
         return provisional.state.address;
     }
 
+    /// The authenticated default path address, or null before an addressed packet authenticates.
+    pub fn defaultPathAddress(self: *const Connection) ?[]const u8 {
+        const token = self.default_path_token orelse return null;
+        return self.pathAddress(token);
+    }
+
     /// Switch subsequent packets to a peer-issued connection id (RFC 9000 5.1).
     /// The id must have arrived in NEW_CONNECTION_ID and must not have been retired.
     pub fn usePeerConnectionId(self: *Connection, seq: u64) Error!void {

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -892,6 +892,12 @@ const H3Engine = struct {
         return c.PyLong_FromUnsignedLongLong(q.localConnectionIdGeneration());
     }
 
+    fn endpointPeerAddress(self: *const H3Engine) py.Object {
+        const q = self.qc orelse return py.none();
+        const address = q.defaultPathAddress() orelse return py.none();
+        return py.fromBytes(address);
+    }
+
     fn nextEvent(self: *H3Engine) py.Object {
         const h = self.h3 orelse return py.newRef(events_obj.need_data); // no datagram fed yet
         return events_obj.fromH3Event(h.nextEvent());
@@ -3062,6 +3068,15 @@ fn h3_endpoint_connection_id_generation(self_obj: ?*c.PyObject, _: ?*c.PyObject)
     };
 }
 
+fn h3_endpoint_peer_address(self_obj: ?*c.PyObject, _: ?*c.PyObject) callconv(.c) py.Object {
+    const self: *ConnectionObject = @ptrCast(self_obj.?);
+    const engine = self.engine orelse return py.raiseRuntime("connection is closed");
+    return switch (engine.*) {
+        .h3 => |*e| e.endpointPeerAddress(),
+        else => py.raiseRuntime("_endpoint_peer_address is only valid for an HTTP/3 connection"),
+    };
+}
+
 fn h3_challenge_path(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Object {
     const self: *ConnectionObject = @ptrCast(self_obj.?);
     const engine = self.engine orelse return py.raiseRuntime("connection is closed");
@@ -3421,6 +3436,7 @@ var h3_methods = [_]py.MethodDef{
     .{ .ml_name = "_set_endpoint_context", .ml_meth = lockedConnectionMethod(h3_set_endpoint_context), .ml_flags = c.METH_VARARGS, .ml_doc = "Configure endpoint-selected connection IDs before receiving the first Initial." },
     .{ .ml_name = "_endpoint_ready", .ml_meth = lockedConnectionMethod(h3_endpoint_ready), .ml_flags = c.METH_NOARGS, .ml_doc = "Whether the endpoint connection authenticated its first Initial." },
     .{ .ml_name = "_endpoint_connection_id_generation", .ml_meth = lockedConnectionMethod(h3_endpoint_connection_id_generation), .ml_flags = c.METH_NOARGS, .ml_doc = "Return the active local connection ID generation." },
+    .{ .ml_name = "_endpoint_peer_address", .ml_meth = lockedConnectionMethod(h3_endpoint_peer_address), .ml_flags = c.METH_NOARGS, .ml_doc = "Return the authenticated default peer address." },
     .{ .ml_name = "challenge_path", .ml_meth = lockedConnectionMethod(h3_challenge_path), .ml_flags = c.METH_VARARGS, .ml_doc = "Queue a QUIC PATH_CHALLENGE for a peer address: challenge_path(peer_address, data). data must be 8 unpredictable bytes. Drain with data_to_send_with_addresses." },
     .{ .ml_name = "use_peer_connection_id", .ml_meth = lockedConnectionMethod(h3_use_peer_connection_id), .ml_flags = c.METH_O, .ml_doc = "Switch future QUIC packets to a peer-issued NEW_CONNECTION_ID sequence: use_peer_connection_id(sequence_number)." },
     .{ .ml_name = "local_connection_ids", .ml_meth = lockedConnectionMethod(h3_local_connection_ids), .ml_flags = c.METH_NOARGS, .ml_doc = "Return every active local QUIC connection ID and sequence number." },

--- a/tests/test_http3.py
+++ b/tests/test_http3.py
@@ -223,6 +223,9 @@ def test_quic_endpoint_completes_retry_and_routes_the_connection() -> None:
     assert routed
     assert all(connection is server for connection in routed)
 
+    spoofed = b"\x40" + replacement_connection_id + b"\x00" * 32
+    assert endpoint.receive_datagram(spoofed, b"spoofed-address", 11_500) is server
+
     endpoint.issue_token(server, 12_000)
     for datagram in endpoint.data_to_send():
         client.receive_datagram(datagram.data, 13_000)

--- a/zttp/_zttp.pyi
+++ b/zttp/_zttp.pyi
@@ -443,6 +443,9 @@ class H3Connection(Connection):
     def _endpoint_connection_id_generation(self) -> int:
         """Return the active local connection ID generation."""
 
+    def _endpoint_peer_address(self) -> bytes | None:
+        """Return the authenticated default peer address."""
+
     def _endpoint_issue_connection_id(
         self,
         sequence_number: int,

--- a/zttp/endpoint.py
+++ b/zttp/endpoint.py
@@ -300,9 +300,12 @@ class QuicEndpoint:
         peer_address: bytes,
         now: int,
     ) -> H3Connection:
-        state.peer_address = peer_address
         try:
             state.connection.receive_datagram(datagram, now, peer_address)
+            authenticated_address = state.connection._endpoint_peer_address()
+            if authenticated_address is None:  # pragma: no cover - accepted connections have an authenticated Initial
+                raise RuntimeError("endpoint connection has no authenticated peer address")
+            state.peer_address = authenticated_address
         finally:
             if state.connection_id_generation != state.connection._endpoint_connection_id_generation():
                 self._sync_routes(state)


### PR DESCRIPTION
## Summary

- Expose the QUIC core's authenticated default path to the endpoint adapter.
- Update endpoint peer state only from authenticated path data.
- Keep forged packets from changing the address bound into NEW_TOKEN values.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

