### PR TITLE
Build Windows ARM64 wheels

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,14 @@ jobs:
         # Zig cross-compiles, but cibuildwheel still needs a native runner per OS
         # to build the manylinux/musllinux containers and the macOS/Windows
         # wheels. aarch64 Linux uses the native ARM runner; macOS arm64 + x86_64
-        # build on the arm runner; Windows builds run natively on amd64 and arm64.
-        os:
-          - "ubuntu-latest"
-          - "ubuntu-24.04-arm"
-          - "macos-latest"
-          - "windows-latest"
-          - "windows-11-vs2026-arm"
+        # build on the arm runner; Windows wheels are tested natively on both arches.
+        include:
+          - os: "ubuntu-latest"
+          - os: "ubuntu-24.04-arm"
+          - os: "macos-latest"
+          - os: "windows-latest"
+          - os: "windows-11-vs2026-arm"
+            zig_target: "aarch64-windows-msvc"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,14 +46,28 @@ jobs:
         with:
           enable-cache: false
 
+      # Native Zig 0.16 exits during Windows ARM64 builds; x64 Zig cross-compiles under emulation.
+      - name: Install x64 Zig on Windows ARM64
+        if: matrix.os == 'windows-11-vs2026-arm'
+        shell: pwsh
+        run: |
+          $archive = Join-Path $env:RUNNER_TEMP "zig-x86_64-windows-0.16.0.zip"
+          Invoke-WebRequest -Uri "https://ziglang.org/download/0.16.0/zig-x86_64-windows-0.16.0.zip" -OutFile $archive
+          $actual = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e") {
+            throw "Zig archive checksum mismatch"
+          }
+          Expand-Archive -Path $archive -DestinationPath $env:RUNNER_TEMP
+          Add-Content -Path $env:GITHUB_PATH -Value (Join-Path $env:RUNNER_TEMP "zig-x86_64-windows-0.16.0")
+
       - name: Test Zig on Windows ARM64
         if: matrix.os == 'windows-11-vs2026-arm'
-        run: |
-          uvx --from ziglang==0.16.0 python-zig version
-          uvx --from ziglang==0.16.0 python-zig build test
+        run: zig build test -Dtarget=aarch64-windows-msvc
 
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        env:
+          HATCH_ZIG_TARGET: "${{ matrix.zig_target }}"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
   build-wheels:
     name: "Wheels on ${{ matrix.os }}"
     runs-on: "${{ matrix.os }}"
-    # Windows builds each cp3x wheel serially at ~2-4 min apiece; six of them
-    # with a cold Zig cache overran the previous 15 min limit.
-    timeout-minutes: 30
+    # Windows builds each cp3x wheel serially at ~2-4 min apiece; eight of them
+    # with a cold Zig cache need more time than the other platforms.
+    timeout-minutes: 40
     permissions:
       contents: read
     strategy:
@@ -23,8 +23,13 @@ jobs:
         # Zig cross-compiles, but cibuildwheel still needs a native runner per OS
         # to build the manylinux/musllinux containers and the macOS/Windows
         # wheels. aarch64 Linux uses the native ARM runner; macOS arm64 + x86_64
-        # build on the arm runner; Windows builds amd64.
-        os: ["ubuntu-latest", "ubuntu-24.04-arm", "macos-latest", "windows-latest"]
+        # build on the arm runner; Windows builds run natively on amd64 and arm64.
+        os:
+          - "ubuntu-latest"
+          - "ubuntu-24.04-arm"
+          - "macos-latest"
+          - "windows-latest"
+          - "windows-11-vs2026-arm"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Test Zig on Windows ARM64
         if: matrix.os == 'windows-11-vs2026-arm'
-        run: uvx --from ziglang==0.16.0 python-zig build test
+        run: |
+          uvx --from ziglang==0.16.0 python-zig version
+          uvx --from ziglang==0.16.0 python-zig build test
 
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Test Zig on Windows ARM64
         if: matrix.os == 'windows-11-vs2026-arm'
-        run: uvx --from ziglang==0.16.0 zig build test
+        run: uvx --from ziglang==0.16.0 python-zig build test
 
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,10 @@ jobs:
         with:
           enable-cache: false
 
+      - name: Test Zig on Windows ARM64
+        if: matrix.os == 'windows-11-vs2026-arm'
+        run: uvx --from ziglang==0.16.0 zig build test
+
       - name: Build wheels
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
 

