### PR TITLE
Send `Connection: close` on closing responses

### DIFF
--- a/src/python/connection_obj.zig
+++ b/src/python/connection_obj.zig
@@ -2958,7 +2958,24 @@ fn send_response(self_obj: ?*c.PyObject, args: ?*c.PyObject) callconv(.c) py.Obj
     if (hdrs_seq != null and !py.isNone(hdrs_seq)) {
         if (!hdrs.borrow(hdrs_seq)) return null;
     }
-    const header_slice = hdrs.headers;
+
+    var close_headers_inline: [BorrowedHeaders.inline_capacity + 1]events.Header = undefined;
+    var close_headers_heap: ?[]events.Header = null;
+    defer if (close_headers_heap) |headers| gpa.free(headers);
+    var header_slice = hdrs.headers;
+    if (e.message.should_close and !core.h1.connection.connectionHasClose(header_slice)) {
+        const expanded = if (header_slice.len < close_headers_inline.len)
+            close_headers_inline[0 .. header_slice.len + 1]
+        else
+            gpa.alloc(events.Header, header_slice.len + 1) catch {
+                _ = c.PyErr_NoMemory();
+                return null;
+            };
+        if (header_slice.len >= close_headers_inline.len) close_headers_heap = expanded;
+        @memcpy(expanded[0..header_slice.len], header_slice);
+        expanded[header_slice.len] = .{ .name = "Connection", .value = "close" };
+        header_slice = expanded;
+    }
 
     const rb = core.h1.writer.reasonPhrase(@intCast(status));
     const w = e.ensureWriter() orelse return null;

--- a/tests/test_connection_signals.py
+++ b/tests/test_connection_signals.py
@@ -95,11 +95,32 @@ def test_should_close_for_locally_sent_request_close() -> None:
     assert conn.should_close() is True
 
 
-def test_peer_close_survives_a_response_without_close() -> None:
-    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+def test_peer_close_is_added_to_response() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: Close\r\n\r\n")
     conn.send_response(200, [(b"content-length", b"0")])
     conn.end_message()
     assert conn.should_close() is True
+    assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nConnection: close\r\n\r\n"
+
+
+def test_peer_close_is_not_duplicated_in_response() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+    conn.send_response(200, [(b"content-length", b"0"), (b"connection", b"keep-alive, close")])
+    assert conn.data_to_send().lower().count(b"connection:") == 1
+
+
+def test_peer_close_is_added_after_many_response_headers() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+    headers = [(f"x-{index}".encode(), b"value") for index in range(17)]
+    conn.send_response(204, headers)
+    assert conn.data_to_send().endswith(b"Connection: close\r\n\r\n")
+
+
+def test_peer_close_is_added_only_to_the_final_response() -> None:
+    conn = _parse(b"GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n")
+    conn.send_informational(100)
+    conn.send_response(204)
+    assert conn.data_to_send() == b"HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n"
 
 
 def test_rejected_response_does_not_set_should_close() -> None:

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -389,4 +389,4 @@ def test_send_response_version_1_1_even_for_http_1_0_request() -> None:
     conn.receive_data(b"GET / HTTP/1.0\r\nHost: h\r\n\r\n")
     assert isinstance(conn.next_event(), zttp.Request)
     conn.send_response(200, [(b"Content-Length", b"0")])
-    assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+    assert conn.data_to_send() == b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"


### PR DESCRIPTION
## Summary

- Add `Connection: close` to final HTTP/1 responses when the parsed request requires closure.
- Preserve caller-provided close tokens and cover HTTP/1.0, informational responses, and large header lists.

Closes #275.

## Other HTTP Parsers

| Parser | Language | Behavior | Reference |
| --- | --- | --- | --- |
| h11 | Python | Adds `Connection: close` when its connection state is not keep-alive or response framing requires closure. | [`_clean_up_response_headers_for_sending`](https://github.com/python-hyper/h11/blob/62c5068c971579d61fa1b55373390e12f25fd856/h11/_connection.py#L602-L655) |
| net/http | Go | Marks responses closing for HTTP/1.0 or a request close option, then emits `Connection: close` for HTTP/1.1. | [`chunkWriter.writeHeader`](https://github.com/golang/go/blob/da7c67f59526a02ef22f80fe91fd2960a6547e59/src/net/http/server.go#L1414-L1424), [header emission](https://github.com/golang/go/blob/da7c67f59526a02ef22f80fe91fd2960a6547e59/src/net/http/server.go#L1564-L1574) |

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Kludex/zttp/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