--- a/build.zig
+++ b/build.zig
@@ -160,7 +160,7 @@ pub fn build(b: *std.Build) void {
     });
     const fix = b.addRunArtifact(fixer);
     // Aro drops dllimport from data declarations; restore it before MSVC linking.
-    if (target.result.os.tag == .windows) fix.addArg("--dll-import-data");
+    if (target.result.os.tag == .windows and target.result.cpu.arch == .aarch64) fix.addArg("--dll-import-data");
     fix.addFileArg(translate.getOutput());
     // The patched copy fix_cimport writes out, used as the `pyc` module source.
     const pyc_file = fix.addOutputFileArg("cimport.zig");

--- a/build.zig
+++ b/build.zig
@@ -1,10 +1,16 @@
 const std = @import("std");
 
+fn defaultTarget(b: *std.Build) std.Target.Query {
+    const triple = b.graph.environ_map.get("HATCH_ZIG_TARGET") orelse return .{ .cpu_model = .baseline };
+    if (triple.len == 0) return .{ .cpu_model = .baseline };
+    return std.Target.Query.parse(.{ .arch_os_abi = triple }) catch @panic("invalid HATCH_ZIG_TARGET");
+}
+
 pub fn build(b: *std.Build) void {
     // Wheels must run on CPUs other than the machine that built them. Keep a
     // conservative default while still allowing an explicit -Dcpu override.
     const target = b.standardTargetOptions(.{
-        .default_target = .{ .cpu_model = .baseline },
+        .default_target = defaultTarget(b),
     });
     const optimize = b.standardOptimizeOption(.{});
     // DWARF debug info is ~3 MB per extension (vs ~450 KB of code); shipped

--- a/build.zig
+++ b/build.zig
@@ -159,6 +159,8 @@ pub fn build(b: *std.Build) void {
         }),
     });
     const fix = b.addRunArtifact(fixer);
+    // Aro drops dllimport from data declarations; restore it before MSVC linking.
+    if (target.result.os.tag == .windows) fix.addArg("--dll-import-data");
     fix.addFileArg(translate.getOutput());
     // The patched copy fix_cimport writes out, used as the `pyc` module source.
     const pyc_file = fix.addOutputFileArg("cimport.zig");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,8 @@ archs = ["arm64", "x86_64"]
 environment = { MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.windows]
-archs = ["AMD64"]
+# Build amd64 on windows-latest and arm64 on windows-11-vs2026-arm.
+archs = ["native"]
 
 [tool.pytest.ini_options]
 addopts = "-rxXs --strict-config --strict-markers"

--- a/src/python/cimport.h
+++ b/src/python/cimport.h
@@ -19,6 +19,14 @@
 #ifndef _Py_ALIGNED_DEF
 #define _Py_ALIGNED_DEF(N, T) __attribute__((aligned(N))) T
 #endif
+#if defined(_WIN32) && defined(_M_ARM64)
+/* Skip MSVC pointer qualifiers and ARM intrinsics unsupported by translate-c. */
+#define __ptr32
+#define __ptr64
+#define _M_CEE
+#include <wchar.h>
+#undef _M_CEE
+#endif
 #include <Python.h>
 /* The Py_T_* / Py_READONLY member-def constants are 3.12+. On 3.10/3.11 the
  * equivalents (T_OBJECT_EX / T_BOOL / READONLY) live in structmember.h, which

--- a/src/python/cimport.h
+++ b/src/python/cimport.h
@@ -20,7 +20,8 @@
 #define _Py_ALIGNED_DEF(N, T) __attribute__((aligned(N))) T
 #endif
 #if defined(_WIN32) && defined(_M_ARM64)
-/* Skip MSVC pointer qualifiers and ARM intrinsics unsupported by translate-c. */
+/* Skip MSVC extensions and ARM intrinsics unsupported by translate-c. */
+#define __pragma(...)
 #define __ptr32
 #define __ptr64
 #define _M_CEE

--- a/src/python/cimport.h
+++ b/src/python/cimport.h
@@ -27,6 +27,9 @@
 #define _M_CEE
 #include <wchar.h>
 #undef _M_CEE
+#include <stdint.h>
+#undef UINT32_MAX
+#define UINT32_MAX 0xffffffffU
 #endif
 #include <Python.h>
 /* The Py_T_* / Py_READONLY member-def constants are 3.12+. On 3.10/3.11 the

--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -221,7 +221,7 @@ fn optionalBytes(obj: ?*c.PyObject, default: []const u8) ?[]const u8 {
 fn readTransportInteger(dict: py.Object, key: [*c]const u8, target: *?u64, found: *usize) bool {
     const value = c.PyDict_GetItemString(dict, key) orelse return true;
     found.* += 1;
-    if (@intFromPtr(c.Py_TYPE(value)) != @intFromPtr(&c.PyLong_Type)) {
+    if (@intFromPtr(c.Py_TYPE(value)) != @intFromPtr(py.data("PyLong_Type"))) {
         _ = py.raiseValue("transport parameter integer values must be non-negative integers");
         return false;
     }
@@ -244,7 +244,7 @@ fn transportParameters(
         return if (role == SERVER) &DEFAULT_SERVER_TRANSPORT_PARAMS else &DEFAULT_CLIENT_TRANSPORT_PARAMS;
     }
 
-    const is_dict = c.PyObject_IsInstance(obj, @ptrCast(&c.PyDict_Type));
+    const is_dict = c.PyObject_IsInstance(obj, @ptrCast(py.data("PyDict_Type")));
     if (is_dict < 0) return null;
     if (is_dict == 0) {
         _ = py.raiseType("transport_params must be a QuicTransportParameters dictionary");
@@ -369,7 +369,7 @@ const TlsCredentialObjects = struct {
 
 fn parseTlsCredentials(obj: ?*c.PyObject) ?TlsCredentialObjects {
     if (obj == null or py.isNone(obj)) return .{};
-    const is_dict = c.PyObject_IsInstance(obj, @ptrCast(&c.PyDict_Type));
+    const is_dict = c.PyObject_IsInstance(obj, @ptrCast(py.data("PyDict_Type")));
     if (is_dict < 0) return null;
     if (is_dict == 0) {
         _ = py.raiseType("credentials must be a TlsCredentials dictionary");
@@ -2758,14 +2758,14 @@ const BorrowedHeaders = struct {
                 c.PySequence_GetItem(seq, @intCast(i));
             if (pair == null) return .failure;
             const pair_owned = !outer_tuple;
-            if (!exactType(pair, &c.PyTuple_Type) or c.PyTuple_Size(pair) < 2) {
+            if (!exactType(pair, py.data("PyTuple_Type")) or c.PyTuple_Size(pair) < 2) {
                 if (pair_owned) py.decref(pair);
                 return .{ .fallback = i };
             }
 
             const name = c.PyTuple_GetItem(pair, 0);
             const value = c.PyTuple_GetItem(pair, 1);
-            if (!exactType(name, &c.PyBytes_Type) or !exactType(value, &c.PyBytes_Type)) {
+            if (!exactType(name, py.data("PyBytes_Type")) or !exactType(value, py.data("PyBytes_Type"))) {
                 if (pair_owned) py.decref(pair);
                 return .{ .fallback = i };
             }
@@ -2820,8 +2820,8 @@ const BorrowedHeaders = struct {
         }
         if (!self.prepare(@intCast(n))) return false;
 
-        const outer_tuple = exactType(seq, &c.PyTuple_Type);
-        if (outer_tuple or exactType(seq, &c.PyList_Type)) {
+        const outer_tuple = exactType(seq, py.data("PyTuple_Type"));
+        if (outer_tuple or exactType(seq, py.data("PyList_Type"))) {
             switch (self.borrowExact(seq, outer_tuple)) {
                 .success => return true,
                 .failure => return false,

--- a/src/python/events_obj.zig
+++ b/src/python/events_obj.zig
@@ -814,7 +814,7 @@ fn headerBlockItem(obj: ?*c.PyObject, raw_idx: py.ssize) callconv(.c) py.Object 
     var idx = raw_idx;
     if (idx < 0) idx += @intCast(self.count);
     if (idx < 0 or idx >= self.count) {
-        c.PyErr_SetString(c.PyExc_IndexError, "header index out of range");
+        c.PyErr_SetString(py.data("PyExc_IndexError").*, "header index out of range");
         return null;
     }
     return headerPair(self, @intCast(idx), false);
@@ -836,7 +836,7 @@ fn headerBlockSubscript(obj: ?*c.PyObject, key: ?*c.PyObject) callconv(.c) py.Ob
     // PySlice_Check expands through _PyObject_CAST_CONST on CPython 3.10;
     // translate-c cannot lower that macro. Exact type comparison is sufficient
     // because slice is final and keeps the extension buildable on 3.10.
-    if (@intFromPtr(c.Py_TYPE(key)) == @intFromPtr(&c.PySlice_Type)) {
+    if (@intFromPtr(c.Py_TYPE(key)) == @intFromPtr(py.data("PySlice_Type"))) {
         const self: *HeaderBlockObject = @ptrCast(obj.?);
         var start: py.ssize = 0;
         var stop: py.ssize = 0;

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -121,13 +121,13 @@ pub fn raise(exc: Object, msg: [*c]const u8) Object {
     return null;
 }
 pub fn raiseType(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_TypeError.* else c.PyExc_TypeError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_TypeError().* else c.PyExc_TypeError, msg);
 }
 pub fn raiseValue(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_ValueError.* else c.PyExc_ValueError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_ValueError().* else c.PyExc_ValueError, msg);
 }
 pub fn raiseRuntime(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_RuntimeError.* else c.PyExc_RuntimeError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_RuntimeError().* else c.PyExc_RuntimeError, msg);
 }
 pub fn errOccurred() bool {
     return c.PyErr_Occurred() != null;
@@ -170,7 +170,7 @@ pub const BorrowedBuffer = struct {
     acquired: bool = false,
 
     pub fn init(o: Object) ?BorrowedBuffer {
-        const bytes_type = if (builtin.os.tag == .windows) c.PyBytes_Type else &c.PyBytes_Type;
+        const bytes_type = if (builtin.os.tag == .windows) c.PyBytes_Type() else &c.PyBytes_Type;
         if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(bytes_type)) {
             return .{ .bytes = asBytes(o) orelse return null, .stable_owner = o };
         }

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -5,6 +5,7 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
+const windows_arm64 = builtin.os.tag == .windows and builtin.cpu.arch == .aarch64;
 
 // The translated CPython C-API. build.zig translates Python.h (via the
 // `cimport.h` shim) to a Zig file, strips a couple of broken declarations that
@@ -121,13 +122,13 @@ pub fn raise(exc: Object, msg: [*c]const u8) Object {
     return null;
 }
 pub fn raiseType(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_TypeError().* else c.PyExc_TypeError, msg);
+    return raise(if (windows_arm64) c.PyExc_TypeError().* else c.PyExc_TypeError, msg);
 }
 pub fn raiseValue(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_ValueError().* else c.PyExc_ValueError, msg);
+    return raise(if (windows_arm64) c.PyExc_ValueError().* else c.PyExc_ValueError, msg);
 }
 pub fn raiseRuntime(msg: [*c]const u8) Object {
-    return raise(if (builtin.os.tag == .windows) c.PyExc_RuntimeError().* else c.PyExc_RuntimeError, msg);
+    return raise(if (windows_arm64) c.PyExc_RuntimeError().* else c.PyExc_RuntimeError, msg);
 }
 pub fn errOccurred() bool {
     return c.PyErr_Occurred() != null;
@@ -170,7 +171,7 @@ pub const BorrowedBuffer = struct {
     acquired: bool = false,
 
     pub fn init(o: Object) ?BorrowedBuffer {
-        const bytes_type = if (builtin.os.tag == .windows) c.PyBytes_Type() else &c.PyBytes_Type;
+        const bytes_type = if (windows_arm64) c.PyBytes_Type() else &c.PyBytes_Type;
         if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(bytes_type)) {
             return .{ .bytes = asBytes(o) orelse return null, .stable_owner = o };
         }

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -18,6 +18,10 @@ pub const c = @import("pyc");
 pub const Object = [*c]c.PyObject;
 pub const ssize = c.Py_ssize_t;
 
+pub inline fn data(comptime name: []const u8) @TypeOf(if (windows_arm64) @field(c, name)() else &@field(c, name)) {
+    return if (windows_arm64) @field(c, name)() else &@field(c, name);
+}
+
 // -- free-threaded critical sections -----------------------------------------
 
 /// A CPython critical section on free-threaded builds and a no-op elsewhere.
@@ -122,13 +126,13 @@ pub fn raise(exc: Object, msg: [*c]const u8) Object {
     return null;
 }
 pub fn raiseType(msg: [*c]const u8) Object {
-    return raise(if (windows_arm64) c.PyExc_TypeError().* else c.PyExc_TypeError, msg);
+    return raise(data("PyExc_TypeError").*, msg);
 }
 pub fn raiseValue(msg: [*c]const u8) Object {
-    return raise(if (windows_arm64) c.PyExc_ValueError().* else c.PyExc_ValueError, msg);
+    return raise(data("PyExc_ValueError").*, msg);
 }
 pub fn raiseRuntime(msg: [*c]const u8) Object {
-    return raise(if (windows_arm64) c.PyExc_RuntimeError().* else c.PyExc_RuntimeError, msg);
+    return raise(data("PyExc_RuntimeError").*, msg);
 }
 pub fn errOccurred() bool {
     return c.PyErr_Occurred() != null;
@@ -171,8 +175,7 @@ pub const BorrowedBuffer = struct {
     acquired: bool = false,
 
     pub fn init(o: Object) ?BorrowedBuffer {
-        const bytes_type = if (windows_arm64) c.PyBytes_Type() else &c.PyBytes_Type;
-        if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(bytes_type)) {
+        if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(data("PyBytes_Type"))) {
             return .{ .bytes = asBytes(o) orelse return null, .stable_owner = o };
         }
 

--- a/src/python/py.zig
+++ b/src/python/py.zig
@@ -4,6 +4,7 @@
 //! adapter reads close to Python.
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 // The translated CPython C-API. build.zig translates Python.h (via the
 // `cimport.h` shim) to a Zig file, strips a couple of broken declarations that
@@ -120,13 +121,13 @@ pub fn raise(exc: Object, msg: [*c]const u8) Object {
     return null;
 }
 pub fn raiseType(msg: [*c]const u8) Object {
-    return raise(c.PyExc_TypeError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_TypeError.* else c.PyExc_TypeError, msg);
 }
 pub fn raiseValue(msg: [*c]const u8) Object {
-    return raise(c.PyExc_ValueError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_ValueError.* else c.PyExc_ValueError, msg);
 }
 pub fn raiseRuntime(msg: [*c]const u8) Object {
-    return raise(c.PyExc_RuntimeError, msg);
+    return raise(if (builtin.os.tag == .windows) c.PyExc_RuntimeError.* else c.PyExc_RuntimeError, msg);
 }
 pub fn errOccurred() bool {
     return c.PyErr_Occurred() != null;
@@ -169,7 +170,8 @@ pub const BorrowedBuffer = struct {
     acquired: bool = false,
 
     pub fn init(o: Object) ?BorrowedBuffer {
-        if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(&c.PyBytes_Type)) {
+        const bytes_type = if (builtin.os.tag == .windows) c.PyBytes_Type else &c.PyBytes_Type;
+        if (@intFromPtr(c.Py_TYPE(o)) == @intFromPtr(bytes_type)) {
             return .{ .bytes = asBytes(o) orelse return null, .stable_owner = o };
         }
 

--- a/tools/fix_cimport.zig
+++ b/tools/fix_cimport.zig
@@ -1,8 +1,7 @@
-//! Copy a translate-c output file, removing the unused
+//! Patch a translate-c output file, removing the unused
 //! `const extern_local_<name>_s = struct { ... };` blocks that Zig 0.16's
 //! translate-c emits for the MSVC secure-CRT functions (wcscat_s, wcscpy_s,
-//! ...). They are unused, which Zig treats as a hard error, and nothing in the
-//! CPython API references them. Run as: `fix_cimport <input.zig> <output.zig>`.
+//! ...), and restoring dllimport metadata on Windows data declarations.
 //!
 //! Each target block starts with a line like
 //!     const extern_local_wcscpy_s = struct {
@@ -18,11 +17,24 @@ pub fn main(init: std.process.Init) !void {
     const cwd = std.Io.Dir.cwd();
 
     const args = try init.minimal.args.toSlice(gpa);
-    if (args.len != 3) return error.UsageNeedsInputAndOutputPaths;
-    const in_path = args[1];
-    const out_path = args[2];
+    const dll_import_data = args.len == 4 and std.mem.eql(u8, args[1], "--dll-import-data");
+    if ((!dll_import_data and args.len != 3) or (dll_import_data and args.len != 4))
+        return error.UsageNeedsInputAndOutputPaths;
+    const path_offset: usize = if (dll_import_data) 2 else 1;
+    const in_path = args[path_offset];
+    const out_path = args[path_offset + 1];
 
     const src = try cwd.readFileAlloc(io, in_path, gpa, .limited(64 * 1024 * 1024));
+
+    var imported_data = std.StringHashMap(void).init(gpa);
+    defer imported_data.deinit();
+    if (dll_import_data) {
+        var declaration_it = std.mem.splitScalar(u8, src, '\n');
+        while (declaration_it.next()) |line| {
+            const declaration = externVariable(line) orelse continue;
+            try imported_data.put(declaration.name, {});
+        }
+    }
 
     var out: std.ArrayList(u8) = .empty;
     var removed: usize = 0;
@@ -57,7 +69,20 @@ pub fn main(init: std.process.Init) !void {
             try out.appendSlice(gpa, "// removed by fix_cimport: discard of stripped secure-CRT block\n");
             continue;
         }
-        try out.appendSlice(gpa, line);
+        if (dll_import_data) {
+            if (externVariable(line)) |declaration| {
+                const replacement = try std.fmt.allocPrint(
+                    gpa,
+                    "pub const {s} = @extern(*{s}, .{{ .name = \"{s}\", .is_dll_import = true }});",
+                    .{ declaration.name, declaration.type, declaration.name },
+                );
+                try out.appendSlice(gpa, replacement);
+            } else {
+                try appendImportedDataLine(gpa, &out, line, &imported_data);
+            }
+        } else {
+            try out.appendSlice(gpa, line);
+        }
         try out.append(gpa, '\n');
     }
     // splitScalar yields a trailing empty element for a trailing newline; the
@@ -65,7 +90,74 @@ pub fn main(init: std.process.Init) !void {
     if (out.items.len > 0 and out.items[out.items.len - 1] == '\n') _ = out.pop();
 
     try cwd.writeFile(io, .{ .sub_path = out_path, .data = out.items });
-    std.debug.print("fix_cimport: removed {d} unused secure-CRT block(s) -> {s}\n", .{ removed, out_path });
+    std.debug.print(
+        "fix_cimport: removed {d} unused secure-CRT block(s), patched {d} DLL import(s) -> {s}\n",
+        .{ removed, imported_data.count(), out_path },
+    );
+}
+
+const ExternVariable = struct {
+    name: []const u8,
+    type: []const u8,
+};
+
+fn externVariable(line: []const u8) ?ExternVariable {
+    const trimmed = std.mem.trim(u8, line, " \t");
+    const prefix = "pub extern var ";
+    if (!std.mem.startsWith(u8, trimmed, prefix) or !std.mem.endsWith(u8, trimmed, ";")) return null;
+    const colon = std.mem.indexOfScalarPos(u8, trimmed, prefix.len, ':') orelse return null;
+    const name = std.mem.trim(u8, trimmed[prefix.len..colon], " \t");
+    const variable_type = std.mem.trim(u8, trimmed[colon + 1 .. trimmed.len - 1], " \t");
+    if (name.len == 0 or variable_type.len == 0) return null;
+    return .{ .name = name, .type = variable_type };
+}
+
+fn appendImportedDataLine(
+    gpa: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    line: []const u8,
+    imported_data: *const std.StringHashMap(void),
+) !void {
+    var index: usize = 0;
+    while (index < line.len) {
+        if (line[index] == '"') {
+            const start = index;
+            index += 1;
+            while (index < line.len) : (index += 1) {
+                if (line[index] == '\\') {
+                    index += 1;
+                } else if (line[index] == '"') {
+                    index += 1;
+                    break;
+                }
+            }
+            try out.appendSlice(gpa, line[start..index]);
+            continue;
+        }
+        if (index + 1 < line.len and line[index] == '/' and line[index + 1] == '/') {
+            try out.appendSlice(gpa, line[index..]);
+            return;
+        }
+        if (isIdentifierStart(line[index])) {
+            const start = index;
+            index += 1;
+            while (index < line.len and isIdentifierContinue(line[index])) : (index += 1) {}
+            const identifier = line[start..index];
+            try out.appendSlice(gpa, identifier);
+            if (imported_data.contains(identifier)) try out.appendSlice(gpa, ".*");
+            continue;
+        }
+        try out.append(gpa, line[index]);
+        index += 1;
+    }
+}
+
+fn isIdentifierStart(byte: u8) bool {
+    return byte == '_' or std.ascii.isAlphabetic(byte);
+}
+
+fn isIdentifierContinue(byte: u8) bool {
+    return isIdentifierStart(byte) or std.ascii.isDigit(byte);
 }
 
 /// A line that opens an unused secure-CRT extern block, e.g.

--- a/tools/fix_cimport.zig
+++ b/tools/fix_cimport.zig
@@ -73,8 +73,8 @@ pub fn main(init: std.process.Init) !void {
             if (externVariable(line)) |declaration| {
                 const replacement = try std.fmt.allocPrint(
                     gpa,
-                    "pub const {s} = @extern(*{s}, .{{ .name = \"{s}\", .is_dll_import = true }});",
-                    .{ declaration.name, declaration.type, declaration.name },
+                    "pub inline fn {s}() *{s} {{ return @extern(*{s}, .{{ .name = \"{s}\", .is_dll_import = true }}); }}",
+                    .{ declaration.name, declaration.type, declaration.type, declaration.name },
                 );
                 try out.appendSlice(gpa, replacement);
             } else {
@@ -144,7 +144,7 @@ fn appendImportedDataLine(
             while (index < line.len and isIdentifierContinue(line[index])) : (index += 1) {}
             const identifier = line[start..index];
             try out.appendSlice(gpa, identifier);
-            if (imported_data.contains(identifier)) try out.appendSlice(gpa, ".*");
+            if (imported_data.contains(identifier)) try out.appendSlice(gpa, "().*");
             continue;
         }
         try out.append(gpa, line[index]);

--- a/tools/fix_cimport.zig
+++ b/tools/fix_cimport.zig
@@ -32,6 +32,7 @@ pub fn main(init: std.process.Init) !void {
         var declaration_it = std.mem.splitScalar(u8, src, '\n');
         while (declaration_it.next()) |line| {
             const declaration = externVariable(line) orelse continue;
+            if (!isPythonData(declaration.name)) continue;
             try imported_data.put(declaration.name, {});
         }
     }
@@ -71,15 +72,18 @@ pub fn main(init: std.process.Init) !void {
         }
         if (dll_import_data) {
             if (externVariable(line)) |declaration| {
-                const replacement = try std.fmt.allocPrint(
-                    gpa,
-                    "pub inline fn {s}() *{s} {{ return @extern(*{s}, .{{ .name = \"{s}\", .is_dll_import = true }}); }}",
-                    .{ declaration.name, declaration.type, declaration.type, declaration.name },
-                );
-                try out.appendSlice(gpa, replacement);
-            } else {
-                try appendImportedDataLine(gpa, &out, line, &imported_data);
+                if (imported_data.contains(declaration.name)) {
+                    const replacement = try std.fmt.allocPrint(
+                        gpa,
+                        "pub inline fn {s}() *{s} {{ return @extern(*{s}, .{{ .name = \"{s}\", .is_dll_import = true }}); }}",
+                        .{ declaration.name, declaration.type, declaration.type, declaration.name },
+                    );
+                    try out.appendSlice(gpa, replacement);
+                    try out.append(gpa, '\n');
+                    continue;
+                }
             }
+            try appendImportedDataLine(gpa, &out, line, &imported_data);
         } else {
             try out.appendSlice(gpa, line);
         }
@@ -158,6 +162,10 @@ fn isIdentifierStart(byte: u8) bool {
 
 fn isIdentifierContinue(byte: u8) bool {
     return isIdentifierStart(byte) or std.ascii.isDigit(byte);
+}
+
+fn isPythonData(name: []const u8) bool {
+    return std.mem.startsWith(u8, name, "Py") or std.mem.startsWith(u8, name, "_Py");
 }
 
 /// A line that opens an unused secure-CRT extern block, e.g.


### PR DESCRIPTION
## Summary

- Build and test native Windows ARM64 wheels on `windows-11-vs2026-arm`.
- Use checksum-pinned x64 Zig under Windows emulation because native Zig 0.16 exits while compiling.
- Target ARM64 explicitly and translate its CPython and Windows SDK headers compatibly.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.